### PR TITLE
Policy commands

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -104,7 +104,9 @@ pub struct ServerStatusResult {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct PolicyReloadResult {}
+pub struct PolicyReloadResult {
+    pub changes: Vec<(String, PolicyChange)>,
+}
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct PolicyListResult {
@@ -171,4 +173,12 @@ pub struct ServerPolicyInfo {}
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub enum PolicyInfoError {
     PolicyDoesNotExist,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum PolicyChange {
+    Added,
+    Removed,
+    Updated,
+    Unchanged,
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,6 @@
 use std::fmt::{self, Display};
 use std::net::{IpAddr, SocketAddr};
+use std::time::Duration;
 
 use bytes::Bytes;
 use camino::{Utf8Path, Utf8PathBuf};
@@ -111,4 +112,63 @@ pub struct PolicyListResult {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct PolicyShowResult {}
+pub struct PolicyInfo {
+    pub name: Box<str>,
+    pub zones: Vec<Name<Bytes>>,
+    pub loader: LoaderPolicyInfo,
+    pub key_manager: KeyManagerPolicyInfo,
+    pub signer: SignerPolicyInfo,
+    pub server: ServerPolicyInfo,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct LoaderPolicyInfo {
+    pub review: ReviewPolicyInfo,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct KeyManagerPolicyInfo {}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct ReviewPolicyInfo {
+    pub required: bool,
+    pub cmd_hook: Option<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct SignerPolicyInfo {
+    pub serial_policy: SignerSerialPolicyInfo,
+    pub sig_inception_offset: Duration,
+    pub sig_validity_offset: Duration,
+    pub denial: SignerDenialPolicyInfo,
+    pub review: ReviewPolicyInfo,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum SignerSerialPolicyInfo {
+    Keep,
+    Counter,
+    UnixTime,
+    DateCounter,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum SignerDenialPolicyInfo {
+    NSec,
+    NSec3 { opt_out: Nsec3OptOutPolicyInfo },
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum Nsec3OptOutPolicyInfo {
+    Disabled,
+    FlagOnly,
+    Enabled,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct ServerPolicyInfo {}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum PolicyInfoError {
+    PolicyDoesNotExist,
+}

--- a/src/api.rs
+++ b/src/api.rs
@@ -104,7 +104,19 @@ pub struct ServerStatusResult {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct PolicyReloadResult {
+pub enum PolicyReloadError {
+    Io(Utf8PathBuf, String),
+}
+
+impl Display for PolicyReloadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let PolicyReloadError::Io(p, e) = self;
+        format!("{p}: {e}").fmt(f)
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct PolicyChanges {
     pub changes: Vec<(String, PolicyChange)>,
 }
 

--- a/src/cli/commands/policy.rs
+++ b/src/cli/commands/policy.rs
@@ -2,7 +2,10 @@ use futures::TryFutureExt;
 use log::error;
 
 use crate::{
-    api::{PolicyListResult, PolicyReloadResult},
+    api::{
+        Nsec3OptOutPolicyInfo, PolicyInfo, PolicyInfoError, PolicyListResult, PolicyReloadResult,
+        ReviewPolicyInfo, SignerDenialPolicyInfo, SignerSerialPolicyInfo,
+    },
     cli::client::CascadeApiClient,
 };
 
@@ -45,7 +48,7 @@ impl Policy {
                 }
             }
             PolicyCommand::Show { name } => {
-                let res: PolicyListResult = client
+                let res: Result<PolicyInfo, PolicyInfoError> = client
                     .get(&format!("policy/{name}"))
                     .send()
                     .and_then(|r| r.json())
@@ -54,7 +57,15 @@ impl Policy {
                         error!("HTTP request failed: {e}");
                     })?;
 
-                println!("Policy info: {res:?}");
+                let p = match res {
+                    Ok(p) => p,
+                    Err(e) => {
+                        eprintln!("{e:?}");
+                        return Err(());
+                    }
+                };
+
+                print_policy(&p);
             }
             PolicyCommand::Reload => {
                 let _res: PolicyReloadResult = client
@@ -71,4 +82,57 @@ impl Policy {
         }
         Ok(())
     }
+}
+
+fn print_policy(p: &PolicyInfo) {
+    let name = &p.name;
+
+    let zones: Vec<_> = p.zones.iter().map(|z| format!("{}", z)).collect();
+
+    let zones = if !zones.is_empty() {
+        zones.join(", ")
+    } else {
+        "<none>".into()
+    };
+
+    let serial_policy = match p.signer.serial_policy {
+        SignerSerialPolicyInfo::Keep => "keep",
+        SignerSerialPolicyInfo::Counter => "counter",
+        SignerSerialPolicyInfo::UnixTime => "unix time",
+        SignerSerialPolicyInfo::DateCounter => "date counter",
+    };
+
+    let inc = p.signer.sig_inception_offset.as_secs();
+    let val = p.signer.sig_validity_offset.as_secs();
+
+    let denial = match &p.signer.denial {
+        SignerDenialPolicyInfo::NSec => "NSEC",
+        SignerDenialPolicyInfo::NSec3 { opt_out } => match opt_out {
+            Nsec3OptOutPolicyInfo::Disabled => "NSEC3 (opt-out: disabled)",
+            Nsec3OptOutPolicyInfo::Enabled => "NSEC3 (opt-out: enabled)",
+            Nsec3OptOutPolicyInfo::FlagOnly => "NSEC3 (opt-out: flag-only)",
+        },
+    };
+
+    fn print_review(r: &ReviewPolicyInfo) {
+        println!("    review:");
+        println!("      required: {}", r.required);
+        println!(
+            "      cmd_hook: {}",
+            r.cmd_hook.as_ref().cloned().unwrap_or("<none>".into())
+        );
+    }
+
+    println!("{name}:");
+    println!("  zones: {zones}");
+    println!("  loader:");
+    print_review(&p.loader.review);
+    println!("  key manager: <unimplemented>");
+    println!("  signer:");
+    println!("    serial policy: {serial_policy}");
+    println!("    signature inception offset: {inc} seconds",);
+    println!("    signature validity offset: {val} seconds",);
+    println!("    denial: {denial}");
+    print_review(&p.signer.review);
+    println!("  server: <unimplemented>");
 }

--- a/src/cli/commands/policy.rs
+++ b/src/cli/commands/policy.rs
@@ -23,6 +23,7 @@ pub enum PolicyCommand {
     Show { name: String },
 
     /// Reload all the policies from the files
+    #[command(name = "reload")]
     Reload,
 }
 

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -258,11 +258,14 @@ impl HttpServer {
         // mutex guard. We could make `reload_all` a function that takes the whole state to fix
         // this.
         let mut policies = state.policies.clone();
-        crate::policy::reload_all(&mut policies, &state.config).unwrap();
+        let changes = crate::policy::reload_all(&mut policies, &state.config).unwrap();
+        let mut changes: Vec<_> = changes.into_iter().map(|(p, c)| (p.into(), c)).collect();
+        changes.sort_by_key(|x: &(String, _)| x.0.clone());
+
         state.policies = policies;
 
         // TODO: Ideally, this would return some information about what changed.
-        Json(PolicyReloadResult {})
+        Json(PolicyReloadResult { changes })
     }
 
     async fn policy_show(


### PR DESCRIPTION
Example output of `policy show`:
```
foo:
  zones: <none>
  loader:
    review:
      required: false
      cmd_hook: <none>
  key manager: <unimplemented>
  signer:
    serial policy: counter
    signature inception offset: 0 seconds
    signature validity offset: 0 seconds
    denial: NSEC3 (opt-out: disabled)
    review:
      required: false
      cmd_hook: <none>
  server: <unimplemented>
```

Example output of `policy reload`:
<img width="479" height="138" alt="image" src="https://github.com/user-attachments/assets/664daf0f-b05e-4a9b-a274-37ae46073df9" />

And `policy list` is simply:
```
policy1
policy2
policy3
```