### PR TITLE
Listen systemd socket on localhost only by default and add IPv6

### DIFF
--- a/pkg/common/cascaded.socket
+++ b/pkg/common/cascaded.socket
@@ -2,8 +2,10 @@
 Description=Cascaded Sockets
 
 [Socket]
-ListenDatagram=0.0.0.0:53
-ListenStream=0.0.0.0:53
+ListenDatagram=127.0.0.1:53
+ListenDatagram=[::1]:53
+ListenStream=127.0.0.1:53
+ListenStream=[::1]:53
 Accept=no
 
 [Install]


### PR DESCRIPTION
This allows users to immediately start Cascade _safely_ (w.r.t. exposing unwanted software to the internet) directly after install, without **having** to configure listening addresses. 

As it stands right now in main, Cascade doesn't even start, if installed through the package manager, because of listen address collision (usually 'systemd-resolved' is listening on 127.0.0.X:53, making the wildcard socket fail). And it felt annoying to start out with a failing service when trying.

This also simplifies the installation/quick start documentation, in that users _can_ immediately start the service, but to use it really they just need to add their IPs; instead of writing: "here are the commands to start cascade, but before you do (because it will fail at this moment), you need to fix this setting here".