### PR TITLE
Fix approval hook env var and rename hook api paths

### DIFF
--- a/approve_or_deny.sh
+++ b/approve_or_deny.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# We expect to receive: <zone name> <zone serial> <approval token>
+# We expect to receive from the environment:
+# - CASCADE_ZONE
+# - CASCADE_SERIAL
+# - CASCADE_TOKEN
+# - CASCADE_SERVER
+# - CASCADE_CONTROL
 set -euo pipefail -x
 
 echo "Hook invoked with $*"
 
-ZONE_NAME="$1"
-ZONE_SERIAL="$2"
-APPROVAL_TOKEN="$3"
-
-wget -qO- "http://127.0.0.1:8950/_unit/rs/approve/${APPROVAL_TOKEN}?zone=${ZONE_NAME}&serial=${ZONE_SERIAL}"
+wget -qO- "http://$CASCADE_CONTROL/approve/${CASCADE_TOKEN}?zone=${CASCADE_ZONE}&serial=${CASCADE_SERIAL}"

--- a/approve_or_deny_signed.sh
+++ b/approve_or_deny_signed.sh
@@ -1,16 +1,23 @@
 #!/usr/bin/env bash
-# We expect to receive: <zone name> <zone serial> <approval token>
+# We expect to receive from the environment:
+# - CASCADE_ZONE
+# - CASCADE_SERIAL
+# - CASCADE_TOKEN
+# - CASCADE_SERVER
+# - CASCADE_UNSIGNED_SERVER
+# - CASCADE_CONTROL
+
 set -euo pipefail -x
 
 echo "Hook invoked with $*"
 
-ZONE_NAME="$1"
-ZONE_SERIAL="$2"
-APPROVAL_TOKEN="$3"
+SERVER_IP=${CASCADE_SERVER%:*}
+SERVER_IP_DIG="${SERVER_IP//[\[\]]/}" # remove brackets from IPv6
+SERVER_PORT=${CASCADE_SERVER##*:} # Using double '##' in case its an IPv6
 
-dig +noall +onesoa +answer @127.0.0.1 -p 8057 "${ZONE_NAME}" AXFR | dnssec-verify -o "${ZONE_NAME}" /dev/stdin /tmp/keys/ || {
-    wget -qO- "http://127.0.0.1:8950/_unit/rs2/reject/${APPROVAL_TOKEN}?zone=${ZONE_NAME}&serial=${ZONE_SERIAL}"
+dig +noall +onesoa +answer "@$SERVER_IP_DIG" -p "$SERVER_PORT" "${CASCADE_ZONE}" AXFR | dnssec-verify -o "${CASCADE_ZONE}" /dev/stdin /tmp/keys/ || {
+    wget -qO- "http://$CASCADE_CONTROL/reject/${CASCADE_TOKEN}?zone=${CASCADE_ZONE}&serial=${CASCADE_SERIAL}"
     exit 0
 }
 
-wget -qO- "http://127.0.0.1:8950/_unit/rs2/approve/${APPROVAL_TOKEN}?zone=${ZONE_NAME}&serial=${ZONE_SERIAL}"
+wget -qO- "http://$CASCADE_CONTROL/approve/${CASCADE_TOKEN}?zone=${CASCADE_ZONE}&serial=${CASCADE_SERIAL}"

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -126,7 +126,7 @@ pub async fn spawn(
         _xfr_out: HashMap::from([(zone_name.clone(), xfr_out)]),
         mode: zone_server::Mode::Prepublish,
         source: zone_server::Source::UnsignedZones,
-        http_api_path: Arc::new(String::from("/_unit/rs/")),
+        http_api_path: Arc::new(String::from("/hook/review-unsigned/")),
     };
     let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
     let (ready_tx, ready_rx) = oneshot::channel();
@@ -171,7 +171,7 @@ pub async fn spawn(
     log::info!("Starting unit 'RS2'");
     let unit = ZoneServerUnit {
         center: center.clone(),
-        http_api_path: Arc::new(String::from("/_unit/rs2/")),
+        http_api_path: Arc::new(String::from("/hook/review-signed/")),
         _xfr_out: HashMap::from([(zone_name.clone(), "127.0.0.1:8055 KEY sec1-key".into())]),
         mode: zone_server::Mode::Prepublish,
         source: zone_server::Source::SignedZones,
@@ -216,7 +216,7 @@ pub async fn spawn(
     log::info!("Starting unit 'PS'");
     let unit = ZoneServerUnit {
         center: center.clone(),
-        http_api_path: Arc::new(String::from("/_unit/ps/")),
+        http_api_path: Arc::new(String::from("/__this_is_not_used_in_publication_server__/")),
         _xfr_out: HashMap::from([(zone_name, "127.0.0.1:8055".into())]),
         mode: zone_server::Mode::Publish,
         source: zone_server::Source::PublishedZones,


### PR DESCRIPTION
- Use nicer names for the hook paths
- Fix the environment variable to also contain the API server endpoint (or be empty if no endpoint found)