### PR TITLE
Rewrite the `log` module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,19 +638,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,15 +651,6 @@ checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "version_check",
 ]
 
 [[package]]
@@ -697,15 +675,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fern"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f0c14694cbd524c8720dd69b0e3179344f04ebb5f90f2e4a440c6ea3b2f1ee"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "flate2"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +689,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -935,12 +910,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,13 +917,13 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hostname"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+checksum = "a56f203cd1c76362b69e3863fd987520ac36cf70a8c92627449b2f64a8cf7d65"
 dependencies = [
+ "cfg-if",
  "libc",
- "match_cfg",
- "winapi",
+ "windows-link",
 ]
 
 [[package]]
@@ -1002,12 +971,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "humantime"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
@@ -1261,17 +1224,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,17 +1349,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
-name = "log-reroute"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "741a3ba679a9a1d331319dda1c7d8f204e9f6760fd867e28576a45d17048bc02"
-dependencies = [
- "arc-swap",
- "log",
- "once_cell",
-]
-
-[[package]]
 name = "loom"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,12 +1360,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
-
-[[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
@@ -1532,9 +1467,8 @@ dependencies = [
  "crossbeam-utils",
  "dirs",
  "domain",
- "env_logger",
- "fern",
  "flate2",
+ "foldhash",
  "futures",
  "futures-util",
  "hashbrown 0.14.5",
@@ -1543,7 +1477,6 @@ dependencies = [
  "indoc",
  "layout-rs",
  "log",
- "log-reroute",
  "nix",
  "non-empty-vec",
  "octseq",
@@ -2522,11 +2455,10 @@ dependencies = [
 
 [[package]]
 name = "syslog"
-version = "6.1.1"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc7e95b5b795122fafe6519e27629b5ab4232c73ebb2428f568e82b1a457ad3"
+checksum = "019f1500a13379b7d051455df397c75770de6311a7a188a699499502704d9f10"
 dependencies = [
- "error-chain",
  "hostname",
  "libc",
  "log",
@@ -2538,15 +2470,6 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "terminal_size"
@@ -3154,15 +3077,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,8 @@ domain         = { git = "https://github.com/NLnetLabs/domain", branch = "patche
     "unstable-zonetree",
     "kmip",
 ] }
-fern           = "0.6.0"
 futures        = "0.3.17"
 futures-util   = "0.3"
-log            = "0.4"
-log-reroute    = "0.1.5"
 octseq         = { version = "0.5.2", default-features = false }
 parking_lot    = "0.11.2"
 tokio          = { version = "1.40", features = ["fs", "io-util", "macros", "net", "rt", "rt-multi-thread", "signal", "sync", "test-util", "time", "tracing"] }
@@ -51,7 +48,6 @@ assert-json-diff   = "2.0"
 async-trait        = "0.1"
 atomic_enum        = "0.2.0"
 crossbeam-utils    = "0.8"
-env_logger         = "0.10"
 flate2             = "*"
 hashbrown          = "0.14"
 layout-rs          = { version = "0.1" }
@@ -67,6 +63,26 @@ uuid               = { version = "1.4", features = ["v4", "fast-rng"] }
 indoc              = "2.0.5"
 rayon = "1.10.0"
 
+# 'log' is a very popular logging crate, and is the primary means for Nameshed
+# to indicate what it's doing at any time.
+[dependencies.log]
+version = "0.4"
+
+# Nameshed contains many performance-sensitive hashmaps and is not expected to
+# be accessible to attackers.  'std's default hasher, which is slow but secure
+# against HashDoS attacks, is not appropriate.  A performant, cryptographically
+# insecure hash function is needed.
+#
+# - 'foldhash' is a fast, insecure, general-purpose hash function.
+#
+#   TODO: Who maintains it, and how well?
+#
+# - 'rustc-hash' is the hash function used by 'rustc'.  It trades hash quality
+#   for performance, as best suites 'rustc'.
+#
+#   TODO: Who maintains it, and how well?
+[dependencies.foldhash]
+version = "0.1.5"
 
 # Nameshed sometimes requires filesystem paths to be encoded within UTF-8 texts.
 # To conveniently resolve the conversion between the OS filesystem encoding and
@@ -79,7 +95,7 @@ features = ["serde1"]
 
 [target.'cfg(unix)'.dependencies]
 nix         = "0.22.0"
-syslog      = "6.1"
+syslog      = "7.0"
 
 [features]
 default = []

--- a/src/bin/nameshedc.rs
+++ b/src/bin/nameshedc.rs
@@ -1,18 +1,33 @@
 use std::process::ExitCode;
 
 use clap::Parser;
-use nameshed::cli::args::Args;
-use nameshed::log::LogConfig;
+use nameshed::{
+    cli::args::Args,
+    config::{LogTarget, LoggingConfig, Setting, SettingSource},
+    log::Logger,
+};
 
 #[tokio::main]
 async fn main() -> ExitCode {
-    LogConfig::init_logging().unwrap();
+    let logger = Logger::launch();
 
     let args = Args::parse();
 
-    let mut logging = LogConfig::default();
-    logging.log_level = args.verbosity.clone();
-    logging.switch_logging(false).unwrap();
+    let log_config = LoggingConfig {
+        // TODO: Use the right sources
+        level: Setting {
+            source: SettingSource::Args,
+            value: args.log_level,
+        },
+        target: Setting {
+            source: SettingSource::Default,
+            value: LogTarget::File("/dev/stdout".into()),
+        },
+        trace_targets: Default::default(),
+    };
+    if let Some(change) = logger.prepare(&log_config).unwrap() {
+        logger.apply(change);
+    }
 
     match args.execute().await {
         Ok(_) => ExitCode::SUCCESS,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 use clap::{command, Parser};
 
-use crate::log::ExitError;
+use crate::config::LogLevel;
 
 use super::client::NameshedApiClient;
 use super::commands::Command;
@@ -19,21 +19,16 @@ pub struct Args {
     )]
     pub server: SocketAddr,
 
-    /// Verbosity: 0-5 or a level name ("off", "error", "warn", "info", "debug" or "trace")
-    #[arg(
-        short = 'v',
-        long = "verbosity",
-        value_name = "LEVEL",
-        default_value = "warn"
-    )]
-    pub verbosity: crate::log::LogFilter,
+    /// The minimum severity of messages to log
+    #[arg(long = "log-level", value_name = "LEVEL", default_value = "warning")]
+    pub log_level: LogLevel,
 
     #[command(subcommand)]
     pub command: Command,
 }
 
 impl Args {
-    pub async fn execute(self) -> Result<(), ExitError> {
+    pub async fn execute(self) -> Result<(), ()> {
         let client = NameshedApiClient::new(format!("http://{}", self.server));
         self.command.execute(client).await
     }

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -4,8 +4,6 @@ pub mod policy;
 pub mod status;
 pub mod zone;
 
-use crate::log::ExitError;
-
 use super::client::NameshedApiClient;
 
 #[derive(Clone, Debug, clap::Subcommand)]
@@ -42,7 +40,7 @@ pub enum Command {
 }
 
 impl Command {
-    pub async fn execute(self, client: NameshedApiClient) -> Result<(), ExitError> {
+    pub async fn execute(self, client: NameshedApiClient) -> Result<(), ()> {
         match self {
             Self::Zone(zone) => zone.execute(client).await,
             Self::Status(status) => status.execute(client).await,

--- a/src/cli/commands/policy.rs
+++ b/src/cli/commands/policy.rs
@@ -4,7 +4,6 @@ use log::error;
 use crate::{
     api::{PolicyListResult, PolicyReloadResult},
     cli::client::NameshedApiClient,
-    log::ExitError,
 };
 
 #[derive(Clone, Debug, clap::Args)]
@@ -28,7 +27,7 @@ pub enum PolicyCommand {
 }
 
 impl Policy {
-    pub async fn execute(self, client: NameshedApiClient) -> Result<(), ExitError> {
+    pub async fn execute(self, client: NameshedApiClient) -> Result<(), ()> {
         match self.command {
             PolicyCommand::List => {
                 let res: PolicyListResult = client
@@ -38,7 +37,6 @@ impl Policy {
                     .await
                     .map_err(|e| {
                         error!("HTTP request failed: {e}");
-                        ExitError
                     })?;
 
                 for policy in res.policies {
@@ -53,7 +51,6 @@ impl Policy {
                     .await
                     .map_err(|e| {
                         error!("HTTP request failed: {e}");
-                        ExitError
                     })?;
 
                 println!("Policy info: {res:?}");
@@ -66,7 +63,6 @@ impl Policy {
                     .await
                     .map_err(|e| {
                         error!("HTTP request failed: {e}");
-                        ExitError
                     })?;
 
                 println!("Policies reloaded");

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -5,7 +5,6 @@ use log::error;
 
 use crate::api::{ServerStatusResult, ZoneStatusResult};
 use crate::cli::client::NameshedApiClient;
-use crate::log::ExitError;
 
 #[derive(Clone, Debug, clap::Args)]
 pub struct Status {
@@ -30,10 +29,7 @@ pub enum StatusCommand {
 //   - maybe have it both on server level status command (so here) and in the zone command?
 
 impl Status {
-    pub async fn execute(
-        self,
-        client: NameshedApiClient,
-    ) -> Result<(), ExitError> {
+    pub async fn execute(self, client: NameshedApiClient) -> Result<(), ()> {
         match self.command {
             Some(StatusCommand::Zone { name }) => {
                 // TODO: move to function that can be called by the general
@@ -46,7 +42,6 @@ impl Status {
                     .await
                     .map_err(|e| {
                         error!("HTTP request failed: {e}");
-                        ExitError
                     })?;
 
                 println!("Success: Sent zone reload command for {}", name)
@@ -60,7 +55,6 @@ impl Status {
                     .await
                     .map_err(|e| {
                         error!("HTTP request failed: {e}");
-                        ExitError
                     })?;
 
                 println!("Server status: {:?}", response)

--- a/src/cli/commands/zone.rs
+++ b/src/cli/commands/zone.rs
@@ -8,7 +8,6 @@ use crate::api::{
     ZoneAdd, ZoneAddResult, ZoneSource, ZoneStage, ZoneStatusResult, ZonesListResult,
 };
 use crate::cli::client::NameshedApiClient;
-use crate::log::ExitError;
 
 #[derive(Clone, Debug, clap::Args)]
 pub struct Zone {
@@ -60,7 +59,7 @@ pub enum ZoneCommand {
 // - reload zone (i.e. from file)
 
 impl Zone {
-    pub async fn execute(self, client: NameshedApiClient) -> Result<(), ExitError> {
+    pub async fn execute(self, client: NameshedApiClient) -> Result<(), ()> {
         match self.command {
             ZoneCommand::Add { name, source } => {
                 let res: ZoneAddResult = client
@@ -71,7 +70,6 @@ impl Zone {
                     .await
                     .map_err(|e| {
                         error!("HTTP request failed: {e}");
-                        ExitError
                     })?;
 
                 println!("Registered zone {}", res.name);
@@ -84,7 +82,6 @@ impl Zone {
                     .await
                     .map_err(|e| {
                         error!("HTTP request failed: {e}");
-                        ExitError
                     })?;
 
                 println!("Removed zone {}", res.name);
@@ -97,7 +94,6 @@ impl Zone {
                     .await
                     .map_err(|e| {
                         error!("HTTP request failed: {e}");
-                        ExitError
                     })?;
 
                 for zone in response.zones {
@@ -119,7 +115,6 @@ impl Zone {
                     .await
                     .map_err(|e| {
                         error!("HTTP request failed: {e}");
-                        ExitError
                     })?;
 
                 println!("Success: Sent zone reload command for {}", zone);
@@ -135,7 +130,6 @@ impl Zone {
                     .await
                     .map_err(|e| {
                         error!("HTTP request failed: {e}");
-                        ExitError
                     })?;
 
                 println!("Server status: {:?}", response);

--- a/src/config/args.rs
+++ b/src/config/args.rs
@@ -44,20 +44,12 @@ impl ArgsSpec {
                 .value_name("LEVEL")
                 .value_parser(EnumValueParser::<LogLevel>::new())
                 .help("The minimum severity of messages to log"),
-            Arg::new("log_file")
-                .long("log-file")
-                .value_name("PATH")
-                .value_parser(ValueParser::new(
-                    PathBufValueParser::new().try_map(Utf8PathBuf::try_from),
-                ))
-                .value_hint(ValueHint::FilePath)
-                .help("The file to write logs to"),
-            Arg::new("syslog")
-                .long("syslog")
-                .conflicts_with("log_file")
-                .hide(cfg!(not(unix)))
-                .action(clap::ArgAction::SetTrue)
-                .help("Whether to output to syslog"),
+            Arg::new("log_target")
+                .short('l')
+                .long("log")
+                .value_name("TARGET")
+                .value_parser(ValueParser::new(LogTargetSpecParser))
+                .help("Where logs should be written to"),
             Arg::new("daemonize")
                 .short('d')
                 .long("daemonize")
@@ -73,10 +65,7 @@ impl ArgsSpec {
                 .get_one::<Utf8PathBuf>("config")
                 .map(|p| p.as_path().into()),
             log_level: matches.get_one::<LogLevel>("log_level").copied(),
-            log_target: matches
-                .get_one::<Utf8PathBuf>("log_file")
-                .map(|p| LogTargetSpec::File(p.as_path().into()))
-                .or_else(|| matches.get_flag("syslog").then_some(LogTargetSpec::Syslog)),
+            log_target: matches.get_one::<LogTargetSpec>("log_target").cloned(),
             daemonize: matches.get_flag("daemonize"),
         }
     }
@@ -85,9 +74,10 @@ impl ArgsSpec {
     pub fn merge(self, config: &mut Config) {
         let daemon = &mut config.daemon;
         let source = SettingSource::Args;
-        daemon.log_level.merge_value(self.log_level, source);
+        daemon.logging.level.merge_value(self.log_level, source);
         daemon
-            .log_target
+            .logging
+            .target
             .merge_value(self.log_target.map(|t| t.build()), source);
         daemon.config_file.merge_value(self.config, source);
         daemon
@@ -108,6 +98,59 @@ pub enum LogTargetSpec {
 
     /// Write logs to the UNIX syslog.
     Syslog,
+}
+
+//--- Parsing
+
+#[derive(Clone, Debug, Default)]
+pub struct LogTargetSpecParser;
+
+impl clap::builder::TypedValueParser for LogTargetSpecParser {
+    type Value = LogTargetSpec;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        // NOTE: Clap's own value parser types use 'Error::invalid_value()' to
+        // produce the appropriate parsing errors, but this is not a publicly
+        // visible function.  It performs a lot of useful work, like printing
+        // possible values and suggesting the closest one.  To work around this,
+        // we delegate to one of those value parsers on error.
+
+        let s = value.to_str().ok_or_else(|| {
+            let parser = clap::builder::StringValueParser::default();
+            parser.parse_ref(cmd, arg, value).unwrap_err()
+        })?;
+
+        if s == "stdout" {
+            Ok(LogTargetSpec::File("/dev/stdout".into()))
+        } else if s == "stderr" {
+            Ok(LogTargetSpec::File("/dev/stderr".into()))
+        } else if let Some(s) = s.strip_prefix("file:") {
+            let path = <&Utf8Path>::from(s);
+            Ok(LogTargetSpec::File(path.into()))
+        } else if s == "syslog" {
+            Ok(LogTargetSpec::Syslog)
+        } else {
+            let parser = clap::builder::PossibleValuesParser::new([
+                "stdout",
+                "stderr",
+                "file:<PATH>",
+                "syslog",
+            ]);
+            Err(parser.parse_ref(cmd, arg, value).unwrap_err())
+        }
+    }
+
+    fn possible_values(
+        &self,
+    ) -> Option<Box<dyn Iterator<Item = clap::builder::PossibleValue> + '_>> {
+        let values = ["stdout", "stderr", "file:<PATH>", "syslog"];
+        Some(Box::new(values.into_iter().map(PossibleValue::new)))
+    }
 }
 
 //--- Conversion

--- a/src/config/file/v1.rs
+++ b/src/config/file/v1.rs
@@ -7,7 +7,8 @@ use serde::Deserialize;
 
 use crate::config::{
     Config, DaemonConfig, GroupId, KeyManagerConfig, LoaderConfig, LogLevel, LogTarget,
-    ReviewConfig, ServerConfig, Setting, SettingSource, SignerConfig, SocketConfig, UserId,
+    LoggingConfig, ReviewConfig, ServerConfig, Setting, SettingSource, SignerConfig, SocketConfig,
+    UserId,
 };
 
 //----------- Spec -------------------------------------------------------------
@@ -77,8 +78,8 @@ pub struct DaemonSpec {
 impl DaemonSpec {
     /// Build the internal configuration.
     pub fn build(self, config_file: Setting<Box<Utf8Path>>) -> DaemonConfig {
-        DaemonConfig {
-            log_level: self
+        let logging = LoggingConfig {
+            level: self
                 .log_level
                 .map(|log_level| Setting {
                     source: SettingSource::File,
@@ -88,7 +89,7 @@ impl DaemonSpec {
                     source: SettingSource::Default,
                     value: LogLevel::Info,
                 }),
-            log_target: self
+            target: self
                 .log_target
                 .map(|log_target| Setting {
                     source: SettingSource::File,
@@ -98,6 +99,11 @@ impl DaemonSpec {
                     source: SettingSource::Default,
                     value: LogTarget::File("/var/log/nameshed.log".into()),
                 }),
+            trace_targets: Default::default(),
+        };
+
+        DaemonConfig {
+            logging,
             config_file,
             daemonize: self
                 .daemonize

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -10,6 +10,7 @@ use tokio::sync::mpsc::{self, Receiver, Sender};
 use crate::common::file_io::TheFileIo;
 use crate::common::tsig::TsigKeyStore;
 use crate::comms::ApplicationCommand;
+use crate::log::Logger;
 use crate::metrics;
 use crate::targets::central_command::{self, CentralCommandTarget};
 use crate::targets::Target;
@@ -131,6 +132,9 @@ pub struct Manager {
     /// Commands for the zone loader.
     loader_tx: Option<mpsc::UnboundedSender<ApplicationCommand>>,
 
+    /// The logger.
+    _logger: &'static Logger,
+
     /// Commands for the review server.
     review_tx: Option<mpsc::UnboundedSender<ApplicationCommand>>,
 
@@ -171,15 +175,9 @@ pub struct Manager {
     app_cmd_rx: Arc<tokio::sync::Mutex<Receiver<(String, ApplicationCommand)>>>,
 }
 
-impl Default for Manager {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Manager {
     /// Creates a new manager.
-    pub fn new() -> Self {
+    pub fn new(logger: &'static Logger) -> Self {
         let (app_cmd_tx, app_cmd_rx) = tokio::sync::mpsc::channel(10);
 
         let tsig_key_store = Default::default();
@@ -190,6 +188,7 @@ impl Manager {
         #[allow(clippy::let_and_return, clippy::default_constructed_unit_structs)]
         let manager = Manager {
             loader_tx: None,
+            _logger: logger,
             review_tx: None,
             key_manager_tx: None,
             signer_tx: None,

--- a/src/units/zone_loader.rs
+++ b/src/units/zone_loader.rs
@@ -71,7 +71,6 @@ use crate::common::net::{
 use crate::common::tsig::{parse_key_strings, TsigKeyStore};
 use crate::common::xfr::parse_xfr_acl;
 use crate::comms::{ApplicationCommand, GraphStatus, Terminated};
-use crate::log::ExitError;
 use crate::manager::Component;
 use crate::metrics::{self, util::append_per_router_metric, Metric, MetricType, MetricUnit};
 use crate::payload::Update;

--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -75,7 +75,6 @@ use crate::common::tsig::{parse_key_strings, TsigKeyStore};
 use crate::common::xfr::parse_xfr_acl;
 use crate::comms::ApplicationCommand;
 use crate::comms::{GraphStatus, Terminated};
-use crate::log::ExitError;
 use crate::manager::Component;
 use crate::metrics::{self, util::append_per_router_metric, Metric, MetricType, MetricUnit};
 use crate::payload::Update;

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -101,7 +101,6 @@ use crate::common::tsig::{parse_key_strings, TsigKeyStore};
 use crate::common::xfr::parse_xfr_acl;
 use crate::comms::ApplicationCommand;
 use crate::comms::{GraphStatus, Terminated};
-use crate::log::ExitError;
 use crate::manager::Component;
 use crate::metrics::{self, util::append_per_router_metric, Metric, MetricType, MetricUnit};
 use crate::payload::Update;


### PR DESCRIPTION
- Implement `log::Log` manually, with an `RwLock`, to support changing the logging strategy after initialization.  This eliminates the need for `log-reroute` while providing more flexibility.

- Provide a safe prepare-apply scheme for changing the log config. This should compose nicely with larger configuration changes.

- Provide a fallback stderr logger, which works even if the logger is poisoned (i.e. a panic occurs while a write lock is held).

- Set up functionality for limiting trace-level logging to a user-specified list of targets.