### PR TITLE
Don't sign unapproved unsigned zones.

### DIFF
--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -958,7 +958,12 @@ fn collect_zone(zone: Zone) -> Vec<StoredRecord> {
             // zone rather than signing an unsigned zone)
             if matches!(
                 rrset.rtype(),
-                Rtype::DNSKEY | Rtype::RRSIG | Rtype::NSEC | Rtype::NSEC3
+                Rtype::DNSKEY
+                    | Rtype::RRSIG
+                    | Rtype::NSEC
+                    | Rtype::NSEC3
+                    | Rtype::CDS
+                    | Rtype::CDNSKEY
             ) {
                 return;
             }


### PR DESCRIPTION
FIX: Don't sign unapproved unsigned zones if `ApplicationCommand:SignZone` is issued in response to a `dnst` trigger by `KeyManager`.

# Background

`ApplicationCommand::SignZone { name, serial }` is issued via two code paths:

1. An unsigned zone is loaded/received causing `Update::UnsignedZoneUpdatedEvent` to be sent to `CentralCommand` which in turn sends `ApplicationComand::SeekApprovalForUnsignedZone` to the "RS" instance of `ZoneServer`. On receiving approval "RS" sends `Update::UnsignedZoneApprovedEvent` to `CentralCommand` which in turn sends `SignZone { name, Some(serial) }` to the "ZS" instance of `ZoneSigner`.

2. `KeyManager` notices that `cron_next` in the dnst state file for a monitored zone has been reached and so issues `dnst -c /path/to/zone.cfg cron` and if the state file is then modified `KeyManager` sends `Update::ResignZoneEvent` to `CentralCommand` which in turn sends `ApplicationCommand::SignZone { name, None }` to the "ZS" instance of `ZoneSigner`.

In the first case the zone with the given name from the `Manager::unsigned_zones` collection is walked by `ZoneSigner` and signed records are produced and the signed records and unsigned records are pushed into a zone in the `Manager::signed_zones` collection, following which `Update::ZoneSignedEvent` is sent to `CentralCommand` which in turn sends `ApplicationCommand::SeekApprovalForSignedZone` to the "RS2" instance of `ZoneServer`. On approval the zone is moved from the `Manager::signed_zones` collection to the `Manager::published_zones` collection and served by the "PS" instance of `ZoneServer`.

In the second case this can go wrong because the `ZoneSigner` fetches the zone to sign from the `Manager::unsigned_zones` collection without knowing if it has been approved for signing or not.

There are at least three ways to solve this:

1. Introduce another zone collection `Manager::zones_to_be_signed`.
2. Have `KeyManager` trigger an unsigned zone approval workflow, but as this should be for an unsigned zone that was already approved signed 
3. Have `ZoneSigner` take the zone to sign from `Manager::published_zones` in the case that it is a resign rather than a first sign.

This PR implements option 3 and ignores any DNSSEC RRs present in the published zone that are the product of signing the zone.