### PR TITLE
Overhaul how zones are reviewed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,6 @@ dependencies = [
  "toml",
  "tracing",
  "url",
- "uuid",
 ]
 
 [[package]]
@@ -518,7 +517,7 @@ dependencies = [
  "octseq",
  "openssl",
  "parking_lot",
- "rand 0.8.5",
+ "rand",
  "ring 0.17.14",
  "rustversion",
  "secrecy",
@@ -1652,18 +1651,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1673,17 +1662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -1693,15 +1672,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -2675,7 +2645,6 @@ checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
- "rand 0.9.2",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ futures            = "0.3.17"
 futures-util       = "0.3"
 humantime          = "2.3.0"
 octseq             = { version = "0.5.2", default-features = false }
-tokio              = { version = "1.40", features = ["fs", "io-util", "macros", "net", "rt", "rt-multi-thread", "signal", "sync", "test-util", "time", "tracing"] }
+tokio              = { version = "1.40", features = ["fs", "io-util", "macros", "net", "rt", "rt-multi-thread", "signal", "sync", "test-util", "time", "tracing", "process"] }
 serde              = { version = "1.0", features = ["derive", "rc"] }
 toml               = "0.8"
 tokio-rustls       = { version = "0.23.4", optional = true }
@@ -50,7 +50,6 @@ crossbeam-utils    = "0.8"
 serde_json         = "1.0"
 serde_with         = "3"
 url                = { version = "2.4", features = ["serde"] }
-uuid               = { version = "1.4", features = ["v4", "fast-rng"] }
 rayon = "1.10.0"
 
 # Jiff is used by zone_signer for the DateCounter serial policy.

--- a/src/api.rs
+++ b/src/api.rs
@@ -43,6 +43,49 @@ pub enum ConfigReloadError {
     Parse(Utf8PathBuf, String),
 }
 
+//----------- ZoneReview -------------------------------------------------------
+
+/// Review a version of a zone.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct ZoneReview {}
+
+/// A stage for reviewing a zone.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum ZoneReviewStage {
+    /// Before signing.
+    Unsigned,
+
+    /// After signing.
+    Signed,
+}
+
+/// A decision upon reviewing a zone.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum ZoneReviewDecision {
+    /// Approve the zone.
+    Approve,
+
+    /// Reject the zone.
+    Reject,
+}
+
+/// The result of a [`ZoneReview`] command.
+pub type ZoneReviewResult = Result<ZoneReviewOutput, ZoneReviewError>;
+
+/// The output of a [`ZoneReview`] command.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct ZoneReviewOutput {}
+
+/// An error from a [`ZoneReview`] command.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum ZoneReviewError {
+    /// The specified zone could not be found.
+    NoSuchZone,
+
+    /// The specified version of the zone was not being reviewed.
+    NotUnderReview,
+}
+
 //------------------------------------------------------------------------------
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/src/cli/commands/zone.rs
+++ b/src/cli/commands/zone.rs
@@ -72,6 +72,34 @@ pub enum ZoneCommand {
     #[command(name = "reload")]
     Reload { zone: Name<Bytes> },
 
+    /// Approve a zone being reviewed.
+    #[command(name = "approve")]
+    Approve {
+        /// Whether to approve an unsigned or signed version of the zone.
+        #[command(flatten)]
+        review_stage: ZoneReviewStage,
+
+        /// The name of the zone.
+        name: Name<Bytes>,
+
+        /// The serial number of the zone.
+        serial: u32,
+    },
+
+    /// Reject a zone being reviewed.
+    #[command(name = "approve")]
+    Reject {
+        /// Whether to reject an unsigned or signed version of the zone.
+        #[command(flatten)]
+        review_stage: ZoneReviewStage,
+
+        /// The name of the zone.
+        name: Name<Bytes>,
+
+        /// The serial number of the zone.
+        serial: u32,
+    },
+
     /// Get the status of a single zone
     #[command(name = "status")]
     Status {
@@ -89,6 +117,19 @@ pub enum ZoneCommand {
         /// The zone toe report the history of.
         zone: Name<Bytes>,
     },
+}
+
+/// The stage to review a zone at.
+#[derive(Clone, Debug, clap::Args)]
+#[group(required = true, multiple = false)]
+pub struct ZoneReviewStage {
+    /// Review the zone before it is signed.
+    #[arg(long = "unsigned")]
+    unsigned: bool,
+
+    /// Review the zone after it is signed.
+    #[arg(long = "signed")]
+    signed: bool,
 }
 
 // From brainstorm in beginning of April 2025
@@ -212,6 +253,82 @@ impl Zone {
                         Ok(())
                     }
                     Err(e) => Err(format!("Failed to reload zone: {e}")),
+                }
+            }
+            ZoneCommand::Approve {
+                review_stage,
+                name,
+                serial,
+            } => {
+                let stage = match review_stage {
+                    ZoneReviewStage {
+                        unsigned: true,
+                        signed: false,
+                    } => "unsigned",
+                    ZoneReviewStage {
+                        unsigned: false,
+                        signed: true,
+                    } => "signed",
+                    _ => unreachable!(),
+                };
+
+                let url = format!("/zone/{name}/{stage}/{serial}/approve");
+                let result: ZoneReviewResult = client
+                    .post(&url)
+                    .send()
+                    .and_then(|r| r.json())
+                    .await
+                    .map_err(|e| format!("HTTP request failed: {e:?}"))?;
+
+                match result {
+                    Ok(ZoneReviewOutput {}) => {
+                        println!("Approved {stage} zone '{name}' with serial number {serial}");
+                        Ok(())
+                    },
+                    Err(ZoneReviewError::NoSuchZone) => {
+                        Err(format!("Zone '{name}' could not be found"))
+                    },
+                    Err(ZoneReviewError::NotUnderReview) => {
+                        Err(format!("The {stage} zone '{name}' with serial number {serial} is not being reviewed right now"))
+                    }
+                }
+            }
+            ZoneCommand::Reject {
+                review_stage,
+                name,
+                serial,
+            } => {
+                let stage = match review_stage {
+                    ZoneReviewStage {
+                        unsigned: true,
+                        signed: false,
+                    } => "unsigned",
+                    ZoneReviewStage {
+                        unsigned: false,
+                        signed: true,
+                    } => "signed",
+                    _ => unreachable!(),
+                };
+
+                let url = format!("/zone/{name}/{stage}/{serial}/reject");
+                let result: ZoneReviewResult = client
+                    .post(&url)
+                    .send()
+                    .and_then(|r| r.json())
+                    .await
+                    .map_err(|e| format!("HTTP request failed: {e:?}"))?;
+
+                match result {
+                    Ok(ZoneReviewOutput {}) => {
+                        println!("Rejected {stage} zone '{name}' with serial number {serial}");
+                        Ok(())
+                    },
+                    Err(ZoneReviewError::NoSuchZone) => {
+                        Err(format!("Zone '{name}' could not be found"))
+                    },
+                    Err(ZoneReviewError::NotUnderReview) => {
+                        Err(format!("The {stage} zone '{name}' with serial number {serial} is not being reviewed right now"))
+                    }
                 }
             }
             ZoneCommand::Status { zone, detailed } => {

--- a/src/comms.rs
+++ b/src/comms.rs
@@ -140,20 +140,25 @@ pub enum ApplicationCommand {
     Changed(Change),
 
     Terminate,
-    HandleZoneReviewApi {
-        zone_name: StoredName,
-        zone_serial: Serial,
-        approval_token: String,
-        operation: String,
-        http_tx: mpsc::Sender<Result<(), ()>>,
+
+    /// Review a zone.
+    ReviewZone {
+        /// The name of the zone.
+        name: StoredName,
+
+        /// The serial number of the zone.
+        serial: Serial,
+
+        /// Whether to approve or reject the zone.
+        decision: api::ZoneReviewDecision,
+
+        /// A handle for returning a response.
+        tx: tokio::sync::oneshot::Sender<api::ZoneReviewResult>,
     },
+
     SeekApprovalForUnsignedZone {
         zone_name: StoredName,
         zone_serial: Serial,
-    },
-    IsZonePendingApproval {
-        zone_name: StoredName,
-        tx: oneshot::Sender<bool>,
     },
 
     /// Refresh a zone.

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -126,7 +126,6 @@ pub async fn spawn(
         _xfr_out: HashMap::from([(zone_name.clone(), xfr_out)]),
         mode: zone_server::Mode::Prepublish,
         source: zone_server::Source::UnsignedZones,
-        http_api_path: Arc::new(String::from("/hook/review-unsigned/")),
     };
     let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
     let (ready_tx, ready_rx) = oneshot::channel();
@@ -171,7 +170,6 @@ pub async fn spawn(
     log::info!("Starting unit 'RS2'");
     let unit = ZoneServerUnit {
         center: center.clone(),
-        http_api_path: Arc::new(String::from("/hook/review-signed/")),
         _xfr_out: HashMap::from([(zone_name.clone(), "127.0.0.1:8055 KEY sec1-key".into())]),
         mode: zone_server::Mode::Prepublish,
         source: zone_server::Source::SignedZones,
@@ -216,7 +214,6 @@ pub async fn spawn(
     log::info!("Starting unit 'PS'");
     let unit = ZoneServerUnit {
         center: center.clone(),
-        http_api_path: Arc::new(String::from("/__this_is_not_used_in_publication_server__/")),
         _xfr_out: HashMap::from([(zone_name, "127.0.0.1:8055".into())]),
         mode: zone_server::Mode::Publish,
         source: zone_server::Source::PublishedZones,

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -3,6 +3,7 @@ use std::net::IpAddr;
 use domain::base::Serial;
 use domain::zonetree::StoredName;
 
+use crate::api;
 use crate::center::Change;
 use crate::zone::SigningTrigger;
 
@@ -30,6 +31,21 @@ pub enum Update {
         /// If this is set, and the zone's SOA serial is greater than or equal
         /// to this value, the refresh can be ignored.
         serial: Option<Serial>,
+    },
+
+    /// Review a zone.
+    ReviewZone {
+        /// The name of the zone.
+        name: StoredName,
+
+        /// The stage of review.
+        stage: api::ZoneReviewStage,
+
+        /// The serial number of the zone.
+        serial: Serial,
+
+        /// Whether to approve or reject the zone.
+        decision: api::ZoneReviewDecision,
     },
 
     UnsignedZoneUpdatedEvent {

--- a/src/targets/central_command.rs
+++ b/src/targets/central_command.rs
@@ -6,7 +6,7 @@ use domain::zonetree::StoredName;
 use log::info;
 use tokio::sync::mpsc;
 
-use crate::api::ZoneReviewStatus;
+use crate::api::{self, ZoneReviewStatus};
 use crate::center::{get_zone, halt_zone, Center, Change};
 use crate::comms::{ApplicationCommand, Terminated};
 use crate::manager::TargetCommand;
@@ -126,6 +126,25 @@ impl CentralCommand {
                     zone_name,
                     source,
                     serial,
+                },
+            ),
+
+            Update::ReviewZone {
+                name,
+                stage,
+                serial,
+                decision,
+            } => (
+                "Passing back zone review",
+                match stage {
+                    api::ZoneReviewStage::Unsigned => "RS",
+                    api::ZoneReviewStage::Signed => "RS2",
+                },
+                ApplicationCommand::ReviewZone {
+                    name,
+                    serial,
+                    decision,
+                    tx: tokio::sync::oneshot::channel().0,
                 },
             ),
 

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -1,16 +1,11 @@
-use std::collections::HashMap;
 use std::process::Command;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
 use std::time::SystemTime;
 
-use axum::extract::OriginalUri;
 use axum::extract::Path;
-use axum::extract::Query;
 use axum::extract::State;
-use axum::http::StatusCode;
 use axum::routing::get;
 use axum::routing::post;
 use axum::Json;
@@ -22,8 +17,7 @@ use domain::base::Serial;
 use domain::crypto::kmip::ConnectionSettings;
 use domain::dep::kmip::client::pool::ConnectionManager;
 use domain::dnssec::sign::keys::keyset::KeyType;
-use log::warn;
-use log::{debug, error, info};
+use log::{error, info};
 use serde::Deserialize;
 use serde::Serialize;
 use tokio::sync::mpsc;
@@ -95,13 +89,8 @@ impl HttpServer {
             center: self.center,
         });
 
-        let unit_router = Router::new()
-            .route("/review-unsigned/{action}/{token}", get(Self::handle_rs))
-            .route("/review-signed/{action}/{token}", get(Self::handle_rs2));
-
         let app = Router::new()
             .route("/", get(|| async { "Hello, World!" }))
-            .nest("/hook", unit_router)
             .route("/status", get(Self::status))
             .route("/config/reload", post(Self::config_reload))
             .route("/zone/", get(Self::zones_list))
@@ -111,6 +100,22 @@ impl HttpServer {
             .route("/zone/{name}/status", get(Self::zone_status))
             .route("/zone/{name}/history", get(Self::zone_history))
             .route("/zone/{name}/reload", post(Self::zone_reload))
+            .route(
+                "/zone/{name}/unsigned/{serial}/approve",
+                post(Self::approve_unsigned),
+            )
+            .route(
+                "/zone/{name}/unsigned/{serial}/reject",
+                post(Self::reject_unsigned),
+            )
+            .route(
+                "/zone/{name}/signed/{serial}/approve",
+                post(Self::approve_signed),
+            )
+            .route(
+                "/zone/{name}/signed/{serial}/reject",
+                post(Self::reject_signed),
+            )
             .route("/policy/", get(Self::policy_list))
             .route("/policy/reload", post(Self::policy_reload))
             .route("/policy/{name}", get(Self::policy_show))
@@ -592,6 +597,110 @@ impl HttpServer {
         }
     }
 
+    /// Approve an unsigned version of a zone.
+    async fn approve_unsigned(
+        State(state): State<Arc<HttpServerState>>,
+        Path((name, serial)): Path<(Name<Bytes>, Serial)>,
+        Json(command): Json<ZoneReview>,
+    ) -> Json<ZoneReviewResult> {
+        let ZoneReview {} = command;
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        state
+            .center
+            .app_cmd_tx
+            .send((
+                "RS".into(),
+                ApplicationCommand::ReviewZone {
+                    name,
+                    serial,
+                    decision: ZoneReviewDecision::Approve,
+                    tx,
+                },
+            ))
+            .unwrap();
+
+        Json(rx.await.unwrap())
+    }
+
+    /// Reject an unsigned version of a zone.
+    async fn reject_unsigned(
+        State(state): State<Arc<HttpServerState>>,
+        Path((name, serial)): Path<(Name<Bytes>, Serial)>,
+        Json(command): Json<ZoneReview>,
+    ) -> Json<ZoneReviewResult> {
+        let ZoneReview {} = command;
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        state
+            .center
+            .app_cmd_tx
+            .send((
+                "RS".into(),
+                ApplicationCommand::ReviewZone {
+                    name,
+                    serial,
+                    decision: ZoneReviewDecision::Reject,
+                    tx,
+                },
+            ))
+            .unwrap();
+
+        Json(rx.await.unwrap())
+    }
+
+    /// Approve a signed version of a zone.
+    async fn approve_signed(
+        State(state): State<Arc<HttpServerState>>,
+        Path((name, serial)): Path<(Name<Bytes>, Serial)>,
+        Json(command): Json<ZoneReview>,
+    ) -> Json<ZoneReviewResult> {
+        let ZoneReview {} = command;
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        state
+            .center
+            .app_cmd_tx
+            .send((
+                "RS2".into(),
+                ApplicationCommand::ReviewZone {
+                    name,
+                    serial,
+                    decision: ZoneReviewDecision::Approve,
+                    tx,
+                },
+            ))
+            .unwrap();
+
+        Json(rx.await.unwrap())
+    }
+
+    /// Reject a signed version of a zone.
+    async fn reject_signed(
+        State(state): State<Arc<HttpServerState>>,
+        Path((name, serial)): Path<(Name<Bytes>, Serial)>,
+        Json(command): Json<ZoneReview>,
+    ) -> Json<ZoneReviewResult> {
+        let ZoneReview {} = command;
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        state
+            .center
+            .app_cmd_tx
+            .send((
+                "RS2".into(),
+                ApplicationCommand::ReviewZone {
+                    name,
+                    serial,
+                    decision: ZoneReviewDecision::Reject,
+                    tx,
+                },
+            ))
+            .unwrap();
+
+        Json(rx.await.unwrap())
+    }
+
     async fn policy_list(State(state): State<Arc<HttpServerState>>) -> Json<PolicyListResult> {
         let state = state.center.state.lock().unwrap();
 
@@ -959,105 +1068,5 @@ impl HttpServer {
         }
 
         Json(Err(()))
-    }
-}
-
-//------------ HttpServer Handler for /<unit>/ -------------------------------
-
-impl HttpServer {
-    async fn handle_rs(
-        uri: OriginalUri,
-        State(state): State<Arc<HttpServerState>>,
-        Path((action, token)): Path<(String, String)>,
-        Query(params): Query<HashMap<String, String>>,
-    ) -> Result<(), StatusCode> {
-        Self::zone_server_unit_api_common("RS", uri, state, action, token, params).await
-    }
-
-    async fn handle_rs2(
-        uri: OriginalUri,
-        State(state): State<Arc<HttpServerState>>,
-        Path((action, token)): Path<(String, String)>,
-        Query(params): Query<HashMap<String, String>>,
-    ) -> Result<(), StatusCode> {
-        Self::zone_server_unit_api_common("RS2", uri, state, action, token, params).await
-    }
-
-    //--- common api implementations
-
-    // All ZoneServerUnit's have the same review API
-    //
-    // API: GET /{approve,reject}/<approval token>?zone=<zone name>&serial=<zone serial>
-    //
-    // NOTE: We use query parameters for the zone details because dots that appear in zone names
-    // are decoded specially by HTTP standards compliant libraries, especially occurences of
-    // handling of /./ are problematic as that gets collapsed to /.
-    async fn zone_server_unit_api_common(
-        unit: &str,
-        uri: OriginalUri,
-        state: Arc<HttpServerState>,
-        action: String,
-        token: String,
-        params: HashMap<String, String>,
-    ) -> Result<(), StatusCode> {
-        let uri = uri.path_and_query().map(|p| p.as_str()).unwrap_or_default();
-        debug!("[{HTTP_UNIT_NAME}]: Got HTTP approval hook request: {uri}");
-
-        let Some(zone_name) = params.get("zone") else {
-            warn!("[{HTTP_UNIT_NAME}]: Invalid HTTP request: {uri}");
-            return Err(StatusCode::BAD_REQUEST);
-        };
-
-        let Some(zone_serial) = params.get("serial") else {
-            warn!("[{HTTP_UNIT_NAME}]: Invalid HTTP request: {uri}");
-            return Err(StatusCode::BAD_REQUEST);
-        };
-
-        if token.is_empty() || !["approve", "reject"].contains(&action.as_ref()) {
-            warn!("[{HTTP_UNIT_NAME}]: Invalid HTTP request: {uri}");
-            return Err(StatusCode::BAD_REQUEST);
-        }
-
-        let Ok(zone_name) = Name::<Bytes>::from_str(zone_name) else {
-            warn!("[{HTTP_UNIT_NAME}]: Invalid zone name '{zone_name}' in request.");
-            return Err(StatusCode::BAD_REQUEST);
-        };
-
-        let Ok(zone_serial) = Serial::from_str(zone_serial) else {
-            warn!("[{HTTP_UNIT_NAME}]: Invalid zone serial '{zone_serial}' in request.");
-            return Err(StatusCode::BAD_REQUEST);
-        };
-
-        let (tx, mut rx) = mpsc::channel(10);
-        state
-            .center
-            .app_cmd_tx
-            .send((
-                unit.into(),
-                ApplicationCommand::HandleZoneReviewApi {
-                    zone_name,
-                    zone_serial,
-                    approval_token: token,
-                    operation: action,
-                    http_tx: tx,
-                },
-            ))
-            .unwrap();
-
-        let res = rx.recv().await;
-        let Some(res) = res else {
-            // Failed to receive response... When would that happen?
-            error!("[{HTTP_UNIT_NAME}]: Failed to receive response from unit {unit} while handling HTTP request: {uri}");
-            return Err(StatusCode::INTERNAL_SERVER_ERROR);
-        };
-
-        let ret = match res {
-            Ok(_) => Ok(()),
-            Err(_) => Err(StatusCode::BAD_REQUEST),
-        };
-
-        debug!("[{HTTP_UNIT_NAME}]: Handled HTTP request: {uri} :: {ret:?}");
-
-        ret
     }
 }

--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -4,8 +4,6 @@ use std::collections::HashMap;
 use std::marker::Sync;
 use std::net::IpAddr;
 use std::pin::Pin;
-use std::process::Command;
-use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -35,15 +33,13 @@ use domain::zonetree::types::EmptyZoneDiff;
 use domain::zonetree::Answer;
 use domain::zonetree::{StoredName, ZoneTree};
 use futures::Future;
-use log::warn;
 use log::{debug, error, info, trace};
 use serde::Deserialize;
-use tokio::sync::mpsc::{self, Sender};
-use tokio::sync::{oneshot, RwLock};
+use tokio::sync::{mpsc, oneshot, RwLock};
 #[cfg(feature = "tls")]
 use tokio_rustls::rustls::ServerConfig;
-use uuid::Uuid;
 
+use crate::api;
 use crate::center::{get_zone, Center};
 use crate::common::tsig::TsigKeyStore;
 use crate::comms::ApplicationCommand;
@@ -80,9 +76,6 @@ pub enum Source {
 #[derive(Debug)]
 pub struct ZoneServerUnit {
     pub center: Arc<Center>,
-
-    /// The relative path at which we should listen for HTTP query API requests
-    pub http_api_path: Arc<String>,
 
     /// XFR out per zone: Allow XFR to, and when with a port also send NOTIFY to.
     pub _xfr_out: HashMap<StoredName, String>,
@@ -162,7 +155,7 @@ impl ZoneServerUnit {
         ready_tx.send(true).map_err(|_| Terminated)?;
 
         let update_tx = self.center.update_tx.clone();
-        ZoneServer::new(self.center, self.http_api_path, self.source)
+        ZoneServer::new(self.center, self.source)
             .run(unit_name, update_tx, cmd_rx)
             .await?;
 
@@ -251,22 +244,20 @@ where
 //------------ ZoneServer ----------------------------------------------------
 
 struct ZoneServer {
-    http_api_path: Arc<String>,
     zone_review_api: Option<ZoneReviewApi>,
     center: Arc<Center>,
     source: Source,
     #[allow(clippy::type_complexity)]
-    pending_approvals: Arc<RwLock<HashMap<(Name<Bytes>, Serial), Vec<Uuid>>>>,
+    pending_approvals: Arc<RwLock<foldhash::HashSet<(Name<Bytes>, Serial)>>>,
     #[allow(clippy::type_complexity)]
-    last_approvals: Arc<RwLock<HashMap<(Name<Bytes>, Serial), Instant>>>,
+    last_approvals: Arc<RwLock<foldhash::HashMap<(Name<Bytes>, Serial), Instant>>>,
 }
 
 impl ZoneServer {
     #[allow(clippy::too_many_arguments)]
-    fn new(center: Arc<Center>, http_api_path: Arc<String>, source: Source) -> Self {
+    fn new(center: Arc<Center>, source: Source) -> Self {
         Self {
             zone_review_api: Default::default(),
-            http_api_path,
             center,
             source,
             pending_approvals: Default::default(),
@@ -276,7 +267,7 @@ impl ZoneServer {
 
     async fn run(
         mut self,
-        unit_name: &str,
+        unit_name: &'static str,
         update_tx: mpsc::UnboundedSender<Update>,
         mut cmd_rx: mpsc::UnboundedReceiver<ApplicationCommand>,
     ) -> Result<(), crate::comms::Terminated> {
@@ -309,7 +300,7 @@ impl ZoneServer {
     async fn handle_command(
         &self,
         cmd: ApplicationCommand,
-        unit_name: &str,
+        unit_name: &'static str,
         update_tx: mpsc::UnboundedSender<Update>,
     ) -> Result<(), Terminated> {
         info!("[{unit_name}] Received command: {cmd:?}",);
@@ -319,29 +310,20 @@ impl ZoneServer {
                 return Err(Terminated);
             }
 
-            ApplicationCommand::HandleZoneReviewApi {
-                zone_name,
-                zone_serial,
-                approval_token,
-                operation,
-                http_tx,
+            ApplicationCommand::ReviewZone {
+                name,
+                serial,
+                decision,
+                tx,
             } => {
                 self.on_zone_review_api_cmd(
-                    zone_name,
-                    zone_serial,
-                    &approval_token,
-                    &operation,
-                    http_tx,
+                    unit_name,
+                    name,
+                    serial,
+                    matches!(decision, api::ZoneReviewDecision::Approve),
+                    tx,
                 )
                 .await;
-            }
-
-            ApplicationCommand::IsZonePendingApproval { zone_name, tx } => {
-                let locked = self.pending_approvals.read().await;
-                let pending = locked
-                    .iter()
-                    .any(|((name, _serial), tokens)| zone_name == name && !tokens.is_empty());
-                let _ = tx.send(pending).ok();
             }
 
             ApplicationCommand::SeekApprovalForUnsignedZone { .. }
@@ -448,7 +430,7 @@ impl ZoneServer {
     async fn on_seek_approval_for_zone_cmd(
         &self,
         cmd: ApplicationCommand,
-        unit_name: &str,
+        unit_name: &'static str,
         update_tx: mpsc::UnboundedSender<Update>,
     ) -> Option<Result<(), Terminated>> {
         let (zone_name, zone_serial, zone_type) = match cmd {
@@ -520,21 +502,15 @@ impl ZoneServer {
 
         info!("[{unit_name}]: Seeking approval for {zone_type} zone '{zone_name}' at serial {zone_serial}.");
 
-        // Only if not already approved...
-        let approval_token = Uuid::new_v4();
-        info!("[{unit_name}]: Generated approval token '{approval_token}' for {zone_type} zone '{zone_name}' at serial {zone_serial}.");
-
         self.pending_approvals
             .write()
             .await
-            .entry((zone_name.clone(), zone_serial))
-            .and_modify(|e| e.push(approval_token))
-            .or_insert(vec![approval_token]);
+            .insert((zone_name.clone(), zone_serial));
 
         let Some(hook) = review.cmd_hook else {
             info!("[{unit_name}] No review hook set; waiting for manual review");
-            info!("[{unit_name}]: Confirm with HTTP GET {}approve/{approval_token}?zone={zone_name}&serial={zone_serial}", self.http_api_path);
-            info!("[{unit_name}]: Reject with HTTP GET {}reject/{approval_token}?zone={zone_name}&serial={zone_serial}", self.http_api_path);
+            info!("[{unit_name}]: Approve with HTTP POST /zone/{zone_name}/{zone_type}/{zone_serial}/approve");
+            info!("[{unit_name}]: Reject with HTTP POST /zone/{zone_name}/{zone_type}/{zone_serial}/reject");
             return None;
         };
 
@@ -545,34 +521,56 @@ impl ZoneServer {
 
         // TODO: Windows support?
         // TODO: Set 'CASCADE_UNSIGNED_SERIAL' and 'CASCADE_UNSIGNED_SERVER'.
-        match Command::new("sh")
+        match tokio::process::Command::new("sh")
             .args(["-c", &hook])
             .envs([
                 ("CASCADE_ZONE", &*zone_name.to_string()),
                 ("CASCADE_SERIAL", &*zone_serial.to_string()),
-                ("CASCADE_TOKEN", &*approval_token.to_string()),
                 ("CASCADE_SERVER", &*review_server.addr().to_string()),
                 (
                     "CASCADE_CONTROL",
-                    &if let Some(addr) = http_api_server_addr {
-                        format!("{}{}", addr, self.http_api_path.strip_suffix("/").unwrap())
-                    } else {
-                        warn!("[{unit_name}]: There is no HTTP API server address specified, but a review hook provided");
-                        "".into()
-                    }
+                    &http_api_server_addr
+                        .expect("An HTTP API server must be set")
+                        .to_string(),
                 ),
             ])
             .spawn()
         {
-            Ok(_) => {
+            Ok(mut child) => {
                 info!("[{unit_name}]: Executed hook '{hook}' for {zone_type} zone '{zone_name}' at serial {zone_serial}");
-                info!("[{unit_name}]: Confirm with HTTP GET {}approve/{approval_token}?zone={zone_name}&serial={zone_serial}", self.http_api_path);
-                info!("[{unit_name}]: Reject with HTTP GET {}reject/{approval_token}?zone={zone_name}&serial={zone_serial}", self.http_api_path);
+
+                // Wait for the child to complete.
+                let update_tx = self.center.update_tx.clone();
+                tokio::spawn(async move {
+                    let status = match child.wait().await {
+                        Ok(status) => status,
+                        Err(error) => {
+                            error!("[{unit_name}]: Failed to watch hook '{hook}': {error}");
+                            return;
+                        }
+                    };
+
+                    debug!("[{unit_name}]: Hook '{hook}' exited with status {status}");
+
+                    let decision = match status.success() {
+                        true => api::ZoneReviewDecision::Approve,
+                        false => api::ZoneReviewDecision::Reject,
+                    };
+
+                    let _ = update_tx.send(Update::ReviewZone {
+                        name: zone_name,
+                        stage: match zone_type {
+                            "unsigned" => api::ZoneReviewStage::Unsigned,
+                            "signed" => api::ZoneReviewStage::Signed,
+                            _ => unreachable!(),
+                        },
+                        serial: zone_serial,
+                        decision,
+                    });
+                });
             }
             Err(err) => {
-                error!(
-                                "[{unit_name}]: Failed to execute hook '{hook}' for {zone_type} zone '{zone_name}' at serial {zone_serial}: {err}",
-                            );
+                error!("[{unit_name}]: Failed to execute hook '{hook}' for {zone_type} zone '{zone_name}' at serial {zone_serial}: {err}");
                 self.pending_approvals
                     .write()
                     .await
@@ -584,22 +582,20 @@ impl ZoneServer {
 
     async fn on_zone_review_api_cmd(
         &self,
+        unit_name: &str,
         zone_name: Name<Bytes>,
         zone_serial: Serial,
-        approval_token: &str,
-        operation: &str,
-        http_tx: Sender<Result<(), ()>>,
+        approve: bool,
+        tx: tokio::sync::oneshot::Sender<api::ZoneReviewResult>,
     ) {
-        http_tx
-            .send(
-                self.zone_review_api
-                    .as_ref()
-                    .expect("This should have been setup on startup.")
-                    .process_request(zone_name.clone(), zone_serial, approval_token, operation)
-                    .await,
-            )
-            .await
-            .expect("TODO: Should this always succeed?");
+        // This can fail if the caller doesn't care about the result.
+        let _ = tx.send(
+            self.zone_review_api
+                .as_ref()
+                .expect("This should have been setup on startup.")
+                .process_request(unit_name, zone_name.clone(), zone_serial, approve)
+                .await,
+        );
     }
 }
 
@@ -738,107 +734,73 @@ fn zone_server_service(
 impl ZoneReviewApi {
     async fn process_request(
         &self,
+        unit_name: &str,
         zone_name: Name<Bytes>,
         zone_serial: Serial,
-        given_approval_token: &str,
-        operation: &str,
-    ) -> Result<(), ()> {
-        let mut status = Err(());
-        let mut remove_approvals = false;
+        approve: bool,
+    ) -> api::ZoneReviewResult {
+        // Was this version of the zone pending review?
+        let existed = {
+            let mut approvals = self.pending_approvals.write().await;
+            approvals.remove(&(zone_name.clone(), zone_serial))
+        };
 
-        // Are approvals pending for this serial of this zone?
-        if let Some(pending_approvals) = self
-            .pending_approvals
-            .write()
-            .await
-            .get_mut(&(zone_name.clone(), zone_serial))
-        {
-            // Is this a valid approval token?
-            if let Ok(given_uuid) = Uuid::from_str(given_approval_token) {
-                if let Some(idx) = pending_approvals
-                    .iter()
-                    .position(|&uuid| uuid == given_uuid)
-                {
-                    // For a rejection remove all pending approvals for the zone.
-                    // For an approval remove only the specified approval.
-                    match operation {
-                        "approve" => {
-                            status = Ok(());
-                            pending_approvals.remove(idx);
-
-                            if pending_approvals.is_empty() {
-                                let (zone_type, event) = match self.source {
-                                    Source::UnsignedZones => (
-                                        "unsigned",
-                                        Update::UnsignedZoneApprovedEvent {
-                                            zone_name: zone_name.clone(),
-                                            zone_serial,
-                                        },
-                                    ),
-                                    Source::SignedZones => (
-                                        "signed",
-                                        Update::SignedZoneApprovedEvent {
-                                            zone_name: zone_name.clone(),
-                                            zone_serial,
-                                        },
-                                    ),
-                                    Source::PublishedZones => unreachable!(),
-                                };
-                                info!("Pending {zone_type} zone '{zone_name}' approved at serial {zone_serial}.");
-                                let approved_at = Instant::now();
-                                self.last_approvals
-                                    .write()
-                                    .await
-                                    .entry((zone_name.clone(), zone_serial))
-                                    .and_modify(|instant| *instant = approved_at)
-                                    .or_insert(approved_at);
-                                self.update_tx.send(event).unwrap();
-                                remove_approvals = true;
-                            }
-                        }
-                        "reject" => {
-                            status = Ok(());
-                            let (zone_type, event) = match self.source {
-                                Source::UnsignedZones => (
-                                    "unsigned",
-                                    Update::UnsignedZoneRejectedEvent {
-                                        zone_name: zone_name.clone(),
-                                        zone_serial,
-                                    },
-                                ),
-                                Source::SignedZones => (
-                                    "signed",
-                                    Update::SignedZoneRejectedEvent {
-                                        zone_name: zone_name.clone(),
-                                        zone_serial,
-                                    },
-                                ),
-                                Source::PublishedZones => unreachable!(),
-                            };
-                            info!("Pending {zone_type} zone '{zone_name}' rejected at serial {zone_serial}.");
-                            self.update_tx.send(event).unwrap();
-                            remove_approvals = true;
-                        }
-                        _ => unreachable!(),
-                    }
-                } else {
-                    warn!("No pending approval found for zone name '{zone_name}' at serial {zone_serial} with approval token '{given_uuid}'.");
-                }
-            } else {
-                warn!("Invalid approval token '{given_approval_token}' in request.");
-            }
-        } else {
-            debug!("No pending approvals for zone name '{zone_name}' at serial {zone_serial}.");
+        if !existed {
+            // TODO: Check whether the zone exists at all.
+            debug!("[{unit_name}] Got a review for {zone_name}/{zone_serial}, but it was not pending review");
+            return Err(api::ZoneReviewError::NotUnderReview);
         }
 
-        if remove_approvals {
-            self.pending_approvals
+        if approve {
+            let (zone_type, event) = match self.source {
+                Source::UnsignedZones => (
+                    "unsigned",
+                    Update::UnsignedZoneApprovedEvent {
+                        zone_name: zone_name.clone(),
+                        zone_serial,
+                    },
+                ),
+                Source::SignedZones => (
+                    "signed",
+                    Update::SignedZoneApprovedEvent {
+                        zone_name: zone_name.clone(),
+                        zone_serial,
+                    },
+                ),
+                Source::PublishedZones => unreachable!(),
+            };
+            info!("Pending {zone_type} zone '{zone_name}' approved at serial {zone_serial}.");
+            let approved_at = Instant::now();
+            self.last_approvals
                 .write()
                 .await
-                .remove(&(zone_name, zone_serial));
+                .entry((zone_name.clone(), zone_serial))
+                .and_modify(|instant| *instant = approved_at)
+                .or_insert(approved_at);
+            self.update_tx.send(event).unwrap();
+        } else {
+            let (zone_type, event) = match self.source {
+                Source::UnsignedZones => (
+                    "unsigned",
+                    Update::UnsignedZoneRejectedEvent {
+                        zone_name: zone_name.clone(),
+                        zone_serial,
+                    },
+                ),
+                Source::SignedZones => (
+                    "signed",
+                    Update::SignedZoneRejectedEvent {
+                        zone_name: zone_name.clone(),
+                        zone_serial,
+                    },
+                ),
+                Source::PublishedZones => unreachable!(),
+            };
+            info!("Pending {zone_type} zone '{zone_name}' rejected at serial {zone_serial}.");
+            self.update_tx.send(event).unwrap();
         }
 
-        status
+        Ok(api::ZoneReviewOutput {})
     }
 }
 
@@ -847,9 +809,9 @@ impl ZoneReviewApi {
 struct ZoneReviewApi {
     update_tx: mpsc::UnboundedSender<Update>,
     #[allow(clippy::type_complexity)]
-    pending_approvals: Arc<RwLock<HashMap<(Name<Bytes>, Serial), Vec<Uuid>>>>,
+    pending_approvals: Arc<RwLock<foldhash::HashSet<(Name<Bytes>, Serial)>>>,
     #[allow(clippy::type_complexity)]
-    last_approvals: Arc<RwLock<HashMap<(Name<Bytes>, Serial), Instant>>>,
+    last_approvals: Arc<RwLock<foldhash::HashMap<(Name<Bytes>, Serial), Instant>>>,
     source: Source,
 }
 
@@ -857,8 +819,8 @@ impl ZoneReviewApi {
     #[allow(clippy::type_complexity)]
     fn new(
         update_tx: mpsc::UnboundedSender<Update>,
-        pending_approvals: Arc<RwLock<HashMap<(Name<Bytes>, Serial), Vec<Uuid>>>>,
-        last_approvals: Arc<RwLock<HashMap<(Name<Bytes>, Serial), Instant>>>,
+        pending_approvals: Arc<RwLock<foldhash::HashSet<(Name<Bytes>, Serial)>>>,
+        last_approvals: Arc<RwLock<foldhash::HashMap<(Name<Bytes>, Serial), Instant>>>,
         source: Source,
     ) -> Self {
         Self {

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -387,7 +387,13 @@ impl ZoneSigner {
             }
         };
         let Some(unsigned_zone) = zone_to_sign else {
-            return Err(format!("Unknown zone '{zone_name}'"));
+            // In some cases, we might receive requests to sign zones that are
+            // not yet available, because the requestor doesn't know the zone
+            // hasn't been signed yet.  The requestors should be fixed; but this
+            // is a quick fix for now.
+
+            debug!("Ignoring request to sign unavailable zone '{zone_name}'");
+            return Ok(());
         };
         let soa_rr = get_zone_soa(unsigned_zone.clone(), zone_name.clone())?;
         let ZoneRecordData::Soa(soa) = soa_rr.data() else {

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -80,6 +80,12 @@ pub struct ZoneState {
     /// approved.
     pub next_min_expiration: Option<Timestamp>,
 
+    /// Unsigned versions of the zone.
+    pub unsigned: foldhash::HashMap<Serial, UnsignedZoneVersionState>,
+
+    /// Signed versions of the zone.
+    pub signed: foldhash::HashMap<Serial, SignedZoneVersionState>,
+
     /// History of interesting events that occurred for this zone.
     pub history: Vec<HistoryItem>,
 
@@ -132,6 +138,45 @@ impl ZoneState {
             .rev()
             .find(|item| item.event.is_of_type(typ) && (serial.is_none() || item.serial == serial))
     }
+}
+
+/// The state of an unsigned version of a zone.
+#[derive(Clone, Debug)]
+pub struct UnsignedZoneVersionState {
+    /// The review state of the zone version.
+    pub review: ZoneVersionReviewState,
+}
+
+/// The state of a signed version of a zone.
+#[derive(Clone, Debug)]
+pub struct SignedZoneVersionState {
+    /// The serial number of the corresponding unsigned version of the zone.
+    pub unsigned_serial: Serial,
+
+    /// The review state of the zone version.
+    pub review: ZoneVersionReviewState,
+}
+
+/// The review state of a version of a zone.
+#[derive(Clone, Debug, Default)]
+pub enum ZoneVersionReviewState {
+    /// The zone is pending review.
+    ///
+    /// If a review script has been configured, it is running now.  Otherwise,
+    /// the zone must be manually reviewed.
+    #[default]
+    Pending,
+
+    /// The zone has been approved.
+    ///
+    /// This is a terminal state.  The zone may have progressed further through
+    /// the pipeline, so it is no longer possible to reject it.
+    Approved,
+
+    /// The zone has been rejected.
+    ///
+    /// The zone has not yet been approved; it can be approved at any time.
+    Rejected,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]


### PR DESCRIPTION
- Zone review no longer involves approval tokens.

- Added commands `cascade zone {approve,reject}` for manually approving
  or rejecting zones.

- Rely on the exit status of hook commands to judge approval/rejection.