### PR TITLE
Add more context on KMIP connection & state saving errors.

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -515,7 +515,7 @@ impl std::fmt::Display for HsmServerAddError {
                 err,
             } => write!(
                 f,
-                "Unable to query HSM '{server_id} at {host}:{port}: {err}"
+                "Unable to query HSM '{server_id}' at {host}:{port}: {err}"
             ),
             HsmServerAddError::CredentialsFileCouldNotBeOpenedForWriting { err } => {
                 // The error already contains everything we want to say so

--- a/src/api.rs
+++ b/src/api.rs
@@ -520,12 +520,12 @@ impl std::fmt::Display for HsmServerAddError {
             HsmServerAddError::CredentialsFileCouldNotBeOpenedForWriting { err } => {
                 // The error already contains everything we want to say so
                 // don't duplicate it.
-                f.write_str(&err)
+                f.write_str(err)
             }
             HsmServerAddError::CredentialsFileCouldNotBeSaved { err } => {
                 // The error already contains everything we want to say so
                 // don't duplicate it.
-                f.write_str(&err)
+                f.write_str(err)
             }
             HsmServerAddError::KmipServerStateFileCouldNotBeCreated { path, err } => {
                 write!(f, "Unable to create KMIP server state file '{path}': {err}")

--- a/src/api.rs
+++ b/src/api.rs
@@ -466,12 +466,75 @@ pub struct HsmServerAddResult {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub enum HsmServerAddError {
-    UnableToConnect,
-    UnableToQuery,
-    CredentialsFileCouldNotBeOpenedForWriting,
-    CredentialsFileCouldNotBeSaved,
-    KmipServerStateFileCouldNotBeCreated,
-    KmipServerStateFileCouldNotBeSaved,
+    UnableToConnect {
+        server_id: String,
+        host: String,
+        port: u16,
+        err: String,
+    },
+    UnableToQuery {
+        server_id: String,
+        host: String,
+        port: u16,
+        err: String,
+    },
+    CredentialsFileCouldNotBeOpenedForWriting {
+        // Path is not needed as the error already contains it.
+        err: String,
+    },
+    CredentialsFileCouldNotBeSaved {
+        // Path is not needed as the error already contains it.
+        err: String,
+    },
+    KmipServerStateFileCouldNotBeCreated {
+        path: String,
+        err: String,
+    },
+    KmipServerStateFileCouldNotBeSaved {
+        path: String,
+        err: String,
+    },
+}
+
+impl std::fmt::Display for HsmServerAddError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HsmServerAddError::UnableToConnect {
+                server_id,
+                host,
+                port,
+                err,
+            } => write!(
+                f,
+                "Unable to connect to HSM '{server_id}' at {host}:{port}: {err}"
+            ),
+            HsmServerAddError::UnableToQuery {
+                server_id,
+                host,
+                port,
+                err,
+            } => write!(
+                f,
+                "Unable to query HSM '{server_id} at {host}:{port}: {err}"
+            ),
+            HsmServerAddError::CredentialsFileCouldNotBeOpenedForWriting { err } => {
+                // The error already contains everything we want to say so
+                // don't duplicate it.
+                f.write_str(&err)
+            }
+            HsmServerAddError::CredentialsFileCouldNotBeSaved { err } => {
+                // The error already contains everything we want to say so
+                // don't duplicate it.
+                f.write_str(&err)
+            }
+            HsmServerAddError::KmipServerStateFileCouldNotBeCreated { path, err } => {
+                write!(f, "Unable to create KMIP server state file '{path}': {err}")
+            }
+            HsmServerAddError::KmipServerStateFileCouldNotBeSaved { path, err } => {
+                write!(f, "Unable to save KMIP server state file '{path}': {err}")
+            }
+        }
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/src/cli/commands/hsm.rs
+++ b/src/cli/commands/hsm.rs
@@ -99,7 +99,7 @@ impl Hsm {
                     Ok(HsmServerAddResult { vendor_id }) => {
                         println!("Added KMIP server '{vendor_id}'.")
                     }
-                    Err(err) => return Err(format!("Add KMIP server command failed: {err:?}")),
+                    Err(err) => return Err(format!("Add KMIP server command failed: {err}")),
                 }
             }
 

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -866,7 +866,7 @@ impl HttpServer {
                     server_id,
                     host: conn_settings.host,
                     port: conn_settings.port,
-                    err: format!("Error creating connection pool: {}", err.to_string()),
+                    err: format!("Error creating connection pool: {err}"),
                 }))
             }
         };
@@ -879,7 +879,7 @@ impl HttpServer {
                     server_id,
                     host: conn_settings.host,
                     port: conn_settings.port,
-                    err: format!("Error retrieving connection from pool: {}", err.to_string()),
+                    err: format!("Error retrieving connection from pool: {err}"),
                 }));
             }
         };

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -861,16 +861,39 @@ impl HttpServer {
             Some(Duration::from_secs(60)),
         ) {
             Ok(pool) => pool,
-            Err(_err) => return Json(Err(HsmServerAddError::UnableToConnect)),
+            Err(err) => {
+                return Json(Err(HsmServerAddError::UnableToConnect {
+                    server_id,
+                    host: conn_settings.host,
+                    port: conn_settings.port,
+                    err: format!("Error creating connection pool: {}", err.to_string()),
+                }))
+            }
         };
 
         // Test the connectivity (but not the HSM capabilities).
-        let Ok(conn) = pool.get() else {
-            return Json(Err(HsmServerAddError::UnableToConnect));
+        let conn = match pool.get() {
+            Ok(conn) => conn,
+            Err(err) => {
+                return Json(Err(HsmServerAddError::UnableToConnect {
+                    server_id,
+                    host: conn_settings.host,
+                    port: conn_settings.port,
+                    err: format!("Error retrieving connection from pool: {}", err.to_string()),
+                }));
+            }
         };
 
-        let Ok(query_res) = conn.query() else {
-            return Json(Err(HsmServerAddError::UnableToQuery));
+        let query_res = match conn.query() {
+            Ok(query_res) => query_res,
+            Err(err) => {
+                return Json(Err(HsmServerAddError::UnableToQuery {
+                    server_id,
+                    host: conn_settings.host,
+                    port: conn_settings.port,
+                    err: err.to_string(),
+                }));
+            }
         };
 
         let vendor_id = query_res
@@ -889,15 +912,19 @@ impl HttpServer {
                 KmipServerCredentialsFileMode::CreateReadWrite,
             ) {
                 Ok(creds_file) => creds_file,
-                Err(_err) => {
+                Err(err) => {
                     return Json(Err(
-                        HsmServerAddError::CredentialsFileCouldNotBeOpenedForWriting,
+                        HsmServerAddError::CredentialsFileCouldNotBeOpenedForWriting {
+                            err: err.to_string(),
+                        },
                     ))
                 }
             };
             let _ = creds_file.insert(server_id, creds);
-            if creds_file.save().is_err() {
-                return Json(Err(HsmServerAddError::CredentialsFileCouldNotBeSaved));
+            if let Err(err) = creds_file.save() {
+                return Json(Err(HsmServerAddError::CredentialsFileCouldNotBeSaved {
+                    err: err.to_string(),
+                }));
             }
         }
 
@@ -906,14 +933,23 @@ impl HttpServer {
         let kmip_state = KmipServerState::from(req);
 
         info!("Writing to KMIP server file '{kmip_server_state_file}");
-        let f = match std::fs::File::create_new(kmip_server_state_file) {
+        let f = match std::fs::File::create_new(kmip_server_state_file.clone()) {
             Ok(f) => f,
-            Err(_err) => return Json(Err(HsmServerAddError::KmipServerStateFileCouldNotBeCreated)),
+            Err(err) => {
+                return Json(Err(
+                    HsmServerAddError::KmipServerStateFileCouldNotBeCreated {
+                        path: kmip_server_state_file.into_string(),
+                        err: err.to_string(),
+                    },
+                ))
+            }
         };
-        if let Err(_err) = serde_json::to_writer_pretty(&f, &kmip_state) {
-            return Json(Err(HsmServerAddError::KmipServerStateFileCouldNotBeSaved));
+        if let Err(err) = serde_json::to_writer_pretty(&f, &kmip_state) {
+            return Json(Err(HsmServerAddError::KmipServerStateFileCouldNotBeSaved {
+                path: kmip_server_state_file.into_string(),
+                err: err.to_string(),
+            }));
         }
-        drop(f);
 
         Json(Ok(HsmServerAddResult { vendor_id }))
     }


### PR DESCRIPTION
The original error that triggered this issue now includes context and that context is now reported back to the CLI user, e.g.:

```
[ximon@secondary4nl ~]$ ./cascade hsm add --insecure hsmrelay 127.0.0.1 --port 5696 --username OpenDNSSEC --password 1234 
[2025-10-02T19:12:12.925Z] ERROR cascade: Error: Add KMIP server command failed: unable to open KMIP credentials file /home/ximon/cascade_dir/kmip/credentials.db in create-read-write mode: No such file or directory (os error 2)
```