### PR TITLE
Clarify field names in policy

### DIFF
--- a/etc/policy.template.toml
+++ b/etc/policy.template.toml
@@ -109,7 +109,7 @@ csk.validity = "31536000"
 ksk.auto-start = true
 zsk.auto-start = true
 csk.auto-start = true
-alg.auto-start = true
+algorithm.auto-start = true
 
 # Whether to automatically check for record propagation.
 #
@@ -124,7 +124,7 @@ alg.auto-start = true
 ksk.auto-report = true
 zsk.auto-report = true
 csk.auto-report = true
-alg.auto-report = true
+algorithm.auto-report = true
 
 # Whether to automatically wait for cache expiry.
 #
@@ -134,7 +134,7 @@ alg.auto-report = true
 ksk.auto-expire = true
 zsk.auto-expire = true
 csk.auto-expire = true
-alg.auto-expire = true
+algorithm.auto-expire = true
 
 # Whether to automatically check for rollover completion.
 #
@@ -148,7 +148,7 @@ alg.auto-expire = true
 ksk.auto-done = true
 zsk.auto-done = true
 csk.auto-done = true
-alg.auto-done = true
+algorithm.auto-done = true
 
 # The hash algorithm used by the parent zones' DS records.
 #
@@ -240,11 +240,11 @@ cds.signature-remain-time = 604800
 # existing keys are rolled over?
 use-csk = false
 
-# Parameters for the cryptographic key material.
+# The cryptographic algorithm (and parameters) for generated keys.
 #
 # DNSSEC supports various cryptographic algorithms for signatures; one must be
 # selected, and for some algorithms, additional parameters are also necessary.
-# The same parameters will be applied to the ZSK and KSK.
+# The same algorithm and parameters will be applied to the ZSK and KSK.
 #
 # - 'rsa-sha256[:<bits>]', RSASHA256 (algorithm 8), with a public key size of
 #   '<bits>' (default 2048) bits.
@@ -261,8 +261,8 @@ use-csk = false
 #
 # NOTE: At the moment, only RSASHA256 and ECDSAP256SHA256 work with HSMs.  Other
 #   algorithms cannot be used with HSMs, and will cause generation failures.
-parameters = "ecdsa-p256-sha256"
-#parameters = "rsa-sha512:4096"
+algorithm = "ecdsa-p256-sha256"
+#algorithm = "rsa-sha512:4096"
 
 
 # How zones are signed.

--- a/etc/policy.template.toml
+++ b/etc/policy.template.toml
@@ -105,7 +105,6 @@ csk.validity = "31536000"
 # By disabling this setting, the user can manually control how new keys are
 # generated, and when rollovers happen.
 #
-# TODO: Maybe we want to start rolling over keys some time before expiry?
 ksk.auto-start = true
 zsk.auto-start = true
 csk.auto-start = true
@@ -153,9 +152,9 @@ algorithm.auto-done = true
 # The hash algorithm used by the parent zones' DS records.
 #
 # Supported options:
-# - 'sha256': SHA-256.
-# - 'sha384': SHA-384.
-ds-algorithm = "sha256"
+# - 'SHA256': SHA-256.
+# - 'SHA384': SHA-384.
+ds-algorithm = "SHA256"
 
 # Whether to automatically remove expired keys.
 #
@@ -246,14 +245,14 @@ use-csk = false
 # selected, and for some algorithms, additional parameters are also necessary.
 # The same algorithm and parameters will be applied to the ZSK and KSK.
 #
-# - 'rsa-sha256[:<bits>]', RSASHA256 (algorithm 8), with a public key size of
+# - 'RSASHA256[:<bits>]', algorithm 8, with a public key size of
 #   '<bits>' (default 2048) bits.
-# - 'rsa-sha512[:<bits>]', RSASHA512 (algorithm 10), with a public key size of
+# - 'RSASHA512[:<bits>]', algorithm 10, with a public key size of
 #   '<bits>' (default 2048) bits.
-# - 'ecdsa-p256-sha256', ECDSAP256SHA256 (algorithm 13).
-# - 'ecdsa-p384-sha384', ECDSAP384SHA384 (algorithm 14).
-# - 'ed25519', ED25519 (algorithm 15).
-# - 'ed448', ED448 (algorithm 16).
+# - 'ECDSAP256SHA256', algorithm 13.
+# - 'ECDSAP384SHA384', algorithm 14.
+# - 'ED25519', algorithm 15.
+# - 'ED448', algorithm 16.
 #
 # There are additional algorithms, but many are now considered insecure, and it
 # is recommended or mandated to avoid them.  In addition, RSA keys smaller than
@@ -261,8 +260,8 @@ use-csk = false
 #
 # NOTE: At the moment, only RSASHA256 and ECDSAP256SHA256 work with HSMs.  Other
 #   algorithms cannot be used with HSMs, and will cause generation failures.
-algorithm = "ecdsa-p256-sha256"
-#algorithm = "rsa-sha512:4096"
+algorithm = "ECDSAP256SHA256"
+#algorithm = "RSASHA512:4096"
 
 
 # How zones are signed.

--- a/src/policy/file/v1.rs
+++ b/src/policy/file/v1.rs
@@ -126,7 +126,7 @@ pub struct KeyManagerSpec {
     pub csk: KeyKindSpec,
 
     /// Policy for algorithm rollovers.
-    pub alg: RolloverSpec,
+    pub algorithm: RolloverSpec,
 
     /// The DS hash algorithm.
     pub ds_algorithm: DsAlgorithm,
@@ -149,7 +149,7 @@ impl KeyManagerSpec {
         KeyManagerPolicy {
             hsm_server_id: self.generation.hsm_server_id,
             use_csk: self.generation.use_csk,
-            algorithm: match self.generation.parameters {
+            algorithm: match self.generation.algorithm {
                 KeyGenerationParametersSpec::RsaSha256(bits) => {
                     KeyParameters::RsaSha256(bits.into())
                 }
@@ -196,7 +196,7 @@ impl KeyManagerSpec {
             auto_ksk: self.ksk.rollover.parse(),
             auto_zsk: self.zsk.rollover.parse(),
             auto_csk: self.csk.rollover.parse(),
-            auto_algorithm: self.alg.parse(),
+            auto_algorithm: self.algorithm.parse(),
 
             // The following have the same defaults as used for
             // signing the zone.
@@ -261,7 +261,7 @@ impl KeyManagerSpec {
                 }),
                 rollover: RolloverSpec::build(&policy.auto_csk),
             },
-            alg: RolloverSpec::build(&policy.auto_algorithm),
+            algorithm: RolloverSpec::build(&policy.auto_algorithm),
 
             ds_algorithm: policy.ds_algorithm.clone(),
             auto_remove: policy.auto_remove,
@@ -283,7 +283,7 @@ impl KeyManagerSpec {
             generation: KeyManagerGenerationSpec {
                 hsm_server_id: policy.hsm_server_id.clone(),
                 use_csk: policy.use_csk,
-                parameters: match policy.algorithm {
+                algorithm: match policy.algorithm {
                     KeyParameters::RsaSha256(bits) => {
                         KeyGenerationParametersSpec::RsaSha256(bits as u16)
                     }
@@ -306,7 +306,7 @@ impl Default for KeyManagerSpec {
             ksk: Default::default(),
             zsk: Default::default(),
             csk: Default::default(),
-            alg: Default::default(),
+            algorithm: Default::default(),
             ds_algorithm: DsAlgorithm::Sha256,
             auto_remove: true,
             records: Default::default(),
@@ -454,7 +454,7 @@ pub struct KeyManagerGenerationSpec {
     pub use_csk: bool,
 
     /// Parameters for the cryptographic key material.
-    pub parameters: KeyGenerationParametersSpec,
+    pub algorithm: KeyGenerationParametersSpec,
 }
 
 impl Default for KeyManagerGenerationSpec {
@@ -466,7 +466,7 @@ impl Default for KeyManagerGenerationSpec {
             // No official reference.
             use_csk: false,
 
-            parameters: KeyGenerationParametersSpec::EcdsaP256Sha256,
+            algorithm: KeyGenerationParametersSpec::EcdsaP256Sha256,
         }
     }
 }

--- a/src/policy/file/v1.rs
+++ b/src/policy/file/v1.rs
@@ -485,15 +485,15 @@ pub enum KeyGenerationParametersSpec {
 impl Display for KeyGenerationParametersSpec {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
-            Self::RsaSha256(2048) => "rsa-sha256",
-            Self::RsaSha512(2048) => "rsa-sha512",
-            Self::EcdsaP256Sha256 => "ecdsa-p256-sha256",
-            Self::EcdsaP384Sha384 => "ecdsa-p384-sha384",
-            Self::Ed25519 => "ed25519",
-            Self::Ed448 => "ed448",
+            Self::RsaSha256(2048) => "RSASHA256",
+            Self::RsaSha512(2048) => "RSASHA512",
+            Self::EcdsaP256Sha256 => "ECDSAP256SHA256",
+            Self::EcdsaP384Sha384 => "ECDSAP384SHA384",
+            Self::Ed25519 => "Ed25519",
+            Self::Ed448 => "ED448",
 
-            Self::RsaSha256(bits) => return write!(f, "rsa-sha256:{bits}"),
-            Self::RsaSha512(bits) => return write!(f, "rsa-sha512:{bits}"),
+            Self::RsaSha256(bits) => return write!(f, "RSASHA256:{bits}"),
+            Self::RsaSha512(bits) => return write!(f, "RSASHA512:{bits}"),
         })
     }
 }
@@ -502,24 +502,24 @@ impl FromStr for KeyGenerationParametersSpec {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Some(bits) = s.strip_prefix("rsa-sha256:") {
+        if let Some(bits) = s.strip_prefix("RSASHA256:") {
             match bits.parse::<u16>() {
                 Ok(bits) => Ok(Self::RsaSha256(bits)),
                 Err(err) => Err(format!("Could not parse key size {bits:?}: {err}")),
             }
-        } else if let Some(bits) = s.strip_prefix("rsa-sha512:") {
+        } else if let Some(bits) = s.strip_prefix("RSASHA512:") {
             match bits.parse::<u16>() {
                 Ok(bits) => Ok(Self::RsaSha512(bits)),
                 Err(err) => Err(format!("Could not parse key size {bits:?}: {err}")),
             }
         } else {
             Ok(match s {
-                "rsa-sha256" => Self::RsaSha256(2048),
-                "rsa-sha512" => Self::RsaSha512(2048),
-                "ecdsa-p256-sha256" => Self::EcdsaP256Sha256,
-                "ecdsa-p384-sha384" => Self::EcdsaP384Sha384,
-                "ed25519" => Self::Ed25519,
-                "ed448" => Self::Ed448,
+                "RSASHA256" => Self::RsaSha256(2048),
+                "RSASHA512" => Self::RsaSha512(2048),
+                "ECDSAP256SHA256" => Self::EcdsaP256Sha256,
+                "ECDSAP384SHA384" => Self::EcdsaP384Sha384,
+                "ED25519" => Self::Ed25519,
+                "ED448" => Self::Ed448,
                 _ => return Err(format!("Unrecognized algorithm {s:?}")),
             })
         }

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -426,7 +426,7 @@ impl Default for AutoConfig {
 /// Therefore, we only support SHA-256 and SHA-384 and the default is
 /// SHA-256.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "UPPERCASE")]
 pub enum DsAlgorithm {
     /// Hash the public key using SHA-256.
     #[default]
@@ -438,8 +438,8 @@ pub enum DsAlgorithm {
 impl Display for DsAlgorithm {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
-            DsAlgorithm::Sha256 => write!(fmt, "SHA-256"),
-            DsAlgorithm::Sha384 => write!(fmt, "SHA-384"),
+            DsAlgorithm::Sha256 => write!(fmt, "SHA256"),
+            DsAlgorithm::Sha384 => write!(fmt, "SHA384"),
         }
     }
 }


### PR DESCRIPTION
`key-manager.alg` (for algorithm rollovers) is now `.algorithm`.  `key-manager.generation.parameters` is now `.algorithm`.