### PR TITLE
Don't hide the cause of HTTP response Serde decoding errors.

### DIFF
--- a/src/cli/client.rs
+++ b/src/cli/client.rs
@@ -41,3 +41,16 @@ impl CascadeApiClient {
         self.request(Method::POST, s)
     }
 }
+
+pub fn format_http_error(err: reqwest::Error) -> String {
+    if err.is_decode() {
+        // Use the debug representation of decoding errors otherwise the cause
+        // of the decoding failure, e.g. the underlying Serde error, gets lost
+        // and makes determining why the response couldn't be decoded a game
+        // of divide and conquer removing response fields one by one until the
+        // offending field is determined.
+        format!("HTTP request failed: {err:?}")
+    } else {
+        format!("HTTP request failed: {err}")
+    }
+}

--- a/src/cli/commands/hsm.rs
+++ b/src/cli/commands/hsm.rs
@@ -23,7 +23,7 @@ use crate::{
         HsmServerAdd, HsmServerAddError, HsmServerAddResult, HsmServerGetResult,
         HsmServerListResult, PolicyInfo, PolicyInfoError, PolicyListResult,
     },
-    cli::client::CascadeApiClient,
+    cli::client::{format_http_error, CascadeApiClient},
     units::http_server::KmipServerState,
 };
 
@@ -93,7 +93,7 @@ impl Hsm {
                     .send()
                     .and_then(|r| r.json())
                     .await
-                    .map_err(|e| format!("HTTP request failed: {e}"))?;
+                    .map_err(format_http_error)?;
 
                 match res {
                     Ok(HsmServerAddResult { vendor_id }) => {
@@ -109,7 +109,7 @@ impl Hsm {
                     .send()
                     .and_then(|r| r.json())
                     .await
-                    .map_err(|e| format!("HTTP request failed: {e}"))?;
+                    .map_err(format_http_error)?;
 
                 for server in res.servers {
                     println!("{server}");
@@ -122,7 +122,7 @@ impl Hsm {
                     .send()
                     .and_then(|r| r.json())
                     .await
-                    .map_err(|e| format!("HTTP request failed: {e}"))?;
+                    .map_err(format_http_error)?;
 
                 match res {
                     Ok(res) => {
@@ -156,14 +156,14 @@ async fn get_policy_names_using_hsm(
         .send()
         .and_then(|r| r.json())
         .await
-        .map_err(|e| format!("HTTP request failed: {e}"))?;
+        .map_err(format_http_error)?;
     for policy_name in res.policies {
         let res: Result<PolicyInfo, PolicyInfoError> = client
             .get(&format!("policy/{policy_name}"))
             .send()
             .and_then(|r| r.json())
             .await
-            .map_err(|e| format!("HTTP request failed: {e}"))?;
+            .map_err(format_http_error)?;
 
         let p = match res {
             Ok(p) => p,

--- a/src/cli/commands/keyset.rs
+++ b/src/cli/commands/keyset.rs
@@ -3,7 +3,7 @@ use domain::base::Name;
 use futures::TryFutureExt;
 
 use crate::api::keyset::*;
-use crate::cli::client::CascadeApiClient;
+use crate::cli::client::{format_http_error, CascadeApiClient};
 
 #[derive(Clone, Debug, clap::Args)]
 pub struct KeySet {
@@ -93,7 +93,7 @@ async fn roll_command(
         .send()
         .and_then(|r| r.json())
         .await
-        .map_err(|e| format!("HTTP request failed: {e}"))?;
+        .map_err(format_http_error)?;
     match res {
         Ok(_) => {
             println!("Manual key roll for {} successful", zone);
@@ -129,7 +129,7 @@ async fn remove_key_command(
         .send()
         .and_then(|r| r.json())
         .await
-        .map_err(|e| format!("HTTP request failed: {e}"))?;
+        .map_err(format_http_error)?;
     match res {
         Ok(_) => {
             println!("Removed key {} from zone {}", key, zone);
@@ -156,7 +156,7 @@ async fn remove_key_command(
 //         .and_then(|r| r.json())
 //         .await
 //         .map_err(|e| {
-//             error!("HTTP request failed: {e}");
+//             error!("HTTP request failed: {e:?}");
 //         })?;
 
 //     for policy in res.policies {
@@ -170,7 +170,7 @@ async fn remove_key_command(
 //         .and_then(|r| r.json())
 //         .await
 //         .map_err(|e| {
-//             error!("HTTP request failed: {e}");
+//             error!("HTTP request failed: {e:?}");
 //         })?;
 
 //     let p = match res {
@@ -190,7 +190,7 @@ async fn remove_key_command(
 //         .and_then(|r| r.json())
 //         .await
 //         .map_err(|e| {
-//             error!("HTTP request failed: {e}");
+//             error!("HTTP request failed: {e:?}");
 //         })?;
 
 //     let res = match res {

--- a/src/cli/commands/policy.rs
+++ b/src/cli/commands/policy.rs
@@ -5,7 +5,7 @@ use crate::{
         PolicyChange, PolicyChanges, PolicyInfo, PolicyInfoError, PolicyListResult,
         PolicyReloadError, ReviewPolicyInfo, SignerDenialPolicyInfo, SignerSerialPolicyInfo,
     },
-    cli::client::CascadeApiClient,
+    cli::client::{format_http_error, CascadeApiClient},
 };
 
 #[derive(Clone, Debug, clap::Args)]
@@ -53,7 +53,7 @@ impl Policy {
                     .send()
                     .and_then(|r| r.json())
                     .await
-                    .map_err(|e| format!("HTTP request failed: {e}"))?;
+                    .map_err(format_http_error)?;
 
                 for policy in res.policies {
                     println!("{policy}");
@@ -65,7 +65,7 @@ impl Policy {
                     .send()
                     .and_then(|r| r.json())
                     .await
-                    .map_err(|e| format!("HTTP request failed: {e}"))?;
+                    .map_err(format_http_error)?;
 
                 let p = match res {
                     Ok(p) => p,
@@ -82,7 +82,7 @@ impl Policy {
                     .send()
                     .and_then(|r| r.json())
                     .await
-                    .map_err(|e| format!("HTTP request failed: {e}"))?;
+                    .map_err(format_http_error)?;
 
                 let res = match res {
                     Ok(res) => res,

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -1,7 +1,7 @@
 use futures::TryFutureExt;
 
 use crate::api::ServerStatusResult;
-use crate::cli::client::CascadeApiClient;
+use crate::cli::client::{format_http_error, CascadeApiClient};
 
 #[derive(Clone, Debug, clap::Args)]
 pub struct Status {
@@ -31,7 +31,7 @@ impl Status {
                     .send()
                     .and_then(|r| r.json())
                     .await
-                    .map_err(|e| format!("HTTP request failed: {e}"))?;
+                    .map_err(format_http_error)?;
 
                 println!("Server status: {:?}", response)
             }

--- a/src/cli/commands/zone.rs
+++ b/src/cli/commands/zone.rs
@@ -6,7 +6,7 @@ use crate::api::{
     ZoneAdd, ZoneAddError, ZoneAddResult, ZoneReloadError, ZoneReloadResult, ZoneSource,
     ZoneStatus, ZoneStatusError, ZonesListResult,
 };
-use crate::cli::client::CascadeApiClient;
+use crate::cli::client::{format_http_error, CascadeApiClient};
 
 #[derive(Clone, Debug, clap::Args)]
 pub struct Zone {
@@ -80,7 +80,7 @@ impl Zone {
                     .send()
                     .and_then(|r| r.json())
                     .await
-                    .map_err(|e| format!("HTTP request failed: {e}"))?;
+                    .map_err(format_http_error)?;
 
                 match res {
                     Ok(res) => {
@@ -96,7 +96,7 @@ impl Zone {
                     .send()
                     .and_then(|r| r.json())
                     .await
-                    .map_err(|e| format!("HTTP request failed: {e}"))?;
+                    .map_err(format_http_error)?;
 
                 println!("Removed zone {}", res.name);
                 Ok(())
@@ -107,7 +107,7 @@ impl Zone {
                     .send()
                     .and_then(|r| r.json())
                     .await
-                    .map_err(|e| format!("HTTP request failed: {e}"))?;
+                    .map_err(format_http_error)?;
 
                 for zone in response.zones {
                     Self::print_zone_status(zone);
@@ -121,7 +121,7 @@ impl Zone {
                     .send()
                     .and_then(|r| r.json())
                     .await
-                    .map_err(|e| format!("HTTP request failed: {e}"))?;
+                    .map_err(format_http_error)?;
 
                 match res {
                     Ok(res) => {
@@ -144,7 +144,7 @@ impl Zone {
             .send()
             .and_then(|r| r.json())
             .await
-            .map_err(|e| format!("HTTP request failed: {e}"))?;
+            .map_err(format_http_error)?;
 
         match response {
             Ok(status) => {


### PR DESCRIPTION
Before:
```
Error: HTTP request failed: error decoding response body
```

After:
```
Error: HTTP request failed: reqwest::Error { kind: Decode, source: Error("invalid type: integer `0`, expected struct Duration", line: 1, column: 851) }
```