### PR TITLE
More zone status update CLI command output.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,7 @@ dependencies = [
  "foldhash",
  "futures",
  "futures-util",
+ "humantime",
  "jiff",
  "log",
  "octseq",
@@ -900,6 +901,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
@@ -2246,9 +2253,9 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
-version = "3.22.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ domain         = { git = "https://github.com/NLnetLabs/domain", branch = "patche
 ] }
 futures        = "0.3.17"
 futures-util   = "0.3"
+humantime      = "2.3.0"
 octseq         = { version = "0.5.2", default-features = false }
 tokio          = { version = "1.40", features = ["fs", "io-util", "macros", "net", "rt", "rt-multi-thread", "signal", "sync", "test-util", "time", "tracing"] }
 serde          = { version = "1.0", features = ["derive", "rc"] }

--- a/src/api.rs
+++ b/src/api.rs
@@ -16,6 +16,35 @@ use crate::zonemaintenance::types::{SigningReport, ZoneRefreshStatus};
 
 const DEFAULT_AXFR_PORT: u16 = 53;
 
+//----------- ConfigReload -----------------------------------------------------
+
+/// Reload Cascade's configuration file.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct ConfigReload {
+    // TODO: Support dry runs.
+}
+
+/// The result of a [`ConfigReload`] command.
+pub type ConfigReloadResult = Result<ConfigReloadOutput, ConfigReloadError>;
+
+/// The output of a [`ConfigReload`] command.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct ConfigReloadOutput {
+    // TODO: A diff between the old and new config.
+}
+
+/// An error from a [`ConfigReload`] command.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum ConfigReloadError {
+    /// The file could not be loaded.
+    Load(String),
+
+    /// The file could not be parsed.
+    Parse(String),
+}
+
+//------------------------------------------------------------------------------
+
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct ZoneAdd {
     pub name: Name<Bytes>,

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,14 +1,18 @@
 use std::fmt::{self, Display};
 use std::net::{IpAddr, SocketAddr};
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use bytes::Bytes;
 use camino::{Utf8Path, Utf8PathBuf};
-use domain::base::Name;
+use domain::base::{Name, Serial};
+use domain::zonetree::StoredName;
 use serde::{Deserialize, Serialize};
 
 use crate::center;
 use crate::units::http_server::KmipServerState;
+use crate::units::zone_loader::ZoneLoaderReport;
+use crate::zone::PipelineMode;
+use crate::zonemaintenance::types::{SigningReport, ZoneRefreshStatus};
 
 const DEFAULT_AXFR_PORT: u16 = 53;
 
@@ -74,6 +78,9 @@ pub enum ZoneSource {
 
         /// The name of a TSIG key, if any.
         tsig_key: Option<String>,
+
+        /// The XFR status of the zone.
+        xfr_status: ZoneRefreshStatus,
     },
 }
 
@@ -82,7 +89,7 @@ impl Display for ZoneSource {
         match self {
             ZoneSource::None => f.write_str("<none>"),
             ZoneSource::Zonefile { path } => path.fmt(f),
-            ZoneSource::Server { addr, tsig_key: _ } => addr.fmt(f),
+            ZoneSource::Server { addr, .. } => addr.fmt(f),
         }
     }
 }
@@ -93,11 +100,13 @@ impl From<&str> for ZoneSource {
             ZoneSource::Server {
                 addr,
                 tsig_key: None,
+                xfr_status: Default::default(),
             }
         } else if let Ok(addr) = s.parse::<IpAddr>() {
             ZoneSource::Server {
                 addr: SocketAddr::new(addr, DEFAULT_AXFR_PORT),
                 tsig_key: None,
+                xfr_status: Default::default(),
             }
         } else {
             ZoneSource::Zonefile {
@@ -109,12 +118,16 @@ impl From<&str> for ZoneSource {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct ZonesListResult {
-    pub zones: Vec<ZoneStatus>,
+    pub zones: Vec<StoredName>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ZoneStage {
     Unsigned,
+    // TODO: Signed is not strictly correct as it is currently set based on
+    // the presence of a zone in the signed zones collection, but that happens
+    // at the start of the signing process, not only once a zone has finished
+    // being signed.
     Signed,
     Published,
 }
@@ -122,9 +135,9 @@ pub enum ZoneStage {
 impl Display for ZoneStage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let str = match self {
-            ZoneStage::Unsigned => "unsigned",
-            ZoneStage::Signed => "signed",
-            ZoneStage::Published => "published",
+            ZoneStage::Unsigned => "loader",
+            ZoneStage::Signed => "signer",
+            ZoneStage::Published => "publication server",
         };
         f.write_str(str)
     }
@@ -141,7 +154,47 @@ pub struct ZoneStatus {
     pub source: ZoneSource,
     pub policy: String,
     pub stage: ZoneStage,
+    pub keys: Vec<KeyInfo>,
     pub key_status: Option<String>,
+    pub receipt_report: Option<ZoneLoaderReport>,
+    pub unsigned_serial: Option<Serial>,
+    pub unsigned_review_status: Option<TimestampedZoneReviewStatus>,
+    pub unsigned_review_addr: Option<SocketAddr>,
+    pub signed_serial: Option<Serial>,
+    pub signed_review_status: Option<TimestampedZoneReviewStatus>,
+    pub signed_review_addr: Option<SocketAddr>,
+    pub signing_report: Option<SigningReport>,
+    pub published_serial: Option<Serial>,
+    pub publish_addr: SocketAddr,
+    pub pipeline_mode: PipelineMode,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct TimestampedZoneReviewStatus {
+    pub status: ZoneReviewStatus,
+    pub when: SystemTime,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub enum ZoneReviewStatus {
+    Pending,
+    Approved,
+    Rejected,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct KeyInfo {
+    pub pubref: String,
+    pub key_type: KeyType,
+    pub key_tag: u16,
+    pub signer: bool,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub enum KeyType {
+    Ksk,
+    Zsk,
+    Csk,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -153,6 +206,7 @@ pub struct ZoneReloadResult {
 pub enum ZoneReloadError {
     ZoneDoesNotExist,
     ZoneWithoutSource,
+    ZoneHalted(String),
 }
 
 impl fmt::Display for ZoneReloadError {
@@ -160,6 +214,9 @@ impl fmt::Display for ZoneReloadError {
         f.write_str(match self {
             Self::ZoneDoesNotExist => "no zone with this name exist",
             Self::ZoneWithoutSource => "the specified zone has no source configured",
+            Self::ZoneHalted(reason) => {
+                return write!(f, "the zone has been halted (reason: {reason})")
+            }
         })
     }
 }
@@ -326,11 +383,7 @@ pub mod keyset {
 
     #[derive(Deserialize, Serialize, Debug, Clone)]
     pub enum KeyRollError {
-        DnstCommandError {
-            status: String,
-            stdout: String,
-            stderr: String,
-        },
+        DnstCommandError(String),
         RxError,
     }
 
@@ -348,11 +401,7 @@ pub mod keyset {
 
     #[derive(Deserialize, Serialize, Debug, Clone)]
     pub enum KeyRemoveError {
-        DnstCommandError {
-            status: String,
-            stdout: String,
-            stderr: String,
-        },
+        DnstCommandError(String),
         RxError,
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use crate::center;
 use crate::units::http_server::KmipServerState;
 use crate::units::zone_loader::ZoneLoaderReport;
-use crate::zone::PipelineMode;
+use crate::zone::{HistoryItem, PipelineMode};
 use crate::zonemaintenance::types::{SigningReport, ZoneRefreshStatus};
 
 const DEFAULT_AXFR_PORT: u16 = 53;
@@ -195,6 +195,16 @@ pub enum KeyType {
     Ksk,
     Zsk,
     Csk,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct ZoneHistory {
+    pub history: Vec<HistoryItem>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum ZoneHistoryError {
+    ZoneDoesNotExist,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/src/center.rs
+++ b/src/center.rs
@@ -10,6 +10,7 @@ use std::{
 use arc_swap::ArcSwap;
 use bytes::Bytes;
 use domain::rdata::dnssec::Timestamp;
+use domain::zonetree::StoredName;
 use domain::{base::Name, zonetree::ZoneTree};
 use tokio::sync::mpsc;
 
@@ -144,6 +145,25 @@ pub fn remove_zone(center: &Arc<Center>, name: Name<Bytes>) -> Result<(), ZoneRe
 
     log::info!("Removed zone '{name}'");
     Ok(())
+}
+
+pub fn get_zone(center: &Center, name: &StoredName) -> Option<Arc<Zone>> {
+    let state = center.state.lock().unwrap();
+    state.zones.get(name).map(|zone| zone.0.clone())
+}
+
+pub fn halt_zone(center: &Arc<Center>, zone_name: &StoredName, hard: bool, reason: &str) {
+    let mut state = center.state.lock().unwrap();
+    {
+        let zone = state.zones.get(zone_name).unwrap();
+        let mut zone_state = zone.0.state.lock().unwrap();
+        if hard {
+            zone_state.hard_halt(reason.to_string());
+        } else {
+            zone_state.soft_halt(reason.to_string());
+        }
+    }
+    state.mark_dirty(center);
 }
 
 //----------- State ------------------------------------------------------------

--- a/src/cli/client.rs
+++ b/src/cli/client.rs
@@ -6,6 +6,7 @@ use url::Url;
 const HTTP_CLIENT_TIMEOUT: Duration = Duration::from_secs(120);
 static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
 
+#[derive(Clone)]
 pub struct CascadeApiClient {
     base_uri: Url,
 }

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -1,0 +1,52 @@
+use futures::TryFutureExt;
+
+use crate::{
+    api::{ConfigReload, ConfigReloadError, ConfigReloadOutput, ConfigReloadResult},
+    cli::client::{format_http_error, CascadeApiClient},
+};
+
+#[derive(Clone, Debug, clap::Args)]
+pub struct Config {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Clone, Debug, clap::Subcommand)]
+pub enum Command {
+    /// Reload the configuration file.
+    #[command(name = "reload")]
+    Reload {
+        // TODO: Support dry-runs.
+    },
+}
+
+impl Config {
+    pub async fn execute(self, client: CascadeApiClient) -> Result<(), String> {
+        match self.command {
+            Command::Reload {} => {
+                let res: ConfigReloadResult = client
+                    .post("config/reload")
+                    .json(&ConfigReload {})
+                    .send()
+                    .and_then(|r| r.json())
+                    .await
+                    .map_err(format_http_error)?;
+
+                match res {
+                    Ok(ConfigReloadOutput {}) => {
+                        println!("Reloaded the configuration file");
+                        Ok(())
+                    }
+
+                    Err(ConfigReloadError::Load(error)) => Err(format!(
+                        "Could not load the new configuration file: {error}"
+                    )),
+
+                    Err(ConfigReloadError::Parse(error)) => Err(format!(
+                        "Could not parse the new configuration file: {error}"
+                    )),
+                }
+            }
+        }
+    }
+}

--- a/src/cli/commands/hsm.rs
+++ b/src/cli/commands/hsm.rs
@@ -127,9 +127,16 @@ impl Hsm {
                 match res {
                     Ok(res) => {
                         print_server(&res.server);
-                        println!("Policies using this HSM:");
-                        for policy_name in get_policy_names_using_hsm(client, &server_id).await? {
-                            println!("  - {policy_name}");
+                        print!("Policies using this HSM:");
+                        let policies = get_policy_names_using_hsm(client, &server_id).await?;
+
+                        if policies.is_empty() {
+                            println!(" None");
+                        } else {
+                            println!();
+                            for policy_name in policies {
+                                println!("  - {policy_name}");
+                            }
                         }
                     }
                     Err(()) => return Err(format!("HSM '{server_id}' not known.")),
@@ -152,7 +159,7 @@ async fn get_policy_names_using_hsm(
 ) -> Result<Vec<String>, String> {
     let mut policies_using_hsm = vec![];
     let res: PolicyListResult = client
-        .get("policy/list")
+        .get("policy/")
         .send()
         .and_then(|r| r.json())
         .await

--- a/src/cli/commands/keyset.rs
+++ b/src/cli/commands/keyset.rs
@@ -100,11 +100,9 @@ async fn roll_command(
             Ok(())
         }
         Err(e) => match e {
-            KeyRollError::DnstCommandError {
-                status: _,
-                stdout: _,
-                stderr,
-            } => Err(format!("Failed manual key roll for {zone}: {stderr}")),
+            KeyRollError::DnstCommandError(err) => {
+                Err(format!("Failed manual key roll for {zone}: {err}"))
+            }
             KeyRollError::RxError => Err(format!(
                 "Failed manual key roll for {zone}: Internal Server Error"
             )),
@@ -136,11 +134,9 @@ async fn remove_key_command(
             Ok(())
         }
         Err(e) => match e {
-            KeyRemoveError::DnstCommandError {
-                status: _,
-                stdout: _,
-                stderr,
-            } => Err(format!("Failed to remove key {key} from {zone}: {stderr}")),
+            KeyRemoveError::DnstCommandError(err) => {
+                Err(format!("Failed to remove key {key} from {zone}: {err}"))
+            }
             KeyRemoveError::RxError => Err(format!(
                 "Failed to remove key {key} from {zone}: Internal Server Error"
             )),

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -1,5 +1,6 @@
 //! The commands of _cascade_.
 
+pub mod config;
 pub mod hsm;
 pub mod keyset;
 pub mod policy;
@@ -10,6 +11,10 @@ use super::client::CascadeApiClient;
 
 #[derive(Clone, Debug, clap::Subcommand)]
 pub enum Command {
+    /// Manage Cascade's configuration.
+    #[command(name = "config")]
+    Config(self::config::Config),
+
     /// Manage zones
     #[command(name = "zone")]
     Zone(self::zone::Zone),
@@ -50,6 +55,7 @@ pub enum Command {
 impl Command {
     pub async fn execute(self, client: CascadeApiClient) -> Result<(), String> {
         match self {
+            Self::Config(cmd) => cmd.execute(client).await,
             Self::Zone(zone) => zone.execute(client).await,
             Self::Status(status) => status.execute(client).await,
             Self::Policy(policy) => policy.execute(client).await,

--- a/src/cli/commands/policy.rs
+++ b/src/cli/commands/policy.rs
@@ -49,7 +49,7 @@ impl Policy {
         match self.command {
             PolicyCommand::List => {
                 let res: PolicyListResult = client
-                    .get("policy/list")
+                    .get("policy/")
                     .send()
                     .and_then(|r| r.json())
                     .await

--- a/src/cli/commands/policy.rs
+++ b/src/cli/commands/policy.rs
@@ -30,7 +30,7 @@ pub enum PolicyCommand {
 }
 
 #[allow(unused)]
-mod ansi {
+pub mod ansi {
     pub const BLACK: &str = "\x1b[0;30m";
     pub const RED: &str = "\x1b[0;31m";
     pub const GREEN: &str = "\x1b[0;32m";

--- a/src/cli/commands/zone.rs
+++ b/src/cli/commands/zone.rs
@@ -1,12 +1,17 @@
-use bytes::Bytes;
-use domain::base::Name;
-use futures::TryFutureExt;
+use std::ops::ControlFlow;
+use std::time::{Duration, SystemTime};
 
-use crate::api::{
-    ZoneAdd, ZoneAddError, ZoneAddResult, ZoneReloadError, ZoneReloadResult, ZoneSource,
-    ZoneStatus, ZoneStatusError, ZonesListResult,
-};
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use domain::base::{Name, Serial};
+use futures::TryFutureExt;
+use humantime::FormattedDuration;
+
+use crate::api::*;
 use crate::cli::client::{format_http_error, CascadeApiClient};
+use crate::cli::commands::policy::ansi;
+use crate::zone::PipelineMode;
+use crate::zonemaintenance::types::SigningReport;
 
 #[derive(Clone, Debug, clap::Args)]
 pub struct Zone {
@@ -45,7 +50,14 @@ pub enum ZoneCommand {
 
     /// Get the status of a single zone
     #[command(name = "status")]
-    Status { zone: Name<Bytes> },
+    Status {
+        /// Whether or not to show additional details.
+        #[arg(long = "detailed")]
+        detailed: bool,
+
+        /// The zone to report the status of.
+        zone: Name<Bytes>,
+    },
 }
 
 // From brainstorm in beginning of April 2025
@@ -109,8 +121,8 @@ impl Zone {
                     .await
                     .map_err(format_http_error)?;
 
-                for zone in response.zones {
-                    Self::print_zone_status(zone);
+                for zone_name in response.zones {
+                    println!("{}", zone_name);
                 }
                 Ok(())
             }
@@ -131,11 +143,15 @@ impl Zone {
                     Err(e) => Err(format!("Failed to reload zone: {e}")),
                 }
             }
-            ZoneCommand::Status { zone } => Self::status(client, zone).await,
+            ZoneCommand::Status { zone, detailed } => Self::status(client, zone, detailed).await,
         }
     }
 
-    async fn status(client: CascadeApiClient, zone: Name<Bytes>) -> Result<(), String> {
+    async fn status(
+        client: CascadeApiClient,
+        zone: Name<Bytes>,
+        detailed: bool,
+    ) -> Result<(), String> {
         // TODO: move to function that can be called by the general
         // status command with a zone arg?
         let url = format!("zone/{}/status", zone);
@@ -147,27 +163,403 @@ impl Zone {
             .map_err(format_http_error)?;
 
         match response {
-            Ok(status) => {
-                Self::print_zone_status(status);
-                Ok(())
-            }
+            Ok(status) => Self::print_zone_status(client, status, detailed).await,
             Err(ZoneStatusError::ZoneDoesNotExist) => Err(format!("zone `{zone}` does not exist")),
         }
     }
 
-    fn print_zone_status(zone: ZoneStatus) {
-        println!("{}", zone.name);
-        println!("  source: {}", zone.source);
-        println!("  policy: {}", zone.policy);
-        println!("  stage: {}", zone.stage);
+    async fn print_zone_status(
+        client: CascadeApiClient,
+        zone: ZoneStatus,
+        detailed: bool,
+    ) -> Result<(), String> {
+        // Fetch the policy for the zone.
+        let url = format!("policy/{}", zone.policy);
+        let response: Result<PolicyInfo, PolicyInfoError> = client
+            .get(&url)
+            .send()
+            .and_then(|r| r.json())
+            .await
+            .map_err(|e| format!("HTTP request failed: {e:?}"))?;
 
-        if let Some(key_status) = zone.key_status {
-            println!("  key:");
-            for line in key_status.lines() {
-                println!("    {line}");
+        let policy = response.map_err(|_| {
+            format!(
+                "policy `{}` used by zone `{}` does not exist",
+                zone.policy, zone.name
+            )
+        })?;
+
+        // Determine progress
+        let progress = determine_progress(&zone, &policy);
+
+        // Output information per step progressed until the first still
+        // in-progress/aborted step or show all steps if all have completed.
+        progress.print(&zone, &policy);
+
+        // If the pipeline is halted, show that.
+        match zone.pipeline_mode {
+            PipelineMode::Running => { /* Nothing to do */ }
+            PipelineMode::SoftHalt(err) => {
+                println!("{}\u{78} An error occurred that prevents further processing of this zone version:{}", ansi::RED, ansi::RESET);
+                println!("{}\u{78} {err}{}", ansi::RED, ansi::RESET);
             }
-        } else {
-            println!("  key: <none>");
+            PipelineMode::HardHalt(err) => {
+                println!(
+                    "{}\u{78} The pipeline for this zone is halted due to a serious error:{}",
+                    ansi::RED,
+                    ansi::RESET
+                );
+                println!("{}\u{78} {err}{}", ansi::RED, ansi::RESET);
+            }
+        }
+
+        if detailed {
+            println!("DNSSEC keys:");
+            for key in zone.keys {
+                match key.key_type {
+                    KeyType::Ksk => print!("  KSK"),
+                    KeyType::Zsk => print!("  ZSK"),
+                    KeyType::Csk => print!("  CSK"),
+                }
+                println!(" tagged {}:", key.key_tag);
+                println!("    Reference: {}", key.pubref);
+                if key.signer {
+                    println!("    Actively used for signing");
+                }
+            }
+            if let Some(key_status) = zone.key_status {
+                println!("  Details:");
+                for line in key_status.lines() {
+                    println!("    {line}");
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum Progress {
+    WaitingForChanges,
+    ChangesReceived,
+    AtUnsignedReview,
+    WaitingToSign,
+    Signing,
+    Signed,
+    AtSignedReview,
+    Published,
+}
+
+fn determine_progress(zone: &ZoneStatus, policy: &PolicyInfo) -> Progress {
+    match zone.stage {
+        ZoneStage::Unsigned => match (&zone.receipt_report, zone.unsigned_review_status) {
+            (None, _) => Progress::WaitingForChanges,
+            (Some(_), None) => Progress::ChangesReceived,
+            (Some(_), Some(TimestampedZoneReviewStatus { status, .. })) => {
+                match status {
+                    ZoneReviewStatus::Pending | ZoneReviewStatus::Rejected => {
+                        Progress::AtUnsignedReview
+                    }
+                    ZoneReviewStatus::Approved => {
+                        // After reviewing comes signing, and if we're not stuck at
+                        // reviewing then we must be somewhere in signing.
+                        match &zone.signing_report {
+                            None | Some(SigningReport::Requested(_)) => Progress::WaitingToSign,
+                            Some(SigningReport::InProgress(_)) => Progress::Signing,
+                            Some(SigningReport::Finished(_)) => Progress::Signed,
+                        }
+                    }
+                }
+            }
+        },
+        ZoneStage::Signed => {
+            if !policy.signer.review.required {
+                match &zone.signing_report {
+                    None | Some(SigningReport::Requested(_)) => Progress::WaitingToSign,
+                    Some(SigningReport::InProgress(_)) => Progress::Signing,
+                    Some(SigningReport::Finished(_)) => Progress::Signed,
+                }
+            } else {
+                // After reviewing comes publication, and if we're not at the
+                // published stage then with review enabled we must still be
+                // at the review stage.
+                Progress::AtSignedReview
+            }
+        }
+        ZoneStage::Published => Progress::Published,
+    }
+}
+
+impl std::fmt::Display for Progress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Progress::WaitingForChanges => f.write_str("Waiting for changes"),
+            Progress::ChangesReceived => f.write_str("Changes received"),
+            Progress::AtUnsignedReview => f.write_str("At unsigned review"),
+            Progress::WaitingToSign => f.write_str("Waiting to sign"),
+            Progress::Signing => f.write_str("Signing"),
+            Progress::Signed => f.write_str("Signed"),
+            Progress::AtSignedReview => f.write_str("At signed review"),
+            Progress::Published => f.write_str("Published"),
         }
     }
+}
+
+impl Progress {
+    pub fn print(&self, zone: &ZoneStatus, policy: &PolicyInfo) {
+        println!(
+            "Status report for zone '{}' using policy '{}'",
+            zone.name, policy.name
+        );
+
+        let mut p = Progress::WaitingForChanges;
+        loop {
+            match p {
+                Progress::WaitingForChanges => self.print_waiting_for_changes(zone),
+                Progress::ChangesReceived => self.print_zone_received(zone),
+                Progress::AtUnsignedReview => self.print_pending_unsigned_review(zone, policy),
+                Progress::WaitingToSign => self.print_waiting_to_sign(zone),
+                Progress::Signing => self.print_signing(zone),
+                Progress::Signed => self.print_signed(zone),
+                Progress::AtSignedReview => self.print_pending_signed_review(zone, policy),
+                Progress::Published => self.print_published(zone),
+            }
+            match p.next(*self) {
+                ControlFlow::Continue(next_p) => p = next_p,
+                ControlFlow::Break(()) => break,
+            }
+        }
+    }
+
+    fn next(&self, max: Progress) -> ControlFlow<(), Progress> {
+        let next = match self {
+            Progress::WaitingForChanges => Progress::ChangesReceived,
+            Progress::ChangesReceived => Progress::AtUnsignedReview,
+            Progress::AtUnsignedReview => Progress::WaitingToSign,
+            Progress::WaitingToSign => Progress::Signing,
+            Progress::Signing => Progress::Signed,
+            Progress::Signed => Progress::AtSignedReview,
+            Progress::AtSignedReview => Progress::Published,
+            Progress::Published => return ControlFlow::Break(()),
+        };
+
+        if next > max {
+            return ControlFlow::Break(());
+        }
+
+        ControlFlow::Continue(next)
+    }
+
+    fn print_waiting_for_changes(&self, zone: &ZoneStatus) {
+        let done = *self > Progress::WaitingForChanges;
+        let waiting_waited = match done {
+            true => "Waited",
+            false => "Waiting",
+        };
+        println!(
+            "{} {} for a new version of the {} zone",
+            status_icon(done),
+            waiting_waited,
+            zone.name
+        );
+        // TODO: When complete, show how long we waited.
+    }
+
+    fn print_zone_received(&self, zone: &ZoneStatus) {
+        // TODO: we have no indication of whether a zone is currently being
+        // received or not, we can only say if it was received after the fact.
+        println!(
+            "{} Loaded {}",
+            status_icon(true),
+            serial_to_string(zone.unsigned_serial),
+        );
+
+        // Print how receival of the zone went.
+        let Some(report) = &zone.receipt_report else {
+            unreachable!();
+        };
+        let (loaded_fetched, filesystem_network) = match zone.source {
+            ZoneSource::None => unreachable!(),
+            ZoneSource::Zonefile { .. } => ("Loaded", "filesystem"),
+            ZoneSource::Server { .. } => ("Fetched", "network"),
+        };
+        println!("  Loaded at {}", to_rfc3339(report.finished_at));
+        println!(
+            "  {loaded_fetched} {} from the {filesystem_network} in {} seconds",
+            format_size(report.byte_count, " ", "B"),
+            report
+                .finished_at
+                .duration_since(report.started_at)
+                .unwrap()
+                .as_secs()
+        );
+    }
+
+    fn print_pending_unsigned_review(&self, zone: &ZoneStatus, policy: &PolicyInfo) {
+        if !policy.loader.review.required {
+            println!(
+                "{} Auto approving signing of {}, no checks enabled in policy.",
+                status_icon(true),
+                serial_to_string(zone.unsigned_serial),
+            );
+        } else {
+            let done = *self > Progress::AtUnsignedReview;
+            let waiting_waited = match done {
+                true => "Waited",
+                false => "Waiting",
+            };
+            println!(
+                "{} {} for approval to sign {}",
+                status_icon(done),
+                waiting_waited,
+                serial_to_string(zone.unsigned_serial),
+            );
+            Self::print_review_hook(&policy.loader.review.cmd_hook);
+            // TODO: When complete, show how long we waited.
+        }
+    }
+
+    fn print_waiting_to_sign(&self, zone: &ZoneStatus) {
+        println!(
+            "{} Approval received to sign {}, signing requested",
+            status_icon(*self > Progress::WaitingToSign),
+            serial_to_string(zone.unsigned_serial)
+        );
+    }
+
+    fn print_signing(&self, zone: &ZoneStatus) {
+        if *self >= Progress::Signed {
+            return;
+        }
+
+        println!(
+            "{} Signing {}",
+            status_icon(*self > Progress::Signing),
+            serial_to_string(zone.unsigned_serial)
+        );
+        Self::print_signing_progress(zone);
+    }
+
+    fn print_signed(&self, zone: &ZoneStatus) {
+        println!(
+            "{} Signed {} as {}",
+            status_icon(*self > Progress::Signed),
+            serial_to_string(zone.unsigned_serial),
+            serial_to_string(zone.signed_serial)
+        );
+
+        Self::print_signing_progress(zone);
+
+        if *self == Progress::Signed {
+            if let Some(addr) = zone.signed_review_addr {
+                println!("  Signed zone available on {addr}");
+            }
+        }
+    }
+
+    fn print_pending_signed_review(&self, zone: &ZoneStatus, policy: &PolicyInfo) {
+        if !policy.signer.review.required {
+            println!(
+                "{} Auto approving publication of {}, no checks enabled in policy.",
+                status_icon(true),
+                serial_to_string(zone.signed_serial)
+            );
+        } else {
+            let done = *self > Progress::AtSignedReview;
+            let waiting_waited = match done {
+                true => "Waited",
+                false => "Waiting",
+            };
+            println!(
+                "{} {} for approval to publish {}",
+                status_icon(*self > Progress::AtSignedReview),
+                waiting_waited,
+                serial_to_string(zone.signed_serial),
+            );
+            Self::print_review_hook(&policy.signer.review.cmd_hook);
+        }
+    }
+
+    fn print_published(&self, zone: &ZoneStatus) {
+        println!(
+            "{} Published {}",
+            status_icon(*self == Progress::Published),
+            serial_to_string(zone.published_serial),
+        );
+        if *self == Progress::Published {
+            println!("  Published zone available on {}", zone.publish_addr);
+        }
+    }
+
+    fn print_review_hook(cmd_hook: &Option<String>) {
+        match cmd_hook {
+            Some(path) => println!("  Configured to invoke {path}"),
+            None => println!("\u{0021} Zone will be held until manually approved"),
+        }
+    }
+
+    fn print_signing_progress(zone: &ZoneStatus) {
+        if let Some(report) = &zone.signing_report {
+            match report {
+                SigningReport::Requested(r) => {
+                    println!("  Signing requested at {}", to_rfc3339(r.requested_at));
+                }
+                SigningReport::InProgress(r) => {
+                    println!("  Signing started at {}", to_rfc3339(r.started_at));
+                    if let (Some(unsigned_rr_count), Some(total_time)) =
+                        (r.unsigned_rr_count, r.total_time)
+                    {
+                        println!(
+                            "  Signed {} in {}",
+                            format_size(unsigned_rr_count, "", " records"),
+                            format_duration(total_time)
+                        );
+                    }
+                }
+                SigningReport::Finished(r) => {
+                    println!("  Signed at {}", to_rfc3339(r.finished_at));
+                    println!(
+                        "  Signed {} in {}",
+                        format_size(r.unsigned_rr_count, "", " records"),
+                        format_duration(r.total_time)
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn status_icon(done: bool) -> String {
+    match done {
+        true => format!("{}\u{2714}{}", ansi::GREEN, ansi::RESET), // tick ✔
+        false => format!("{}\u{2022}{}", ansi::YELLOW, ansi::RESET), // bullet •
+    }
+}
+
+fn format_size(v: usize, spacer: &str, suffix: &str) -> String {
+    match v {
+        n if n > 1_000_000 => format!("{}{spacer}M{suffix}", n / 1_000_000),
+        n if n > 1_000 => format!("{}{spacer}K{suffix}", n / 1_000),
+        n => format!("{n}{spacer}{suffix}"),
+    }
+}
+
+fn serial_to_string(serial: Option<Serial>) -> String {
+    match serial {
+        Some(serial) => format!("version {serial}"),
+        None => "<serial number not yet known>".to_string(),
+    }
+}
+
+fn to_rfc3339(v: SystemTime) -> String {
+    let now = SystemTime::now();
+    let diff = now.duration_since(v).unwrap();
+    let rfc3339 = DateTime::<Utc>::from(v).to_rfc3339_opts(chrono::SecondsFormat::Secs, false);
+    format!("{rfc3339} ({} ago)", format_duration(diff))
+}
+
+fn format_duration(duration: Duration) -> FormattedDuration {
+    // See: https://github.com/chronotope/humantime/issues/35
+    humantime::format_duration(Duration::from_secs(duration.as_secs()))
 }

--- a/src/comms.rs
+++ b/src/comms.rs
@@ -69,12 +69,15 @@ use domain::base::Serial;
 use domain::zonetree::StoredName;
 use std::fmt::{self, Debug};
 use std::net::IpAddr;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::api;
 use crate::api::ZoneAdd;
 use crate::center::Change;
+use crate::units::zone_loader::ZoneLoaderReport;
+use crate::zone::SigningTrigger;
 use crate::zone::ZoneLoadSource;
+use crate::zonemaintenance::types::{SigningReport, ZoneReport};
 
 //------------ GraphMetrics --------------------------------------------------
 pub trait GraphStatus: Send + Sync {
@@ -132,7 +135,7 @@ impl fmt::Display for UnitStatus {
 pub struct Terminated;
 
 #[allow(clippy::enum_variant_names)]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum ApplicationCommand {
     /// A change has occurred.
     Changed(Change),
@@ -148,6 +151,10 @@ pub enum ApplicationCommand {
     SeekApprovalForUnsignedZone {
         zone_name: StoredName,
         zone_serial: Serial,
+    },
+    IsZonePendingApproval {
+        zone_name: StoredName,
+        tx: oneshot::Sender<bool>,
     },
 
     /// Refresh a zone.
@@ -180,6 +187,7 @@ pub enum ApplicationCommand {
     SignZone {
         zone_name: StoredName,
         zone_serial: Option<Serial>,
+        trigger: SigningTrigger,
     },
     SeekApprovalForSignedZone {
         zone_name: StoredName,
@@ -191,6 +199,14 @@ pub enum ApplicationCommand {
     },
     RegisterZone {
         register: ZoneAdd,
+    },
+    GetZoneReport {
+        zone_name: StoredName,
+        report_tx: oneshot::Sender<(ZoneReport, Option<ZoneLoaderReport>)>,
+    },
+    GetSigningReport {
+        zone_name: StoredName,
+        report_tx: oneshot::Sender<SigningReport>,
     },
 
     RollKey {

--- a/src/config/file/v1.rs
+++ b/src/config/file/v1.rs
@@ -36,6 +36,14 @@ pub struct Spec {
     #[serde(default = "Spec::dnst_binary_path_default")]
     pub dnst_binary_path: Box<Utf8Path>,
 
+    /// The file storing KMIP server credentials.
+    #[serde(default = "Spec::kmip_credentials_store_path_default")]
+    pub kmip_credentials_store_path: Box<Utf8Path>,
+
+    /// The directory storing KMIP server state.
+    #[serde(default = "Spec::kmip_server_state_dir_default")]
+    pub kmip_server_state_dir: Box<Utf8Path>,
+
     /// Remote control configuration.
     pub remote_control: RemoteControlSpec,
 
@@ -65,6 +73,8 @@ impl Spec {
         config.tsig_store_path = self.tsig_store_path;
         config.keys_dir = self.keys_dir;
         config.dnst_binary_path = self.dnst_binary_path;
+        config.kmip_credentials_store_path = self.kmip_credentials_store_path;
+        config.kmip_server_state_dir = self.kmip_server_state_dir;
         self.remote_control.parse_into(&mut config.remote_control);
         self.daemon.parse_into(&mut config.daemon);
         self.loader.parse_into(&mut config.loader);
@@ -84,6 +94,8 @@ impl Default for Spec {
             tsig_store_path: Self::tsig_store_path_default(),
             keys_dir: Self::keys_dir_default(),
             dnst_binary_path: Self::dnst_binary_path_default(),
+            kmip_credentials_store_path: Self::kmip_credentials_store_path_default(),
+            kmip_server_state_dir: Self::kmip_server_state_dir_default(),
             remote_control: Default::default(),
             daemon: Default::default(),
             loader: Default::default(),
@@ -118,6 +130,16 @@ impl Spec {
     /// The default value for `dnst_keyset_dir`.
     fn keys_dir_default() -> Box<Utf8Path> {
         "/var/db/cascade/keys".into()
+    }
+
+    /// The default value for `kmip_credentials_store_path`.
+    fn kmip_credentials_store_path_default() -> Box<Utf8Path> {
+        "/var/lib/cascade/kmip/credentials.db".into()
+    }
+
+    /// The default value for `kmip_server_state_dir`.
+    fn kmip_server_state_dir_default() -> Box<Utf8Path> {
+        "/var/lib/cascade/kmip".into()
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -366,6 +366,16 @@ pub enum SocketConfig {
     // TODO: TLS
 }
 
+impl SocketConfig {
+    pub fn addr(&self) -> SocketAddr {
+        match self {
+            SocketConfig::UDP { addr } => *addr,
+            SocketConfig::TCP { addr } => *addr,
+            SocketConfig::TCPUDP { addr } => *addr,
+        }
+    }
+}
+
 //----------- LogLevel ---------------------------------------------------------
 
 /// A severity level for logging.

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -4,6 +4,7 @@ use domain::base::Serial;
 use domain::zonetree::StoredName;
 
 use crate::center::Change;
+use crate::zone::SigningTrigger;
 
 //------------ Update --------------------------------------------------------
 
@@ -35,13 +36,28 @@ pub enum Update {
         zone_name: StoredName,
         zone_serial: Serial,
     },
+
     UnsignedZoneApprovedEvent {
         zone_name: StoredName,
         zone_serial: Serial,
     },
+
+    UnsignedZoneRejectedEvent {
+        zone_name: StoredName,
+        zone_serial: Serial,
+    },
+
     ZoneSignedEvent {
         zone_name: StoredName,
         zone_serial: Serial,
+        trigger: SigningTrigger,
+    },
+
+    ZoneSigningFailedEvent {
+        zone_name: StoredName,
+        zone_serial: Option<Serial>,
+        trigger: SigningTrigger,
+        reason: String,
     },
 
     SignedZoneApprovedEvent {
@@ -49,7 +65,13 @@ pub enum Update {
         zone_serial: Serial,
     },
 
+    SignedZoneRejectedEvent {
+        zone_name: StoredName,
+        zone_serial: Serial,
+    },
+
     ResignZoneEvent {
         zone_name: StoredName,
+        trigger: SigningTrigger,
     },
 }

--- a/src/state/v1.rs
+++ b/src/state/v1.rs
@@ -180,6 +180,16 @@ impl ConfigSpec {
         update_value(&mut config.keys_dir, self.keys_dir, changed);
         update_value(&mut config.dnst_binary_path, self.dnst_binary_path, changed);
         update_value(
+            &mut config.kmip_credentials_store_path,
+            self.kmip_credentials_store_path,
+            changed,
+        );
+        update_value(
+            &mut config.kmip_server_state_dir,
+            self.kmip_server_state_dir,
+            changed,
+        );
+        update_value(
             &mut config.remote_control,
             self.remote_control.parse(),
             changed,

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
+use std::time::SystemTime;
 
 use axum::extract::OriginalUri;
 use axum::extract::Path;
@@ -20,6 +21,7 @@ use domain::base::Name;
 use domain::base::Serial;
 use domain::crypto::kmip::ConnectionSettings;
 use domain::dep::kmip::client::pool::ConnectionManager;
+use domain::dnssec::sign::keys::keyset::KeyType;
 use log::warn;
 use log::{debug, error, info};
 use serde::Deserialize;
@@ -27,9 +29,11 @@ use serde::Serialize;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::task::JoinSet;
+use tokio::time::Instant;
 
 use crate::api;
 use crate::api::keyset::*;
+use crate::api::KeyInfo;
 use crate::api::*;
 use crate::center;
 use crate::center::Center;
@@ -40,6 +44,13 @@ use crate::policy::SignerSerialPolicy;
 use crate::units::key_manager::KmipClientCredentials;
 use crate::units::key_manager::KmipClientCredentialsFile;
 use crate::units::key_manager::KmipServerCredentialsFileMode;
+use crate::units::zone_loader::ZoneLoaderReport;
+use crate::units::zone_signer::KeySetState;
+use crate::zone::HistoricalEvent;
+use crate::zone::HistoricalEventType;
+use crate::zone::ZoneLoadSource;
+use crate::zonemaintenance::maintainer::read_soa;
+use crate::zonemaintenance::types::ZoneReportDetails;
 
 const HTTP_UNIT_NAME: &str = "HS";
 
@@ -202,14 +213,11 @@ impl HttpServer {
 
     async fn zones_list(State(http_state): State<Arc<HttpServerState>>) -> Json<ZonesListResult> {
         let state = http_state.center.state.lock().unwrap();
-        let names: Vec<_> = state.zones.iter().map(|z| z.0.name.clone()).collect();
-        drop(state);
-
-        let zones = names
+        let zones = state
+            .zones
             .iter()
-            .filter_map(|z| Self::get_zone_status(http_state.clone(), z).ok())
-            .collect();
-
+            .map(|z| z.0.name.clone())
+            .collect::<Vec<_>>();
         Json(ZonesListResult { zones })
     }
 
@@ -217,74 +225,309 @@ impl HttpServer {
         State(state): State<Arc<HttpServerState>>,
         Path(name): Path<Name<Bytes>>,
     ) -> Json<Result<ZoneStatus, ZoneStatusError>> {
-        Json(Self::get_zone_status(state, &name))
+        Json(Self::get_zone_status(state, name).await)
     }
 
-    fn get_zone_status(
+    async fn get_zone_status(
         state: Arc<HttpServerState>,
-        name: &Name<Bytes>,
+        name: Name<Bytes>,
     ) -> Result<ZoneStatus, ZoneStatusError> {
-        let center = &state.center;
+        let mut zone_loaded_at = None;
+        let mut zone_loaded_in = None;
+        let mut zone_loaded_bytes = 0;
+        let dnst_binary_path;
+        let cfg_path;
+        let state_path;
+        let app_cmd_tx;
+        let policy;
+        let mut source;
+        let unsigned_review_addr;
+        let signed_review_addr;
+        let publish_addr;
+        let unsigned_review_status;
+        let signed_review_status;
+        let pipeline_mode;
+        {
+            let locked_state = state.center.state.lock().unwrap();
+            dnst_binary_path = locked_state.config.dnst_binary_path.clone();
+            let keys_dir = &locked_state.config.keys_dir;
+            cfg_path = keys_dir.join(format!("{name}.cfg"));
+            state_path = keys_dir.join(format!("{name}.state"));
+            app_cmd_tx = state.center.app_cmd_tx.clone();
+            let zone = locked_state
+                .zones
+                .get(&name)
+                .ok_or(ZoneStatusError::ZoneDoesNotExist)?;
+            let zone_state = zone.0.state.lock().unwrap();
+            pipeline_mode = zone_state.pipeline_mode.clone();
+            policy = zone_state
+                .policy
+                .as_ref()
+                .map_or("<none>".into(), |p| p.name.to_string());
+            // TODO: Needs some info from the zone loader?
+            source = match zone_state.source.clone() {
+                ZoneLoadSource::None => api::ZoneSource::None,
+                ZoneLoadSource::Zonefile { path } => api::ZoneSource::Zonefile { path },
+                ZoneLoadSource::Server { addr, tsig_key: _ } => api::ZoneSource::Server {
+                    addr,
+                    tsig_key: None,
+                    xfr_status: Default::default(),
+                },
+            };
+            unsigned_review_addr = locked_state
+                .config
+                .loader
+                .review
+                .servers
+                .first()
+                .map(|v| v.addr());
+            signed_review_addr = locked_state
+                .config
+                .signer
+                .review
+                .servers
+                .first()
+                .map(|v| v.addr());
+            publish_addr = locked_state
+                .config
+                .server
+                .servers
+                .first()
+                .expect("Server must have a publish address")
+                .addr();
 
-        let state = center.state.lock().unwrap();
-        let zone = state
-            .zones
-            .get(name)
-            .ok_or(ZoneStatusError::ZoneDoesNotExist)?;
-        let zone_state = zone.0.state.lock().unwrap();
+            unsigned_review_status = zone_state
+                .find_last_event(HistoricalEventType::UnsignedZoneReview, None)
+                .map(|item| {
+                    let HistoricalEvent::UnsignedZoneReview { status, when } = item.event else {
+                        unreachable!()
+                    };
+                    TimestampedZoneReviewStatus { status, when }
+                });
 
-        // TODO: Needs some info from the zone loader?
-        let source = match zone_state.source.clone() {
-            crate::zone::ZoneLoadSource::None => api::ZoneSource::None,
-            crate::zone::ZoneLoadSource::Zonefile { path } => api::ZoneSource::Zonefile { path },
-            crate::zone::ZoneLoadSource::Server { addr, tsig_key: _ } => api::ZoneSource::Server {
-                addr,
-                tsig_key: None,
-            },
-        };
-
-        let policy = zone_state
-            .policy
-            .as_ref()
-            .map_or("<none>".into(), |p| p.name.to_string());
+            signed_review_status = zone_state
+                .find_last_event(HistoricalEventType::SignedZoneReview, None)
+                .map(|item| {
+                    let HistoricalEvent::SignedZoneReview { status, when } = item.event else {
+                        unreachable!()
+                    };
+                    TimestampedZoneReviewStatus { status, when }
+                });
+        }
 
         // TODO: We need to show multiple versions here
-        let stage = if center
-            .published_zones
-            .load()
-            .get_zone(&name, Class::IN)
-            .is_some()
-        {
+        let unsigned_zones = state.center.unsigned_zones.load();
+        let signed_zones = state.center.signed_zones.load();
+        let published_zones = state.center.published_zones.load();
+        let unsigned_zone = unsigned_zones.get_zone(&name, Class::IN);
+        let signed_zone = signed_zones.get_zone(&name, Class::IN);
+        let published_zone = published_zones.get_zone(&name, Class::IN);
+
+        // Determine the highest stage the zone has progressed to.
+        let stage = if published_zone.is_some() {
             ZoneStage::Published
-        } else if center
-            .signed_zones
-            .load()
-            .get_zone(&name, Class::IN)
-            .is_some()
-        {
+        } else if signed_zone.is_some() {
             ZoneStage::Signed
         } else {
             ZoneStage::Unsigned
         };
 
-        let dnst_binary = &state.config.dnst_binary_path;
-        let keys_dir = &state.config.keys_dir;
-        let cfg = keys_dir.join(format!("{name}.cfg"));
-        let key_status = Command::new(dnst_binary.as_std_path())
-            .arg("keyset")
-            .arg("-c")
-            .arg(cfg)
-            .arg("status")
-            .output()
-            .ok()
-            .map(|o| String::from_utf8_lossy(&o.stdout).to_string());
+        // Query key status
+        let key_status = {
+            // TODO: Move this into key manager as that is the component that knows
+            // about dnst?
+            if let Some(stdout) = Command::new(dnst_binary_path.as_std_path())
+                .arg("keyset")
+                .arg("-c")
+                .arg(cfg_path)
+                .arg("status")
+                .arg("-v")
+                .output()
+                .ok()
+                .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
+            {
+                // Invoke dnst to get status information about the keys for the
+                // zone. Strip out lines that would be correct for a dnst user but
+                // confusing for a cascade user, and rewrite advice to invoke dnst
+                // to be equivalent advice to invoke cascade.
+                let mut sanitized_output = String::new();
+                for line in stdout.lines() {
+                    if line.contains("Next time to run the 'cron' subcommand") {
+                        continue;
+                    }
+
+                    if line.contains("dnst keyset -c") {
+                        // The config file path after -c should NOT contain a
+                        // space as it is based on a zone name, and zone names
+                        // cannot contain spaces. Find the config file path so
+                        // that we can strip it out (as users of the cascade
+                        // CLI should not need to know or care what internal
+                        // dnst config files are being used).
+                        let mut parts = line.split(' ');
+                        if parts.any(|part| part == "-c") {
+                            if let Some(dnst_config_path) = parts.next() {
+                                let sanitized_line = line.replace(
+                                    &format!("dnst keyset -c {dnst_config_path}"),
+                                    &format!("cascade keyset {name}"),
+                                );
+                                sanitized_output.push_str(&sanitized_line);
+                                sanitized_output.push('\n');
+                                continue;
+                            }
+                        }
+                    }
+
+                    sanitized_output.push_str(line);
+                    sanitized_output.push('\n');
+                }
+                Some(sanitized_output)
+            } else {
+                None
+            }
+        };
+
+        // Query XFR status
+        let (tx, rx) = oneshot::channel();
+        app_cmd_tx
+            .send((
+                "ZL".to_owned(),
+                ApplicationCommand::GetZoneReport {
+                    zone_name: name.clone(),
+                    report_tx: tx,
+                },
+            ))
+            .ok();
+        if let Ok((zone_maintainer_report, zone_loader_report)) = rx.await {
+            match zone_maintainer_report.details() {
+                ZoneReportDetails::Primary => {
+                    if let Some(report) = zone_loader_report {
+                        if let Ok(duration) = report.finished_at.duration_since(report.started_at) {
+                            zone_loaded_in = Some(duration);
+                            zone_loaded_at = Some(report.finished_at);
+                            zone_loaded_bytes = report.byte_count;
+                        }
+                    }
+                }
+                ZoneReportDetails::PendingSecondary(s) | ZoneReportDetails::Secondary(s) => {
+                    let api::ZoneSource::Server { xfr_status, .. } = &mut source else {
+                        unreachable!("A secondary must have been configured from a server source");
+                    };
+                    *xfr_status = s.status();
+                    let metrics = s.metrics();
+                    let now = Instant::now();
+                    let now_t = SystemTime::now();
+                    if let (Some(checked_at), Some(refreshed_at)) = (
+                        metrics.last_soa_serial_check_succeeded_at,
+                        metrics.last_refreshed_at,
+                    ) {
+                        zone_loaded_in = Some(refreshed_at.duration_since(checked_at));
+                        zone_loaded_at = now_t.checked_sub(now.duration_since(refreshed_at));
+                        zone_loaded_bytes = metrics.last_refresh_succeeded_bytes.unwrap();
+                    }
+                }
+            }
+        }
+
+        // Query zone keys
+        let mut keys = vec![];
+        match std::fs::read_to_string(&state_path) {
+            Ok(json) => {
+                let keyset_state: KeySetState = serde_json::from_str(&json).unwrap();
+                for (pubref, key) in keyset_state.keyset.keys() {
+                    let (key_type, signer) = match key.keytype() {
+                        KeyType::Ksk(s) => (api::KeyType::Ksk, s.signer()),
+                        KeyType::Zsk(s) => (api::KeyType::Zsk, s.signer()),
+                        KeyType::Csk(s1, s2) => (api::KeyType::Csk, s1.signer() || s2.signer()),
+                        KeyType::Include(_) => continue,
+                    };
+                    keys.push(KeyInfo {
+                        pubref: pubref.clone(),
+                        key_type,
+                        key_tag: key.key_tag(),
+                        signer,
+                    });
+                }
+            }
+            Err(err) => {
+                error!("Unable to read `dnst keyset` state file '{state_path}' while querying status of zone {name} for the API: {err}");
+            }
+        }
+
+        // Query signing status
+        let mut signing_report = None;
+        if stage >= ZoneStage::Signed {
+            let (report_tx, rx) = oneshot::channel();
+            app_cmd_tx
+                .send((
+                    "ZS".to_owned(),
+                    ApplicationCommand::GetSigningReport {
+                        zone_name: name.clone(),
+                        report_tx,
+                    },
+                ))
+                .ok();
+            if let Ok(report) = rx.await {
+                signing_report = Some(report);
+            }
+        }
+
+        let receipt_report =
+            if let (Some(finished_at), Some(zone_loaded_in)) = (zone_loaded_at, zone_loaded_in) {
+                let started_at = finished_at.checked_sub(zone_loaded_in).unwrap();
+                Some(ZoneLoaderReport {
+                    started_at,
+                    finished_at,
+                    byte_count: zone_loaded_bytes,
+                })
+            } else {
+                None
+            };
+
+        // Query zone serials
+        let mut unsigned_serial = None;
+        if let Some(zone) = unsigned_zone {
+            if let Ok(Some((soa, _ttl))) = read_soa(&zone.read(), name.clone()).await {
+                unsigned_serial = Some(soa.serial());
+            }
+        }
+        let mut signed_serial = None;
+        if let Some(zone) = signed_zone {
+            if let Ok(Some((soa, _ttl))) = read_soa(&zone.read(), name.clone()).await {
+                signed_serial = Some(soa.serial());
+            }
+        }
+        let mut published_serial = None;
+        if let Some(zone) = published_zone {
+            if let Ok(Some((soa, _ttl))) = read_soa(&zone.read(), name.clone()).await {
+                published_serial = Some(soa.serial());
+            }
+        }
+
+        // If the timing were unlucky we may have a published serial but not
+        // signed serial as the signed zone may have just been removed. Use
+        // the published serial as the signed serial in this case.
+        if signed_serial.is_none() && published_serial.is_some() {
+            signed_serial = published_serial;
+        }
 
         Ok(ZoneStatus {
-            name: name.clone(),
+            name,
             source,
             policy,
             stage,
+            keys,
             key_status,
+            receipt_report,
+            unsigned_serial,
+            unsigned_review_status,
+            unsigned_review_addr,
+            signed_serial,
+            signed_review_status,
+            signed_review_addr,
+            signing_report,
+            published_serial,
+            publish_addr,
+            pipeline_mode,
         })
     }
 
@@ -305,6 +548,9 @@ impl HttpServer {
             .get(&name)
             .ok_or(ZoneReloadError::ZoneDoesNotExist)?;
         let zone_state = zone.0.state.lock().unwrap();
+        if let Some(reason) = zone_state.halted(true) {
+            return Err(ZoneReloadError::ZoneHalted(reason));
+        }
 
         let source = zone_state.source.clone();
         match zone_state.source.clone() {

--- a/src/units/key_manager.rs
+++ b/src/units/key_manager.rs
@@ -472,7 +472,7 @@ impl TryFrom<&Utf8PathBuf> for KeySetInfo {
         // Get the modified time of the state file before we read
         // state file itself. This is safe if there is a concurrent
         // update.
-        let keyset_state_modified = file_modified(&state_path)?;
+        let keyset_state_modified = file_modified(state_path)?;
 
         /// Persistent state for the keyset command.
         /// Copied frmo the keyset branch of dnst.
@@ -873,7 +873,7 @@ impl KmipClientCredentialsFile {
     }
 
     /// Remove any existing configuration for the specified KMIP server.
-
+    ///
     /// Returns any previous configuration if found.
     pub fn remove(&mut self, server_id: &str) -> Option<KmipClientCredentials> {
         self.credentials.0.remove(server_id)
@@ -905,8 +905,8 @@ impl KeySetCommand {
     pub fn new(
         name: StoredName,
         center: Arc<Center>,
-        keys_dir: Box<Utf8Path>,
-        dnst_binary_path: Box<Utf8Path>,
+        #[allow(clippy::boxed_local)] keys_dir: Box<Utf8Path>,
+        #[allow(clippy::boxed_local)] dnst_binary_path: Box<Utf8Path>,
     ) -> Self {
         let cfg_path = keys_dir.join(format!("{name}.cfg"));
         let mut cmd = Command::new(dnst_binary_path.as_std_path());

--- a/src/units/key_manager.rs
+++ b/src/units/key_manager.rs
@@ -1,23 +1,28 @@
 use crate::api;
-use crate::center::Center;
+use crate::api::keyset::{KeyRemoveError, KeyRollError};
+use crate::center::{get_zone, halt_zone, Center};
 use crate::cli::commands::hsm::Error;
 use crate::comms::{ApplicationCommand, Terminated};
 use crate::payload::Update;
 use crate::policy::KeyParameters;
+use crate::targets::central_command::record_zone_event;
 use crate::units::http_server::KmipServerState;
+use crate::zone::{HistoricalEvent, SigningTrigger};
 use bytes::Bytes;
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use core::time::Duration;
 use domain::base::Name;
 use domain::dnssec::sign::keys::keyset::{KeySet, UnixTime};
+use domain::zonetree::StoredName;
 use log::error;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::fmt::{Display, Formatter};
+use std::ffi::OsStr;
+use std::fmt::Formatter;
 use std::fs::{metadata, File, OpenOptions};
-use std::io::{BufReader, BufWriter, Seek, SeekFrom, Write};
+use std::io::{BufReader, BufWriter, ErrorKind, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output};
 use std::sync::Arc;
 use tokio::select;
 use tokio::sync::{mpsc, oneshot, Mutex};
@@ -84,48 +89,34 @@ impl KeyManager {
                     self.tick().await;
                 }
                 cmd = cmd_rx.recv() => {
-                    self.run_cmd(cmd).await?;
+                    log::debug!("[KM] Received command: {cmd:?}");
+                    if matches!(cmd, Some(ApplicationCommand::Terminate) | None) {
+                        return Err(Terminated);
+                    }
+
+                    if let Err(err) = self.run_cmd(cmd.unwrap()).await {
+                        log::error!("[KM] Error: {err}");
+                    }
                 }
             }
         }
     }
 
-    async fn run_cmd(&self, cmd: Option<ApplicationCommand>) -> Result<(), Terminated> {
-        log::info!("[KM] Received command: {cmd:?}");
-
+    async fn run_cmd(&self, cmd: ApplicationCommand) -> Result<(), String> {
         match cmd {
-            Some(ApplicationCommand::Terminate) | None => Err(Terminated),
-            Some(ApplicationCommand::RegisterZone {
+            ApplicationCommand::RegisterZone {
                 register: crate::api::ZoneAdd { name, .. },
-            }) => {
+            } => {
                 let state_path = self.keys_dir.join(format!("{name}.state"));
 
-                let mut cmd = self.keyset_cmd(&name);
+                let mut cmd = self.keyset_cmd(name.clone());
 
                 cmd.arg("create")
                     .arg("-n")
                     .arg(name.to_string())
                     .arg("-s")
-                    .arg(&state_path);
-
-                log::info!("Running {cmd:?}");
-
-                let output = cmd.output().map_err(|e| {
-                    error!("[KM]: Error creating keyset for {name}: {e}");
-                    Terminated
-                })?;
-                if !output.status.success() {
-                    error!("[KM]: Create command failed for {name}: {}", output.status);
-                    error!(
-                        "[KM]: Create stdout {}",
-                        String::from_utf8_lossy(&output.stdout)
-                    );
-                    error!(
-                        "[KM]: Create stderr {}",
-                        String::from_utf8_lossy(&output.stderr)
-                    );
-                    return Err(Terminated);
-                }
+                    .arg(&state_path)
+                    .output()?;
 
                 // Lookup the policy for the zone to see if it uses a KMIP
                 // server.
@@ -167,7 +158,7 @@ impl KeyManager {
                         has_credentials,
                     } = kmip_server;
 
-                    let mut cmd = self.keyset_cmd(&name);
+                    let mut cmd = self.keyset_cmd(name.clone());
 
                     // TODO: This command should get issued _after_ keyset create
                     // but _before_ keyset init, both of which are issued above.
@@ -202,89 +193,32 @@ impl KeyManager {
                     }
 
                     // TODO: --client-cert, --client-key, --server-cert and --ca-cert
-
-                    log::info!("Running {cmd:?}");
-
-                    let output = cmd.output().map_err(|e| {
-                        error!("[KM]: Error adding KMIP server '{server_id}' for {name}: {e}");
-                        Terminated
-                    })?;
-                    if !output.status.success() {
-                        error!(
-                            "[KM]: Add KMIP server command failed for {name}: {}",
-                            output.status
-                        );
-                        error!(
-                            "[KM]: Create stdout {}",
-                            String::from_utf8_lossy(&output.stdout)
-                        );
-                        error!(
-                            "[KM]: Create stderr {}",
-                            String::from_utf8_lossy(&output.stderr)
-                        );
-                        return Err(Terminated);
-                    }
+                    cmd.output()?;
                 }
 
                 // Set config
                 let config_commands = policy_to_commands(&self.center, &name);
                 for c in config_commands {
-                    let mut cmd = self.keyset_cmd(&name);
+                    let mut cmd = self.keyset_cmd(name.clone());
 
                     cmd.arg("set");
                     for a in c {
                         cmd.arg(a);
                     }
 
-                    log::info!("Running {cmd:?}");
-
-                    let output = cmd.output().map_err(|e| {
-                        error!("[KM]: keyset command failed for {name}: {e}");
-                        Terminated
-                    })?;
-                    if !output.status.success() {
-                        error!("[KM]: set command failed for {name}: {}", output.status);
-                        error!(
-                            "[KM]: Create stdout {}",
-                            String::from_utf8_lossy(&output.stdout)
-                        );
-                        error!(
-                            "[KM]: Create stderr {}",
-                            String::from_utf8_lossy(&output.stderr)
-                        );
-                        return Err(Terminated);
-                    }
+                    cmd.output()?;
                 }
 
                 // TODO: This should not happen immediately after
                 // `keyset create` but only once the zone is enabled.
                 // We currently do not have a good mechanism for that
                 // so we init the key immediately.
-                let mut cmd = self.keyset_cmd(&name);
-                cmd.arg("init");
-
-                log::info!("Running {cmd:?}");
-
-                let output = cmd.output().map_err(|e| {
-                    error!("[KM]: Error initializing keyset for {name}: {e}");
-                    Terminated
-                })?;
-                if !output.status.success() {
-                    error!("[KM]: init command failed for {name}: {}", output.status);
-                    error!(
-                        "[KM]: Create stdout {}",
-                        String::from_utf8_lossy(&output.stdout)
-                    );
-                    error!(
-                        "[KM]: Create stderr {}",
-                        String::from_utf8_lossy(&output.stderr)
-                    );
-                    return Err(Terminated);
-                }
+                self.keyset_cmd(name.clone()).arg("init").output()?;
 
                 Ok(())
             }
-            Some(ApplicationCommand::RollKey {
+
+            ApplicationCommand::RollKey {
                 zone,
                 key_roll:
                     api::keyset::KeyRoll {
@@ -292,8 +226,8 @@ impl KeyManager {
                         cmd: roll_cmd,
                     },
                 http_tx,
-            }) => {
-                let mut cmd = self.keyset_cmd(&zone);
+            } => {
+                let mut cmd = self.keyset_cmd(zone);
 
                 cmd.arg(match roll_variant {
                     api::keyset::KeyRollVariant::Ksk => "ksk",
@@ -323,40 +257,23 @@ impl KeyManager {
                     }
                 }
 
-                log::info!("Running {cmd:?}");
-
-                let output = cmd.output().map_err(|e| {
-                    error!("[KM]: Error running key roll command for {zone}: {e}");
-                    Terminated
-                })?;
-                if output.status.success() {
-                    http_tx.send(Ok(())).await.unwrap();
-                } else {
-                    error!(
-                        "[KM]: Manual key roll command failed for {zone}: {}",
-                        output.status
-                    );
-                    error!(
-                        "[KM]: Manual key roll stdout: {}",
-                        String::from_utf8_lossy(&output.stdout)
-                    );
-                    error!(
-                        "[KM]: Manual key roll stderr: {}",
-                        String::from_utf8_lossy(&output.stderr)
-                    );
-                    http_tx
-                        .send(Err(api::keyset::KeyRollError::DnstCommandError {
-                            status: output.status.to_string(),
-                            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-                            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-                        }))
-                        .await
-                        .unwrap();
+                if let Err(KeySetCommandError { err, output }) = cmd.output() {
+                    let client_err = match output {
+                        Some(output) => KeyRollError::DnstCommandError(
+                            String::from_utf8_lossy(&output.stderr).into(),
+                        ),
+                        None => KeyRollError::DnstCommandError(err.clone()),
+                    };
+                    http_tx.send(Err(client_err)).await.unwrap();
+                    return Err(format!("key roll command failed: {err}"));
                 }
+
+                http_tx.send(Ok(())).await.unwrap();
 
                 Ok(())
             }
-            Some(ApplicationCommand::RemoveKey {
+
+            ApplicationCommand::RemoveKey {
                 zone,
                 key_remove:
                     api::keyset::KeyRemove {
@@ -365,8 +282,8 @@ impl KeyManager {
                         continue_flag,
                     },
                 http_tx,
-            }) => {
-                let mut cmd = self.keyset_cmd(&zone);
+            } => {
+                let mut cmd = self.keyset_cmd(zone);
 
                 cmd.arg("remove-key").arg(key);
 
@@ -378,49 +295,34 @@ impl KeyManager {
                     cmd.arg("--continue");
                 }
 
-                log::info!("Running {cmd:?}");
-
-                let output = cmd.output().map_err(|e| {
-                    error!("[KM]: Error running key removal command for {zone}: {e}");
-                    Terminated
-                })?;
-                if output.status.success() {
-                    http_tx.send(Ok(())).await.unwrap();
-                } else {
-                    error!(
-                        "[KM]: Key remove command failed for {zone}: {}",
-                        output.status
-                    );
-                    error!(
-                        "[KM]: Key remove stdout {}",
-                        String::from_utf8_lossy(&output.stdout)
-                    );
-                    error!(
-                        "[KM]: Key remove stderr {}",
-                        String::from_utf8_lossy(&output.stderr)
-                    );
-                    http_tx
-                        .send(Err(api::keyset::KeyRemoveError::DnstCommandError {
-                            status: output.status.to_string(),
-                            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-                            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-                        }))
-                        .await
-                        .unwrap();
+                if let Err(KeySetCommandError { err, output }) = cmd.output() {
+                    let client_err = match output {
+                        Some(output) => KeyRemoveError::DnstCommandError(
+                            String::from_utf8_lossy(&output.stderr).into(),
+                        ),
+                        None => KeyRemoveError::DnstCommandError(err.clone()),
+                    };
+                    http_tx.send(Err(client_err)).await.unwrap();
+                    return Err(format!("key removal command failed: {err}"));
                 }
+
+                http_tx.send(Ok(())).await.unwrap();
 
                 Ok(())
             }
-            Some(_) => Ok(()), // not for us
+
+            _ => Ok(()), // not for us
         }
     }
 
     /// Create a keyset command with the config file for the given zone
-    fn keyset_cmd(&self, name: impl Display) -> Command {
-        let cfg_path = self.keys_dir.join(format!("{name}.cfg"));
-        let mut cmd = Command::new(self.dnst_binary_path.as_std_path());
-        cmd.arg("keyset").arg("-c").arg(&cfg_path);
-        cmd
+    fn keyset_cmd(&self, name: StoredName) -> KeySetCommand {
+        KeySetCommand::new(
+            name,
+            self.center.clone(),
+            self.keys_dir.clone(),
+            self.dnst_binary_path.clone(),
+        )
     }
 
     async fn tick(&self) {
@@ -433,23 +335,50 @@ impl KeyManager {
                 continue;
             }
 
-            let info = ks_info.get(&apex_name);
-            let Some(info) = info else {
-                let value = get_keyset_info(state_path);
-                let _ = ks_info.insert(apex_name, value);
-                continue;
+            // We can't use HashMap::entry() here as we can't do 'continue'
+            // from inside a closure.
+            let info = match ks_info.get_mut(&apex_name) {
+                Some(info) => info,
+                None => {
+                    match KeySetInfo::try_from(&state_path) {
+                        Ok(new_info) => {
+                            let _ = ks_info.insert(apex_name.clone(), new_info.clone());
+                            // SAFETY: We just added it so it must exist.
+                            ks_info.get_mut(&apex_name).unwrap()
+                        }
+                        Err(err) => {
+                            log::error!(
+                                "[KM]: Failed to load key set state for zone '{apex_name}': {err}"
+                            );
+                            continue;
+                        }
+                    }
+                }
             };
 
-            let keyset_state_modified = file_modified(&state_path).unwrap();
+            let keyset_state_modified = match file_modified(&state_path) {
+                Ok(modified) => modified,
+                Err(err) => {
+                    log::error!("[KM]: {err}");
+                    continue;
+                }
+            };
             if keyset_state_modified != info.keyset_state_modified {
                 // Keyset state file is modified. Update our data and
                 // signal the signer to re-sign the zone.
-                let new_info = get_keyset_info(&state_path);
+                let new_info = match KeySetInfo::try_from(&state_path) {
+                    Ok(info) => info,
+                    Err(err) => {
+                        log::error!("[KM]: {err}");
+                        continue;
+                    }
+                };
                 let _ = ks_info.insert(apex_name, new_info);
                 self.center
                     .update_tx
                     .send(Update::ResignZoneEvent {
                         zone_name: zone.apex_name().clone(),
+                        trigger: SigningTrigger::ExternallyModifiedKeySetState,
                     })
                     .unwrap();
                 continue;
@@ -460,39 +389,36 @@ impl KeyManager {
             };
 
             if *cron_next < UnixTime::now() {
-                println!("Invoking keyset cron for zone {apex_name}");
-                let Ok(res) = self.keyset_cmd(&apex_name).arg("cron").output() else {
-                    error!(
-                        "Failed to invoke keyset binary at '{}",
-                        self.dnst_binary_path
-                    );
-
-                    // Clear cron_next.
-                    let info = KeySetInfo {
-                        cron_next: None,
-                        keyset_state_modified: info.keyset_state_modified.clone(),
-                        retries: 0,
-                    };
-                    let _ = ks_info.insert(apex_name, info);
+                let Ok(res) = self
+                    .keyset_cmd(zone.apex_name().clone())
+                    .arg("cron")
+                    .output()
+                else {
+                    info.clear_cron_next();
                     continue;
                 };
 
                 if res.status.success() {
-                    println!("CRON OUT: {}", String::from_utf8_lossy(&res.stdout));
-
                     // We expect cron to change the state file. If
                     // that is the case, get a new KeySetInfo and notify
                     // the signer.
-                    let new_info = get_keyset_info(&state_path);
+                    let new_info = match KeySetInfo::try_from(&state_path) {
+                        Ok(info) => info,
+                        Err(err) => {
+                            log::error!("[KM]: {err}");
+                            continue;
+                        }
+                    };
                     if new_info.keyset_state_modified != info.keyset_state_modified {
                         // Something happened. Update ks_info and signal the
                         // signer.
-                        let new_info = get_keyset_info(&state_path);
+                        // let new_info = get_keyset_info(&state_path);
                         let _ = ks_info.insert(apex_name, new_info);
                         self.center
                             .update_tx
                             .send(Update::ResignZoneEvent {
                                 zone_name: zone.apex_name().clone(),
+                                trigger: SigningTrigger::KeySetModifiedAfterCron,
                             })
                             .unwrap();
                         continue;
@@ -501,37 +427,15 @@ impl KeyManager {
                     // Nothing happened. Assume that the timing could be off.
                     // Try again in a minute. After a few tries log an error
                     // and give up.
-                    let cron_next = cron_next.clone() + Duration::from_secs(60);
-                    let new_info = KeySetInfo {
-                        cron_next: Some(cron_next),
-                        keyset_state_modified: info.keyset_state_modified.clone(),
-                        retries: info.retries + 1,
-                    };
-                    if new_info.retries >= CRON_MAX_RETRIES {
+                    info.retry_after(Duration::from_secs(60));
+                    if info.retries >= CRON_MAX_RETRIES {
                         error!(
                             "The command 'dnst keyset cron' failed to update state file {state_path}", 
                         );
-
-                        // Clear cron_next.
-                        let info = KeySetInfo {
-                            cron_next: None,
-                            keyset_state_modified: info.keyset_state_modified.clone(),
-                            retries: 0,
-                        };
-                        let _ = ks_info.insert(apex_name, info);
-                        continue;
+                        info.clear_cron_next();
                     }
-                    let _ = ks_info.insert(apex_name, new_info);
-                    continue;
                 } else {
-                    println!("CRON ERR: {}", String::from_utf8_lossy(&res.stderr));
-                    // Clear cron_next.
-                    let info = KeySetInfo {
-                        cron_next: None,
-                        keyset_state_modified: info.keyset_state_modified.clone(),
-                        retries: 0,
-                    };
-                    let _ = ks_info.insert(apex_name, info);
+                    info.clear_cron_next();
                 }
             }
         }
@@ -547,55 +451,85 @@ pub struct KeySetInfo {
     retries: u32,
 }
 
+impl KeySetInfo {
+    fn clear_cron_next(&mut self) {
+        self.cron_next = None;
+        self.retries = 0;
+    }
+
+    fn retry_after(&mut self, after: Duration) {
+        if let Some(cron_next) = self.cron_next.take() {
+            self.cron_next = Some(cron_next + after);
+        }
+        self.retries += 1;
+    }
+}
+
+impl TryFrom<&Utf8PathBuf> for KeySetInfo {
+    type Error = String;
+
+    fn try_from(state_path: &Utf8PathBuf) -> Result<Self, Self::Error> {
+        // Get the modified time of the state file before we read
+        // state file itself. This is safe if there is a concurrent
+        // update.
+        let keyset_state_modified = file_modified(&state_path)?;
+
+        /// Persistent state for the keyset command.
+        /// Copied frmo the keyset branch of dnst.
+        #[allow(dead_code)]
+        #[derive(Deserialize)]
+        struct KeySetState {
+            /// Domain KeySet state.
+            keyset: KeySet,
+
+            dnskey_rrset: Vec<String>,
+            ds_rrset: Vec<String>,
+            cds_rrset: Vec<String>,
+            ns_rrset: Vec<String>,
+            cron_next: Option<UnixTime>,
+        }
+
+        let state = std::fs::read_to_string(state_path)
+            .map_err(|err| format!("Failed to read file '{state_path}': {err}"))?;
+        let state: KeySetState = serde_json::from_str(&state).map_err(|err| {
+            format!("Failed to parse keyset JSON from file '{state_path}': {err}")
+        })?;
+
+        Ok(KeySetInfo {
+            keyset_state_modified,
+            cron_next: state.cron_next,
+            retries: 0,
+        })
+    }
+}
+
 // Maximum number of times to try the cron command when the state file does
 // not change.
 const CRON_MAX_RETRIES: u32 = 5;
 
 fn file_modified(filename: impl AsRef<Path>) -> Result<UnixTime, String> {
-    let md = metadata(filename).unwrap();
-    let modified = md.modified().unwrap();
+    let md = metadata(&filename).map_err(|err| {
+        format!(
+            "Failed to query metadata for file '{}': {err}",
+            filename.as_ref().display()
+        )
+    })?;
+    let modified = md.modified().map_err(|err| {
+        format!(
+            "Failed to query modified timestamp for file '{}': {err}",
+            filename.as_ref().display()
+        )
+    })?;
     modified
         .try_into()
-        .map_err(|e| format!("unable to convert from SystemTime: {e}"))
-}
-
-fn get_keyset_info(state_path: impl AsRef<Path>) -> KeySetInfo {
-    // Get the modified time of the state file before we read
-    // state file itself. This is safe if there is a concurrent
-    // update.
-    let keyset_state_modified = file_modified(&state_path).unwrap();
-
-    /// Persistent state for the keyset command.
-    /// Copied frmo the keyset branch of dnst.
-    #[allow(dead_code)]
-    #[derive(Deserialize)]
-    struct KeySetState {
-        /// Domain KeySet state.
-        keyset: KeySet,
-
-        dnskey_rrset: Vec<String>,
-        ds_rrset: Vec<String>,
-        cds_rrset: Vec<String>,
-        ns_rrset: Vec<String>,
-        cron_next: Option<UnixTime>,
-    }
-
-    let state = std::fs::read_to_string(state_path).unwrap();
-    let state: KeySetState = serde_json::from_str(&state).unwrap();
-
-    KeySetInfo {
-        keyset_state_modified,
-        cron_next: state.cron_next,
-        retries: 0,
-    }
+        .map_err(|err| format!("Failed to query modified timestamp for file '{}': unable to convert from SystemTime: {err}", filename.as_ref().display()))
 }
 
 fn policy_to_commands(center: &Center, zone_name: &Name<Bytes>) -> Vec<Vec<String>> {
     // Ensure that the mutexes are locked only in this block;
     let policy = {
-        let state = center.state.lock().unwrap();
-        let zone = state.zones.get(zone_name).unwrap();
-        let zone_state = zone.0.state.lock().unwrap();
+        let zone = get_zone(center, zone_name).unwrap();
+        let zone_state = zone.state.lock().unwrap();
         zone_state.policy.clone()
     }
     .unwrap();
@@ -939,7 +873,7 @@ impl KmipClientCredentialsFile {
     }
 
     /// Remove any existing configuration for the specified KMIP server.
-    ///
+
     /// Returns any previous configuration if found.
     pub fn remove(&mut self, server_id: &str) -> Option<KmipClientCredentials> {
         self.credentials.0.remove(server_id)
@@ -947,5 +881,112 @@ impl KmipClientCredentialsFile {
 
     pub fn is_empty(&self) -> bool {
         self.credentials.0.is_empty()
+    }
+}
+
+pub struct KeySetCommand {
+    cmd: Command,
+    name: StoredName,
+    center: Arc<Center>,
+}
+
+pub struct KeySetCommandError {
+    err: String,
+    output: Option<Output>,
+}
+
+impl From<KeySetCommandError> for String {
+    fn from(err: KeySetCommandError) -> Self {
+        err.err
+    }
+}
+
+impl KeySetCommand {
+    pub fn new(
+        name: StoredName,
+        center: Arc<Center>,
+        keys_dir: Box<Utf8Path>,
+        dnst_binary_path: Box<Utf8Path>,
+    ) -> Self {
+        let cfg_path = keys_dir.join(format!("{name}.cfg"));
+        let mut cmd = Command::new(dnst_binary_path.as_std_path());
+        cmd.arg("keyset").arg("-c").arg(&cfg_path);
+        Self { cmd, name, center }
+    }
+
+    pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut KeySetCommand {
+        self.cmd.arg(arg);
+        self
+    }
+
+    pub fn output(&mut self) -> Result<Output, KeySetCommandError> {
+        self.exec()
+            .inspect(|_| {
+                record_zone_event(
+                    &self.center,
+                    &self.name,
+                    HistoricalEvent::KeySetCommand(self.cmd_to_string()),
+                    None,
+                );
+            })
+            .inspect_err(|KeySetCommandError { err, output: _ }| {
+                record_zone_event(
+                    &self.center,
+                    &self.name,
+                    HistoricalEvent::KeySetError(err.clone()),
+                    None,
+                );
+                halt_zone(&self.center, &self.name, true, err);
+            })
+    }
+
+    fn exec(&mut self) -> Result<Output, KeySetCommandError> {
+        log::info!("Executing keyset command {}", self.cmd_to_string());
+        let output = self.cmd.output().map_err(|msg| {
+            let mut err = format!(
+                "Keyset command '{}' for zone '{}' could not be executed: {msg}",
+                self.cmd_to_string(),
+                self.name,
+            );
+            if matches!(msg.kind(), ErrorKind::NotFound) {
+                err.push_str(&format!(
+                    " [path: {}]",
+                    self.cmd.get_program().to_string_lossy()
+                ));
+            }
+            KeySetCommandError { err, output: None }
+        })?;
+
+        if !output.status.success() {
+            let err = format!(
+                "Keyset command '{}' for zone '{}' returned non-zero exit code: {} [stdout={}, stderr={}]",
+                self.cmd_to_string(),
+                self.name,
+                output.status,
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr),
+            );
+            return Err(KeySetCommandError {
+                err,
+                output: Some(output),
+            });
+        }
+
+        log::debug!(
+            "Keyset command {} for zone '{}' stdout: {}",
+            self.cmd_to_string(),
+            self.name,
+            String::from_utf8_lossy(&output.stdout)
+        );
+
+        Ok(output)
+    }
+
+    fn cmd_to_string(&self) -> String {
+        self.cmd
+            .get_args()
+            .map(|v| v.to_string_lossy())
+            .collect::<Vec<_>>()
+            .join(" ")
     }
 }

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -211,6 +211,7 @@ pub enum HistoricalEvent {
 
 impl HistoricalEvent {
     pub fn is_of_type(&self, typ: HistoricalEventType) -> bool {
+        #[allow(clippy::match_like_matches_macro)]
         match (self, typ) {
             (HistoricalEvent::Added, HistoricalEventType::Added) => true,
             (HistoricalEvent::Removed, HistoricalEventType::Removed) => true,

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -87,7 +87,6 @@ pub struct ZoneState {
     /// the moment.
     // TODO: make the pipeline stop accepting new data when hard halted.
     pub pipeline_mode: PipelineMode,
-
     // TODO:
     // - A log?
     // - Initialization?
@@ -113,8 +112,8 @@ impl ZoneState {
 
     pub fn halted(&self, hard: bool) -> Option<String> {
         match &self.pipeline_mode {
-            PipelineMode::SoftHalt(r) if !hard=> Some(r.clone()),
-            PipelineMode::HardHalt(r) if hard=> Some(r.clone()),
+            PipelineMode::SoftHalt(r) if !hard => Some(r.clone()),
+            PipelineMode::HardHalt(r) if hard => Some(r.clone()),
             _ => None,
         }
     }

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -8,7 +8,7 @@ use std::{
     io, mem,
     net::SocketAddr,
     sync::{Arc, Mutex},
-    time::Duration,
+    time::{Duration, SystemTime},
 };
 
 use bytes::Bytes;
@@ -18,9 +18,10 @@ use domain::{
     zonetree::{self, ZoneBuilder},
 };
 use domain::{rdata::dnssec::Timestamp, tsig};
+use serde::{Deserialize, Serialize};
 
 use crate::{
-    api,
+    api::{self, ZoneReviewStatus},
     center::{Center, Change},
     config::Config,
     payload::Update,
@@ -79,9 +80,14 @@ pub struct ZoneState {
     /// approved.
     pub next_min_expiration: Option<Timestamp>,
 
-    /// The last serial number we signed for this zone
-    pub last_signed_serial: Option<Serial>,
-    //
+    /// History of interesting events that occurred for this zone.
+    pub history: Vec<HistoryItem>,
+
+    /// Whether or not the pipeline for this zone should be allowed to flow at
+    /// the moment.
+    // TODO: make the pipeline stop accepting new data when hard halted.
+    pub pipeline_mode: PipelineMode,
+
     // TODO:
     // - A log?
     // - Initialization?
@@ -90,6 +96,152 @@ pub struct ZoneState {
     // - Key manager state
     // - Signer state
     // - Server state
+}
+
+impl ZoneState {
+    pub fn hard_halt(&mut self, reason: String) {
+        self.pipeline_mode = PipelineMode::HardHalt(reason);
+    }
+
+    pub fn soft_halt(&mut self, reason: String) {
+        self.pipeline_mode = PipelineMode::SoftHalt(reason);
+    }
+
+    pub fn resume(&mut self) {
+        self.pipeline_mode = PipelineMode::Running;
+    }
+
+    pub fn halted(&self, hard: bool) -> Option<String> {
+        match &self.pipeline_mode {
+            PipelineMode::SoftHalt(r) if !hard=> Some(r.clone()),
+            PipelineMode::HardHalt(r) if hard=> Some(r.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn record_event(&mut self, event: HistoricalEvent, serial: Option<Serial>) {
+        self.history.push(HistoryItem::new(event, serial));
+    }
+
+    pub fn find_last_event(
+        &self,
+        typ: HistoricalEventType,
+        serial: Option<Serial>,
+    ) -> Option<&HistoryItem> {
+        self.history
+            .iter()
+            .rev()
+            .find(|item| item.event.is_of_type(typ) && (serial.is_none() || item.serial == serial))
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub enum PipelineMode {
+    /// Newly received zone data will flow through the pipeline.
+    #[default]
+    Running,
+
+    /// The current zone data could not be fully processed through the
+    /// pipeline. When new zone data is received it will flow through the
+    /// pipeline as normal.
+    SoftHalt(String),
+
+    /// The current zone data could not be fully processed through the
+    /// pipeline. The pipeline for this zone will remain halted until manually
+    /// restarted.
+    HardHalt(String),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct HistoryItem {
+    pub when: SystemTime,
+    pub serial: Option<Serial>,
+    pub event: HistoricalEvent,
+}
+
+impl HistoryItem {
+    pub fn new(event: HistoricalEvent, serial: Option<Serial>) -> Self {
+        Self {
+            when: SystemTime::now(),
+            serial,
+            event,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum HistoricalEventType {
+    Added,
+    Removed,
+    PolicyChanged,
+    SourceChanged,
+    NewVersionReceived,
+    SigningSucceeded,
+    SigningFailed,
+    UnsignedZoneReview,
+    SignedZoneReview,
+    KeySetCommand,
+    KeySetError,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub enum HistoricalEvent {
+    Added,
+    Removed,
+    PolicyChanged,
+    SourceChanged,
+    NewVersionReceived,
+    SigningSucceeded {
+        trigger: SigningTrigger,
+    },
+    SigningFailed {
+        trigger: SigningTrigger,
+        reason: String,
+    },
+    UnsignedZoneReview {
+        status: ZoneReviewStatus,
+        when: SystemTime,
+    },
+    SignedZoneReview {
+        status: ZoneReviewStatus,
+        when: SystemTime,
+    },
+    KeySetCommand(String),
+    KeySetError(String),
+}
+
+impl HistoricalEvent {
+    pub fn is_of_type(&self, typ: HistoricalEventType) -> bool {
+        match (self, typ) {
+            (HistoricalEvent::Added, HistoricalEventType::Added) => true,
+            (HistoricalEvent::Removed, HistoricalEventType::Removed) => true,
+            (HistoricalEvent::PolicyChanged, HistoricalEventType::PolicyChanged) => true,
+            (HistoricalEvent::SourceChanged, HistoricalEventType::SourceChanged) => true,
+            (HistoricalEvent::NewVersionReceived, HistoricalEventType::NewVersionReceived) => true,
+            (HistoricalEvent::SigningSucceeded { .. }, HistoricalEventType::SigningSucceeded) => {
+                true
+            }
+            (HistoricalEvent::SigningFailed { .. }, HistoricalEventType::SigningFailed) => true,
+            (
+                HistoricalEvent::UnsignedZoneReview { .. },
+                HistoricalEventType::UnsignedZoneReview,
+            ) => true,
+            (HistoricalEvent::SignedZoneReview { .. }, HistoricalEventType::SignedZoneReview) => {
+                true
+            }
+            (HistoricalEvent::KeySetCommand(_), HistoricalEventType::KeySetCommand) => true,
+            (HistoricalEvent::KeySetError(_), HistoricalEventType::KeySetError) => true,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub enum SigningTrigger {
+    ExternallyModifiedKeySetState,
+    SignatureExpiration,
+    ZoneChangesApproved,
+    KeySetModifiedAfterCron,
 }
 
 /// How to load the contents of a zone.
@@ -324,7 +476,7 @@ pub fn change_source(
         api::ZoneSource::Zonefile { path } => ZoneLoadSource::Zonefile { path },
 
         // TODO: Look up the TSIG key.
-        api::ZoneSource::Server { addr, tsig_key: _ } => ZoneLoadSource::Server {
+        api::ZoneSource::Server { addr, .. } => ZoneLoadSource::Server {
             addr,
             tsig_key: None,
         },

--- a/src/zone/state/mod.rs
+++ b/src/zone/state/mod.rs
@@ -87,13 +87,13 @@ impl Spec {
                 source,
                 min_expiration,
                 next_min_expiration,
-                last_signed_serial,
+                history,
             }) => {
                 state.policy = policy.map(|policy| sync_policy(policy.parse(), zone, policies));
                 state.source = source.parse();
                 state.min_expiration = min_expiration;
                 state.next_min_expiration = next_min_expiration;
-                state.last_signed_serial = last_signed_serial;
+                state.history = history;
             }
         }
     }

--- a/src/zone/state/v1.rs
+++ b/src/zone/state/v1.rs
@@ -5,13 +5,11 @@ use std::{net::SocketAddr, time::Duration};
 use bytes::Bytes;
 use camino::Utf8Path;
 use domain::base::Ttl;
-use domain::{
-    base::{Name, Serial},
-    rdata::dnssec::Timestamp,
-};
+use domain::{base::Name, rdata::dnssec::Timestamp};
 use serde::{Deserialize, Serialize};
 
 use crate::policy::{AutoConfig, DsAlgorithm, KeyParameters};
+use crate::zone::HistoryItem;
 use crate::{
     policy::{
         KeyManagerPolicy, LoaderPolicy, PolicyVersion, ReviewPolicy, ServerPolicy,
@@ -44,8 +42,8 @@ pub struct Spec {
     /// approved.
     pub next_min_expiration: Option<Timestamp>,
 
-    /// The last serial number we signed for this zone
-    pub last_signed_serial: Option<Serial>,
+    /// History of interesting events that occurred for this zone.
+    pub history: Vec<HistoryItem>,
 }
 
 //--- Conversion
@@ -58,7 +56,7 @@ impl Spec {
             source: ZoneLoadSourceSpec::build(&zone.source),
             min_expiration: zone.min_expiration,
             next_min_expiration: zone.next_min_expiration,
-            last_signed_serial: zone.last_signed_serial,
+            history: zone.history.clone(),
         }
     }
 }

--- a/src/zonemaintenance/maintainer.rs
+++ b/src/zonemaintenance/maintainer.rs
@@ -1536,8 +1536,8 @@ where
     ) -> Result<(Soa<Name<Bytes>>, usize), ZoneMaintainerError> {
         // Abort if the zone is in a hard halt state.
         {
-            let zone = get_zone(&center, zone.apex_name())
-                .ok_or_else(|| ZoneMaintainerError::UnknownZone)?;
+            let zone =
+                get_zone(&center, zone.apex_name()).ok_or(ZoneMaintainerError::UnknownZone)?;
             let zone_state = zone.state.lock().unwrap();
             if let Some(err) = zone_state.halted(true) {
                 return Err(ZoneMaintainerError::ZoneHardHalted(err));


### PR DESCRIPTION
See: https://github.com/NLnetLabs/cascade/issues/69

Outputs something like the following for a local zonefile.

```
# cascade zone status example.com
Zone: example.com
Status: At the published pipeline stage 
Policy: dummy
Latest input:
  Serial: 1
  Loaded from the zonefile '/etc/cascade/medium_example.com'
  Received 29252 bytes at 2025-09-23T08:09:02+00:00 in 0s
  Configured for automatic review by '/etc/cascade/approve_or_deny.sh'
  Waiting for zone reload command to receive changes
  Unsigned zone available on 127.0.0.1:9051
Latest output:
  Serial: 2025092301
  Signed at 2025-09-23T08:09:10+00:00
  Signed 998 records in 1s
  Signed zone available on 127.0.0.1:9052
  Not configured for review
  Published zone available on 127.0.0.1:9053
  Re-signing scheduled at ? (in ?)
DNSSEC keys:
  KSK tagged 56940:
    Reference: file:///var/lib/cascade/keys/Kexample.com.+013+56940.key
    Actively used for signing
  ZSK tagged 61464:
    Reference: file:///var/lib/cascade/keys/Kexample.com.+013+61464.key
    Actively used for signing
  Details:
    AlgorithmRoll: Propagation1
    Check that the following RRset has propagated to all name servers:
    example.com. 3600 IN DNSKEY 257 3 13 aHA8V1KdCN2qCLLZirvBEe4AxjHlm0nUpbx5lIQb72FEhXQYTjpl+xxyVsM4t0oIEMyAnE73ABNGKNugOIgdbw==
    example.com. 3600 IN DNSKEY 256 3 13 oXIb2C1bLk7sUzkAz0RV7tZPV0z07APUne0F80G7TCOF32fxA2U9ASQsDrm5yuYqn49s1eZ/RST69S7SQXyMFA==
    example.com. 3600 IN RRSIG DNSKEY 13 2 3600 1759824542 1758528542 56940 example.com. 3W1XDzI+pwZvgdISZnLy8LrGm4brzDEcVv2ZB0fzw6iN9VNmkJ+F4CqhNM1vfrucnVnHf2Jwvo7Gsux3xq6pRQ==
    
    Check that all authoritative records in the zone have been signed with the following Key(s) and that all nameservers of the zone serve that version or later:
    example.com. 3600 IN DNSKEY 256 3 13 oXIb2C1bLk7sUzkAz0RV7tZPV0z07APUne0F80G7TCOF32fxA2U9ASQsDrm5yuYqn49s1eZ/RST69S7SQXyMFA== ; key tag 61464
    
    For the next step run:
    	cascade keyset example.com algorithm propagation1-complete <ttl>
    	automation is enabled for this step.
    
    Automatic key roll state:
    Roll AlgorithmRoll, state Propagation1:
    	Wait until the new DNSKEY RRset has propagated to all nameservers.
    	Try again after 2025-09-23T08:19:08Z
    
    key file:///var/lib/cascade/keys/Kexample.com.+013+56940.key expires at 2026-09-23T08:09:02Z
    key file:///var/lib/cascade/keys/Kexample.com.+013+61464.key expires at 2025-10-23T08:09:02Z
```

Here is an XFR sourced zone example:
```
# cascade zone status example.com
Zone: example.com
Status: At the published pipeline stage 
Policy: dummy
Latest input:
  Serial: 1
  Received from 127.0.0.1:8055
  Received 27178 bytes at 2025-09-23T08:17:08+00:00 in 0s
  Configured for automatic review by '/etc/cascade/approve_or_deny.sh'
  XFR from 127.0.0.1:8055 refresh pending
  Unsigned zone available on 127.0.0.1:9051
Latest output:
  Serial: 2025092300
  Signed at 2025-09-23T08:17:10+00:00
  Signed 997 records in 1s
  Signed zone available on 127.0.0.1:9052
  Not configured for review
  Published zone available on 127.0.0.1:9053
  Re-signing scheduled at ? (in ?)
DNSSEC keys:
  KSK tagged 59630:
    Reference: file:///var/lib/cascade/keys/Kexample.com.+013+59630.key
    Actively used for signing
  ZSK tagged 29990:
    Reference: file:///var/lib/cascade/keys/Kexample.com.+013+29990.key
    Actively used for signing
  Details:
    AlgorithmRoll: Propagation1
    Check that the following RRset has propagated to all name servers:
    example.com. 3600 IN DNSKEY 256 3 13 VqHY4voCmIh55oVj3bHypx/TvreTpyjsjhGSOo/afUY3r0iJc5nenbM+GGMpZuRIknd/kaEI4DDIxZwnnljUkA==
    example.com. 3600 IN DNSKEY 257 3 13 Y1iGYorlixG4mLQ2zAd6VJ9N++6qlTuKEXeF6/1jmEv8wYmpa1SqLQ3y9+Np8mQxGcdKBQMyb/3u8Uzu2bwnFA==
    example.com. 3600 IN RRSIG DNSKEY 13 2 3600 1759825028 1758529028 59630 example.com. Nm1a3bBig8mpmpRWM7WyeOdy+d3XjZvJxXerhhcndAOy5i9sZYCUYZKW1aLAT3o3y6z5iKUzeynqpC3O/nPZPw==
    
    Check that all authoritative records in the zone have been signed with the following Key(s) and that all nameservers of the zone serve that version or later:
    example.com. 3600 IN DNSKEY 256 3 13 VqHY4voCmIh55oVj3bHypx/TvreTpyjsjhGSOo/afUY3r0iJc5nenbM+GGMpZuRIknd/kaEI4DDIxZwnnljUkA== ; key tag 29990
    
    For the next step run:
    	cascade keyset example.com algorithm propagation1-complete <ttl>
    	automation is enabled for this step.
    
    key file:///var/lib/cascade/keys/Kexample.com.+013+59630.key expires at 2026-09-23T08:17:08Z
    key file:///var/lib/cascade/keys/Kexample.com.+013+29990.key expires at 2025-10-23T08:17:08Z
```

Note that in these examples the output of `dnst keyset -v` was automatically modified to replace occurences of `dnst keyset -c /some/path ...` with the equivalent `cascade keyset <zone> ...` command, and deliberately omits the "Next time to run the 'cron' subcommand" output of `dnst keyset status` as users of Cascade don't need to know about that so it gets stripped.

Observations:
- Re-signing has just been implemented at https://github.com/NLnetLabs/cascade/pull/74.
- If approval hook execution fails that isn't currently (but should be) reflected in the status line, unclear why not.
- Lacks DS and DNSKEY RRs.
- The implementation doesn't attempt to ensure that the data included is all from the same atomic snapshot point in time so the data could in theory appear confusing/inconsistent.
- Lacks whether or not the XFR was IXFR or AXFR.
- Lacks _when_ the pending XFR refresh (caused by SOA REFRESH) will happen.
- Lacks support for showing failed operations, e.g. review denied, internal signing error.
- When using unicode symbols such as ✓ lacks support for non-unicode terminals.