### PR TITLE
Fix missing name on zone remove error

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -113,7 +113,30 @@ impl From<center::ZoneAddError> for ZoneAddError {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct ZoneRemoveResult {}
+pub struct ZoneRemoveResult {
+    pub name: Name<Bytes>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum ZoneRemoveError {
+    NotFound,
+}
+
+impl fmt::Display for ZoneRemoveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::NotFound => "no such zone was found",
+        })
+    }
+}
+
+impl From<center::ZoneRemoveError> for ZoneRemoveError {
+    fn from(value: center::ZoneRemoveError) -> Self {
+        match value {
+            center::ZoneRemoveError::NotFound => Self::NotFound,
+        }
+    }
+}
 
 /// How to load the contents of a zone.
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/src/cli/commands/zone.rs
+++ b/src/cli/commands/zone.rs
@@ -174,15 +174,20 @@ impl Zone {
                 }
             }
             ZoneCommand::Remove { name } => {
-                let res: ZoneAddResult = client
+                let res: Result<ZoneRemoveResult, ZoneRemoveError> = client
                     .post(&format!("zone/{name}/remove"))
                     .send()
                     .and_then(|r| r.json())
                     .await
                     .map_err(format_http_error)?;
 
-                println!("Removed zone {}", res.name);
-                Ok(())
+                match res {
+                    Ok(res) => {
+                        println!("Removed zone {}", res.name);
+                        Ok(())
+                    }
+                    Err(e) => Err(format!("Failed to remove zone: {e}")),
+                }
             }
             ZoneCommand::List => {
                 let response: ZonesListResult = client

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -210,11 +210,13 @@ impl HttpServer {
     async fn zone_remove(
         State(state): State<Arc<HttpServerState>>,
         Path(name): Path<Name<Bytes>>,
-    ) -> Json<ZoneRemoveResult> {
+    ) -> Json<Result<ZoneRemoveResult, ZoneRemoveError>> {
         // TODO: Use the result.
-        let _ = center::remove_zone(&state.center, name);
-
-        Json(ZoneRemoveResult {})
+        Json(
+            center::remove_zone(&state.center, name.clone())
+                .map(|_| ZoneRemoveResult { name })
+                .map_err(|e| e.into()),
+        )
     }
 
     async fn zones_list(State(http_state): State<Arc<HttpServerState>>) -> Json<ZonesListResult> {


### PR DESCRIPTION
Fixes
```
root@ubuntu-s-1vcpu-1gb-ams3-01:~# cascade zone remove example.com
[2025-10-01T21:26:26.685Z] ERROR cascade: Error: HTTP request failed: reqwest::Error { kind: Decode, source: Error("missing field `name`", line: 1, column: 2) }
```