### PR TITLE
Add template config/policy file generation command

### DIFF
--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod hsm;
 pub mod keyset;
 pub mod policy;
 pub mod status;
+pub mod template;
 pub mod zone;
 
 use super::client::CascadeApiClient;
@@ -45,6 +46,9 @@ pub enum Command {
     Hsm(self::hsm::Hsm),
     // /// Show the manual pages
     // Help(self::help::Help),
+    /// Generate example config or policy files
+    #[command(name = "template")]
+    Template(self::template::Template),
 }
 
 impl Command {
@@ -55,6 +59,7 @@ impl Command {
             Self::Policy(policy) => policy.execute(client).await,
             Self::KeySet(keyset) => keyset.execute(client).await,
             Self::Hsm(hsm) => hsm.execute(client).await,
+            Self::Template(template) => template.execute(client).await,
         }
     }
 }

--- a/src/cli/commands/template.rs
+++ b/src/cli/commands/template.rs
@@ -1,0 +1,29 @@
+use crate::cli::client::CascadeApiClient;
+
+#[derive(Clone, Debug, clap::Args)]
+pub struct Template {
+    #[command(subcommand)]
+    command: FileSelection,
+}
+
+#[derive(Clone, Debug, clap::Subcommand)]
+pub enum FileSelection {
+    /// Generate a config template
+    #[command(name = "config")]
+    Config,
+    /// Generate a policy template
+    #[command(name = "policy")]
+    Policy,
+}
+
+impl Template {
+    pub async fn execute(self, _client: CascadeApiClient) -> Result<(), String> {
+        match self.command {
+            FileSelection::Config => println!("{}", include_str!("../../../etc/config.toml")),
+            // TODO: Set file path once policy template exists
+            // FileSelection::Policy => println!("{}", include_str!("../../../etc/policies/default.toml")),
+            FileSelection::Policy => todo!(),
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
How about this for a start?

Then if we change the policy creation experience we might reconsider having the policy template here, but as long as the user has to create those files themself, this would probably be a good way of providing the templates.

- [ ] Once there is an example policy file, this can be included as well.