### PR TITLE
Various fixes.

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -466,12 +466,75 @@ pub struct HsmServerAddResult {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub enum HsmServerAddError {
-    UnableToConnect,
-    UnableToQuery,
-    CredentialsFileCouldNotBeOpenedForWriting,
-    CredentialsFileCouldNotBeSaved,
-    KmipServerStateFileCouldNotBeCreated,
-    KmipServerStateFileCouldNotBeSaved,
+    UnableToConnect {
+        server_id: String,
+        host: String,
+        port: u16,
+        err: String,
+    },
+    UnableToQuery {
+        server_id: String,
+        host: String,
+        port: u16,
+        err: String,
+    },
+    CredentialsFileCouldNotBeOpenedForWriting {
+        // Path is not needed as the error already contains it.
+        err: String,
+    },
+    CredentialsFileCouldNotBeSaved {
+        // Path is not needed as the error already contains it.
+        err: String,
+    },
+    KmipServerStateFileCouldNotBeCreated {
+        path: String,
+        err: String,
+    },
+    KmipServerStateFileCouldNotBeSaved {
+        path: String,
+        err: String,
+    },
+}
+
+impl std::fmt::Display for HsmServerAddError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HsmServerAddError::UnableToConnect {
+                server_id,
+                host,
+                port,
+                err,
+            } => write!(
+                f,
+                "Unable to connect to HSM '{server_id}' at {host}:{port}: {err}"
+            ),
+            HsmServerAddError::UnableToQuery {
+                server_id,
+                host,
+                port,
+                err,
+            } => write!(
+                f,
+                "Unable to query HSM '{server_id} at {host}:{port}: {err}"
+            ),
+            HsmServerAddError::CredentialsFileCouldNotBeOpenedForWriting { err } => {
+                // The error already contains everything we want to say so
+                // don't duplicate it.
+                f.write_str(err)
+            }
+            HsmServerAddError::CredentialsFileCouldNotBeSaved { err } => {
+                // The error already contains everything we want to say so
+                // don't duplicate it.
+                f.write_str(err)
+            }
+            HsmServerAddError::KmipServerStateFileCouldNotBeCreated { path, err } => {
+                write!(f, "Unable to create KMIP server state file '{path}': {err}")
+            }
+            HsmServerAddError::KmipServerStateFileCouldNotBeSaved { path, err } => {
+                write!(f, "Unable to save KMIP server state file '{path}': {err}")
+            }
+        }
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/src/cli/commands/zone.rs
+++ b/src/cli/commands/zone.rs
@@ -528,31 +528,57 @@ impl Progress {
     fn print_zone_received(&self, zone: &ZoneStatus) {
         // TODO: we have no indication of whether a zone is currently being
         // received or not, we can only say if it was received after the fact.
-        println!(
-            "{} Loaded {}",
-            status_icon(true),
-            serial_to_string(zone.unsigned_serial),
-        );
-
         // Print how receival of the zone went.
         let Some(report) = &zone.receipt_report else {
-            unreachable!();
+            // This shouldn't happen.
+            println!(
+                "{}\u{78} The receipt report for this zone is unavailable.{}",
+                ansi::RED,
+                ansi::RESET
+            );
+            return;
         };
-        let (loaded_fetched, filesystem_network) = match zone.source {
+
+        let (loading_fetching, loaded_fetched, filesystem_network) = match zone.source {
             ZoneSource::None => unreachable!(),
-            ZoneSource::Zonefile { .. } => ("Loaded", "filesystem"),
-            ZoneSource::Server { .. } => ("Fetched", "network"),
+            ZoneSource::Zonefile { .. } => ("Loading", "Loaded", "filesystem"),
+            ZoneSource::Server { .. } => ("Fetching", "Fetched", "network"),
         };
-        println!("  Loaded at {}", to_rfc3339_ago(report.finished_at));
-        println!(
-            "  {loaded_fetched} {} from the {filesystem_network} in {} seconds",
-            format_size(report.byte_count, " ", "B"),
-            report
-                .finished_at
-                .duration_since(report.started_at)
-                .unwrap()
-                .as_secs()
-        );
+
+        match report.finished_at {
+            None => {
+                println!("{} {loading_fetching} ..", status_icon(false),);
+
+                println!(
+                    "  {loaded_fetched} {} and {} in {} seconds",
+                    format_size(report.byte_count, " ", "B"),
+                    format_size(report.record_count, "", " records"),
+                    SystemTime::now()
+                        .duration_since(report.started_at)
+                        .unwrap()
+                        .as_secs()
+                );
+            }
+            Some(finished_at) => {
+                println!(
+                    "{} Loaded {}",
+                    status_icon(true),
+                    serial_to_string(zone.unsigned_serial),
+                );
+
+                println!("  Loaded at {}", to_rfc3339_ago(report.finished_at));
+
+                println!(
+                    "  {loaded_fetched} {} and {} from the {filesystem_network} in {} seconds",
+                    format_size(report.byte_count, " ", "B"),
+                    format_size(report.record_count, "", " records"),
+                    finished_at
+                        .duration_since(report.started_at)
+                        .unwrap()
+                        .as_secs()
+                );
+            }
+        }
     }
 
     fn print_pending_unsigned_review(&self, zone: &ZoneStatus, policy: &PolicyInfo) {
@@ -662,10 +688,16 @@ impl Progress {
         if let Some(report) = &zone.signing_report {
             match report {
                 SigningReport::Requested(r) => {
-                    println!("  Signing requested at {}", to_rfc3339_ago(r.requested_at));
+                    println!(
+                        "  Signing requested at {}",
+                        to_rfc3339_ago(Some(r.requested_at))
+                    );
                 }
                 SigningReport::InProgress(r) => {
-                    println!("  Signing started at {}", to_rfc3339_ago(r.started_at));
+                    println!(
+                        "  Signing started at {}",
+                        to_rfc3339_ago(Some(r.started_at))
+                    );
                     if let (Some(unsigned_rr_count), Some(total_time)) =
                         (r.unsigned_rr_count, r.total_time)
                     {
@@ -677,7 +709,7 @@ impl Progress {
                     }
                 }
                 SigningReport::Finished(r) => {
-                    println!("  Signed at {}", to_rfc3339_ago(r.finished_at));
+                    println!("  Signed at {}", to_rfc3339_ago(Some(r.finished_at)));
                     println!(
                         "  Signed {} in {}",
                         format_size(r.unsigned_rr_count, "", " records"),
@@ -711,11 +743,16 @@ fn serial_to_string(serial: Option<Serial>) -> String {
     }
 }
 
-fn to_rfc3339_ago(v: SystemTime) -> String {
-    let now = SystemTime::now();
-    let diff = now.duration_since(v).unwrap();
-    let rfc3339 = to_rfc3339(v);
-    format!("{rfc3339} ({} ago)", format_duration(diff))
+fn to_rfc3339_ago(v: Option<SystemTime>) -> String {
+    match v {
+        Some(v) => {
+            let now = SystemTime::now();
+            let diff = now.duration_since(v).unwrap();
+            let rfc3339 = to_rfc3339(v);
+            format!("{rfc3339} ({} ago)", format_duration(diff))
+        }
+        None => "Not yet finished".to_string(),
+    }
 }
 
 fn to_rfc3339(v: SystemTime) -> String {

--- a/src/targets/central_command.rs
+++ b/src/targets/central_command.rs
@@ -3,7 +3,7 @@ use std::time::SystemTime;
 
 use domain::base::Serial;
 use domain::zonetree::StoredName;
-use log::info;
+use log::{info, warn};
 use tokio::sync::mpsc;
 
 use crate::api::ZoneReviewStatus;
@@ -11,7 +11,7 @@ use crate::center::{get_zone, halt_zone, Center, Change};
 use crate::comms::{ApplicationCommand, Terminated};
 use crate::manager::TargetCommand;
 use crate::payload::Update;
-use crate::zone::{HistoricalEvent, SigningTrigger};
+use crate::zone::{HistoricalEvent, PipelineMode, SigningTrigger};
 
 pub struct CentralCommand {
     pub center: Arc<Center>,
@@ -139,6 +139,16 @@ impl CentralCommand {
                     HistoricalEvent::NewVersionReceived,
                     Some(zone_serial),
                 );
+
+                if let Some(zone) = get_zone(&self.center, &zone_name) {
+                    if let Ok(zone_state) = zone.state.lock() {
+                        if matches!(zone_state.pipeline_mode, PipelineMode::HardHalt(_)) {
+                            warn!("[CC]: NOT instructing review server to publish the unsigned zone as the pipeline for the zone is hard halted");
+                            return;
+                        }
+                    }
+                }
+
                 (
                     "Instructing review server to publish the unsigned zone",
                     "RS",

--- a/src/units/zone_loader.rs
+++ b/src/units/zone_loader.rs
@@ -11,14 +11,17 @@ use std::time::SystemTime;
 use bytes::{BufMut, Bytes};
 use camino::Utf8Path;
 use domain::base::iana::{Class, Rcode};
+use domain::base::name::FlattenInto;
 use domain::base::{Name, Rtype, Serial};
 use domain::net::server::middleware::notify::Notifiable;
 use domain::rdata::ZoneRecordData;
 use domain::tsig::KeyStore;
-use domain::zonefile::inplace;
+use domain::zonefile::inplace::{self, Entry};
+use domain::zonetree::error::RecordError;
+use domain::zonetree::parsed::Zonefile;
 use domain::zonetree::{
     AnswerContent, InMemoryZoneDiff, ReadableZone, StoredName, WritableZone, WritableZoneNode,
-    Zone, ZoneStore,
+    Zone, ZoneBuilder, ZoneStore,
 };
 use foldhash::HashMap;
 use futures::Future;
@@ -31,7 +34,7 @@ use tokio::time::Instant;
 #[cfg(feature = "tls")]
 use tokio_rustls::rustls::ServerConfig;
 
-use crate::center::{Center, Change};
+use crate::center::{halt_zone, Center, Change};
 use crate::common::light_weight_zone::LightWeightZone;
 use crate::comms::{ApplicationCommand, Terminated};
 use crate::payload::Update;
@@ -40,14 +43,16 @@ use crate::zonemaintenance::maintainer::{
     Config, ConnectionFactory, DefaultConnFactory, TypedZone, ZoneMaintainer,
 };
 use crate::zonemaintenance::types::{
-    NotifyConfig, TransportStrategy, XfrConfig, XfrStrategy, ZoneConfig, ZoneId,
+    NotifyConfig, TransportStrategy, XfrConfig, XfrStrategy, ZoneConfig, ZoneId, ZoneInfo,
+    ZoneReport, ZoneReportDetails,
 };
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ZoneLoaderReport {
     pub started_at: SystemTime,
-    pub finished_at: SystemTime,
+    pub finished_at: Option<SystemTime>,
     pub byte_count: usize,
+    pub record_count: usize,
 }
 
 #[derive(Debug)]
@@ -99,6 +104,7 @@ impl ZoneLoader {
             let max_zones_loading_at_once = max_zones_loading_at_once.clone();
             let zone_updated_tx = zone_updated_tx.clone();
             let receipt_info = receipt_info.clone();
+            let center = self.center.clone();
             tokio::spawn(async move {
                 info!("[ZL]: Waiting to add zone '{name}' with source '{source:?}'");
                 let _permit = max_zones_loading_at_once.acquire().await.unwrap();
@@ -111,8 +117,14 @@ impl ZoneLoader {
                     }
 
                     ZoneLoadSource::Zonefile { path } => {
-                        match Self::register_primary_zone(name.clone(), &path, &zone_updated_tx)
-                            .await
+                        match Self::register_primary_zone(
+                            center,
+                            name.clone(),
+                            &path,
+                            &zone_updated_tx,
+                            receipt_info.clone(),
+                        )
+                        .await
                         {
                             Ok((zone, ri)) => {
                                 receipt_info.lock().unwrap().insert(name.clone(), ri);
@@ -200,6 +212,7 @@ impl ZoneLoader {
                 };
                 zone_maintainer.remove_zone(id).await;
                 let zone_maintainer = zone_maintainer.clone();
+                let center = self.center.clone();
 
                 tokio::spawn(async move {
                     let zone = match source {
@@ -209,8 +222,14 @@ impl ZoneLoader {
                         }
 
                         ZoneLoadSource::Zonefile { path } => {
-                            match Self::register_primary_zone(name.clone(), &path, &zone_updated_tx)
-                                .await
+                            match Self::register_primary_zone(
+                                center,
+                                name.clone(),
+                                &path,
+                                &zone_updated_tx,
+                                receipt_info.clone(),
+                            )
+                            .await
                             {
                                 Ok((zone, ri)) => {
                                     receipt_info.lock().unwrap().insert(name.clone(), ri);
@@ -271,13 +290,30 @@ impl ZoneLoader {
                 if let Ok(report) = zone_maintainer.zone_status(&zone_name, Class::IN).await {
                     let zone_loader_report = receipt_info.lock().unwrap().get(&zone_name).cloned();
                     report_tx.send((report, zone_loader_report)).unwrap();
+                } else {
+                    let report = ZoneReport::new(
+                        ZoneId::new(zone_name.clone(), Class::IN),
+                        ZoneReportDetails::Primary,
+                        vec![],
+                        ZoneInfo::default(),
+                    );
+                    let zone_loader_report = receipt_info.lock().unwrap().get(&zone_name).cloned();
+                    report_tx.send((report, zone_loader_report)).unwrap();
                 }
             }
 
             Some(ApplicationCommand::ReloadZone { zone_name, source }) => match source {
                 ZoneLoadSource::None => return Ok(()),
                 ZoneLoadSource::Zonefile { path } => {
-                    Self::remove_and_add(zone_name, path, zone_maintainer, &zone_updated_tx).await?
+                    Self::remove_and_add(
+                        self.center.clone(),
+                        zone_name,
+                        path,
+                        zone_maintainer,
+                        &zone_updated_tx,
+                        receipt_info,
+                    )
+                    .await?
                 }
                 ZoneLoadSource::Server { .. } => {
                     zone_maintainer
@@ -295,10 +331,12 @@ impl ZoneLoader {
     }
 
     async fn remove_and_add<KS, CF>(
+        center: Arc<Center>,
         name: StoredName,
         path: Box<Utf8Path>,
         zone_maintainer: Arc<ZoneMaintainer<KS, CF>>,
         zone_updated_tx: &Sender<(StoredName, Serial)>,
+        receipt_info: Arc<Mutex<HashMap<StoredName, ZoneLoaderReport>>>,
     ) -> Result<(), Terminated>
     where
         KS: Deref + Send + Sync + 'static,
@@ -313,7 +351,9 @@ impl ZoneLoader {
         };
         zone_maintainer.remove_zone(id).await;
 
-        let (zone, _) = Self::register_primary_zone(name.clone(), &path, zone_updated_tx).await?;
+        let (zone, _) =
+            Self::register_primary_zone(center, name.clone(), &path, zone_updated_tx, receipt_info)
+                .await?;
 
         // TODO: Handle (or iron out) potential errors here.
         let _ = zone_maintainer.insert_zone(zone).await;
@@ -321,19 +361,22 @@ impl ZoneLoader {
     }
 
     async fn register_primary_zone(
+        center: Arc<Center>,
         zone_name: StoredName,
         zone_path: &Utf8Path,
         zone_updated_tx: &Sender<(Name<Bytes>, Serial)>,
+        receipt_info: Arc<Mutex<HashMap<StoredName, ZoneLoaderReport>>>,
     ) -> Result<(TypedZone, ZoneLoaderReport), Terminated> {
-        let started_at = SystemTime::now();
-        let (zone, byte_count) = {
+        let (zone, _byte_count) = {
             let zone_name = zone_name.clone();
             let zone_path: Box<Utf8Path> = zone_path.into();
-            tokio::task::spawn_blocking(move || load_file_into_zone(&zone_name, &zone_path))
-                .await
-                .unwrap_or(Err(Terminated))?
+            let cloned_receipt_info = receipt_info.clone();
+            tokio::task::spawn_blocking(move || {
+                load_file_into_zone(center, &zone_name, &zone_path, cloned_receipt_info)
+            })
+            .await
+            .unwrap_or(Err(Terminated))?
         };
-        let duration = SystemTime::now().duration_since(started_at).unwrap();
         let Some(serial) = get_zone_serial(zone_name.clone(), &zone).await else {
             error!("[ZL]: Zone file '{zone_path}' lacks a SOA record. Skipping zone.");
             return Err(Terminated);
@@ -345,12 +388,13 @@ impl ZoneLoader {
             .await
             .unwrap();
         let zone = Zone::new(NotifyOnWriteZone::new(zone, zone_updated_tx.clone()));
-        let receipt_info = ZoneLoaderReport {
-            started_at,
-            finished_at: started_at.checked_add(duration).unwrap(),
-            byte_count,
-        };
-        Ok((TypedZone::new(zone, zone_cfg), receipt_info))
+        let report = receipt_info
+            .lock()
+            .unwrap()
+            .get(&zone_name)
+            .cloned()
+            .unwrap();
+        Ok((TypedZone::new(zone, zone_cfg), report))
     }
 
     fn register_secondary_zone(
@@ -406,11 +450,13 @@ async fn get_zone_serial(apex_name: Name<Bytes>, zone: &Zone) -> Option<Serial> 
 }
 
 fn load_file_into_zone(
+    center: Arc<Center>,
     zone_name: &StoredName,
     zone_path: &Utf8Path,
+    receipt_info: Arc<Mutex<HashMap<StoredName, ZoneLoaderReport>>>,
 ) -> Result<(Zone, usize), Terminated> {
     let before = Instant::now();
-    info!("[ZL]: Loading primary zone '{zone_name}' from '{zone_path}'..",);
+    log::info!("[ZL]: Loading primary zone '{zone_name}' from '{zone_path}'..");
     let mut zone_file = File::open(zone_path)
         .inspect_err(|err| error!("[ZL]: Failed to open zone file '{zone_path}': {err}",))
         .map_err(|_| Terminated)?;
@@ -420,26 +466,103 @@ fn load_file_into_zone(
         .map_err(|_| Terminated)?
         .len();
 
+    let report = ZoneLoaderReport {
+        started_at: SystemTime::now(),
+        finished_at: None,
+        byte_count: zone_file_len.try_into().unwrap_or_default(),
+        record_count: 0,
+    };
+    let _ = receipt_info
+        .lock()
+        .unwrap()
+        .insert(zone_name.clone(), report);
+
+    debug!("[ZL]: Allocating {zone_file_len} bytes to read zone '{zone_name}' from '{zone_path}");
     let mut buf = inplace::Zonefile::with_capacity(zone_file_len as usize).writer();
+
+    debug!("[ZL]: Reading {zone_file_len} bytes for zone '{zone_name}' from '{zone_path}");
     std::io::copy(&mut zone_file, &mut buf)
         .inspect_err(|err| error!("[ZL]: Failed to read data from file '{zone_path}': {err}",))
         .map_err(|_| Terminated)?;
     let mut reader = buf.into_inner();
     reader.set_origin(zone_name.clone());
-    let res = Zone::try_from(reader);
-    let Ok(zone) = res else {
-        let errors = res.unwrap_err();
-        let mut msg = format!("Got {} errors", errors.len());
-        for (name, err) in errors.into_iter() {
-            msg.push_str(&format!("  {name}: {err}\n"));
+
+    debug!("[ZL]: Parsing stage 1 {zone_file_len} bytes of zone '{zone_name}' data");
+    let mut parsed_zone_file = Zonefile::default();
+    let mut rr_count = 0;
+    let mut loading_error = None;
+
+    for res in reader {
+        match res.map_err(RecordError::MalformedRecord) {
+            Ok(Entry::Record(r)) => {
+                let stored_rec = r.flatten_into();
+                // let name = stored_rec.owner().clone();
+                if let Err(err) = parsed_zone_file.insert(stored_rec) {
+                    error!("[ZL]: Unable to parse record in '{zone_name}': {err}");
+                    loading_error = Some(err.to_string());
+                    break;
+                }
+
+                rr_count += 1;
+                if rr_count % 1000 == 0 {
+                    if let Some(ri) = receipt_info.lock().unwrap().get_mut(zone_name) {
+                        ri.record_count = rr_count;
+                    }
+                }
+            }
+
+            Ok(Entry::Include { .. }) => {
+                // Not supported at this time.
+                error!("[ZL] Zone file $INCLUDE directive in zone '{zone_name}' is not supported");
+                loading_error =
+                    Some("Zone file contains unsupported $INCLUDE directive".to_string());
+                break;
+            }
+
+            Err(err) => {
+                // The inplace::Zonefile parser is not capable of
+                // continuing after an error, so we immediately return for
+                // now.
+                error!("[ZL]: Fatal error while parsing zone '{zone_name}': {err}");
+                loading_error = Some(err.to_string());
+                break;
+            }
         }
-        error!("[ZL]: Failed to parse zone '{zone_name}': {msg}");
+    }
+
+    if let Some(err) = loading_error {
+        halt_zone(
+            &center,
+            zone_name,
+            true,
+            &format!("Encountered an error while loading the zone: {err}"),
+        );
+        return Err(Terminated);
+    }
+
+    debug!("[ZL]: Parsing stage 2 of zone '{zone_name}' data");
+    let res = ZoneBuilder::try_from(parsed_zone_file).map(Zone::from);
+    let Ok(zone) = res else {
+        let err = format!("{}", res.unwrap_err());
+        error!("[ZL]: Failed to build a zone tree for '{zone_name}': {err}");
+        halt_zone(
+            &center,
+            zone_name,
+            true,
+            &format!("Encountered an error while loading the zone: {err}"),
+        );
         return Err(Terminated);
     };
     info!(
         "Loaded {zone_file_len} bytes from '{zone_path}' in {} secs",
         before.elapsed().as_secs()
     );
+
+    if let Some(ri) = receipt_info.lock().unwrap().get_mut(zone_name) {
+        ri.record_count = rr_count;
+        ri.finished_at = Some(SystemTime::now());
+    }
+
     Ok((zone, zone_file_len as usize))
 }
 

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -38,7 +38,7 @@ use log::{debug, error, info, trace};
 use rayon::slice::ParallelSliceMut;
 use serde::{Deserialize, Serialize};
 use tokio::select;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, OwnedSemaphorePermit};
 use tokio::sync::{oneshot, RwLock, Semaphore};
 use tokio::task::spawn_blocking;
 use tokio::time::{sleep_until, Instant};
@@ -54,7 +54,7 @@ use crate::payload::Update;
 use crate::policy::{PolicyVersion, SignerDenialPolicy, SignerSerialPolicy};
 use crate::units::http_server::KmipServerState;
 use crate::units::key_manager::{KmipClientCredentialsFile, KmipServerCredentialsFileMode};
-use crate::zone::{HistoricalEventType, SigningTrigger};
+use crate::zone::{HistoricalEventType, PipelineMode, SigningTrigger};
 use crate::zonemaintenance::types::{
     serialize_duration_as_secs, serialize_instant_as_duration_secs, serialize_opt_duration_as_secs,
     SigningFinishedReport, SigningInProgressReport, SigningReport, SigningRequestedReport,
@@ -178,6 +178,7 @@ impl ZoneSignerUnit {
 struct ZoneSigner {
     center: Arc<Center>,
     use_lightweight_zone_tree: bool,
+    max_concurrent_operations: usize,
     concurrent_operation_permits: Semaphore,
     max_concurrent_rrsig_generation_tasks: usize,
     signer_status: Arc<RwLock<ZoneSignerStatus>>,
@@ -203,9 +204,10 @@ impl ZoneSigner {
         Self {
             center,
             use_lightweight_zone_tree,
+            max_concurrent_operations,
             concurrent_operation_permits: Semaphore::new(max_concurrent_operations),
             max_concurrent_rrsig_generation_tasks,
-            signer_status: Default::default(),
+            signer_status: Arc::new(RwLock::new(ZoneSignerStatus::new())),
             _treat_single_keys_as_csks: treat_single_keys_as_csks,
             kmip_servers: Default::default(),
             keys_dir,
@@ -365,8 +367,17 @@ impl ZoneSigner {
         // newest will overwrite the oldest. When the permit is then finally
         // acquired, further down where start() is invoked it will fail
         // because the enqueued status item will no longer exist...
-        info!("[ZS]: Waiting to start signing operation for zone '{zone_name}'.");
-        self.signer_status.write().await.enqueue(zone_name.clone());
+        info!("[ZS]: Waiting to enqueue signing operation for zone '{zone_name}'.");
+        let (q_size, _q_permit, _zone_permit) = {
+            let mut signer_status = self.signer_status.write().await;
+            signer_status.enqueue(zone_name.clone()).await?
+        };
+
+        let num_ops_in_progress =
+            self.max_concurrent_operations - self.concurrent_operation_permits.available_permits();
+        info!(
+            "[ZS]: Waiting to start signing operation for zone '{zone_name}': {num_ops_in_progress} signing operations are in progress and {} operations are queued ahead of us.", q_size - 1
+        );
 
         let _permit = self.concurrent_operation_permits.acquire().await.unwrap();
         info!("[ZS]: Starting signing operation for zone '{zone_name}'");
@@ -399,6 +410,12 @@ impl ZoneSigner {
             let state = self.center.state.lock().unwrap();
             let zone = state.zones.get(zone_name).unwrap();
             let zone_state = zone.0.state.lock().unwrap();
+
+            // Do NOT sign a zone that is halted.
+            if zone_state.pipeline_mode != PipelineMode::Running {
+                return Err(format!("Zone '{zone_name}' is halted"));
+            }
+
             let last_signed_serial = zone_state
                 .find_last_event(HistoricalEventType::SigningSucceeded, None)
                 .and_then(|item| item.serial);
@@ -477,10 +494,14 @@ impl ZoneSigner {
             new_soa,
         );
 
+        //
+        // Record the start of signing for this zone.
+        //
         self.signer_status
             .write()
             .await
-            .start(zone_name, soa.serial());
+            .start(zone_name, soa.serial())
+            .await?;
 
         //
         // Lookup the signed zone to update, or create a new empty zone to
@@ -1534,15 +1555,13 @@ impl ZoneSigningStatus {
         Self::Requested(RequestedStatus::new())
     }
 
-    fn start(self, zone_serial: Serial) -> Self {
+    #[allow(clippy::result_large_err)]
+    fn start(self, zone_serial: Serial) -> Result<Self, Self> {
         match self {
             ZoneSigningStatus::Requested(s) => {
-                Self::InProgress(InProgressStatus::new(s, zone_serial))
+                Ok(Self::InProgress(InProgressStatus::new(s, zone_serial)))
             }
-            ZoneSigningStatus::InProgress(_) => self,
-            ZoneSigningStatus::Finished(_) => {
-                panic!("Cannot start a signing operation that already finished")
-            }
+            ZoneSigningStatus::InProgress(_) | ZoneSigningStatus::Finished(_) => Err(self),
         }
     }
 
@@ -1557,9 +1576,19 @@ impl ZoneSigningStatus {
     }
 }
 
+impl std::fmt::Display for ZoneSigningStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ZoneSigningStatus::Requested(_) => f.write_str("Requested"),
+            ZoneSigningStatus::InProgress(_) => f.write_str("InProgress"),
+            ZoneSigningStatus::Finished(_) => f.write_str("Finished"),
+        }
+    }
+}
+
 //------------ ZoneSignerStatus ----------------------------------------------
 
-const MAX_SIGNING_HISTORY: usize = 100;
+const SIGNING_QUEUE_SIZE: usize = 100;
 
 #[derive(Serialize)]
 struct NamedZoneSigningStatus {
@@ -1567,15 +1596,27 @@ struct NamedZoneSigningStatus {
     status: ZoneSigningStatus,
 }
 
-#[derive(Serialize)]
 struct ZoneSignerStatus {
     // Maps zone names to signing status, keeping records of previous signing.
     // Use VecDeque for its ability to act as a ring buffer: check size, if
     // at max desired capacity pop_front(), then in both cases push_back().
     zones_being_signed: VecDeque<NamedZoneSigningStatus>,
+
+    // Sign each zone only once at a time.
+    zone_semaphores: HashMap<StoredName, Arc<Semaphore>>,
+
+    queue_semaphore: Arc<Semaphore>,
 }
 
 impl ZoneSignerStatus {
+    pub fn new() -> Self {
+        Self {
+            zones_being_signed: VecDeque::with_capacity(SIGNING_QUEUE_SIZE),
+            zone_semaphores: Default::default(),
+            queue_semaphore: Arc::new(Semaphore::new(SIGNING_QUEUE_SIZE)),
+        }
+    }
+
     #[allow(dead_code)]
     pub fn get(&self, wanted_zone_name: &StoredName) -> Option<&NamedZoneSigningStatus> {
         self.zones_being_signed
@@ -1589,28 +1630,59 @@ impl ZoneSignerStatus {
             .rfind(|v| v.zone_name == wanted_zone_name)
     }
 
-    pub fn enqueue(&mut self, zone_name: StoredName) {
+    /// Enqueue a zone for signing.
+    pub async fn enqueue(
+        &mut self,
+        zone_name: StoredName,
+    ) -> Result<(usize, OwnedSemaphorePermit, OwnedSemaphorePermit), String> {
+        let approx_q_size = SIGNING_QUEUE_SIZE - self.queue_semaphore.available_permits() + 1;
+        let queue_permit = self
+            .queue_semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|err| format!("Attempt to enqueue '{zone_name}' to sign failed: unable to acquire quue permit: {err}"))?;
         if self.zones_being_signed.len() == self.zones_being_signed.capacity() {
             // Discard oldest.
-            let _ = self.zones_being_signed.pop_front();
+            let signing_status = self.zones_being_signed.pop_front();
+            if let Some(signing_status) = signing_status {
+                if !matches!(signing_status.status, ZoneSigningStatus::Finished(_)) {
+                    return Err(format!("Attempt to enqueue '{zone_name}' to sign failed: next free queue item is not actually free but was for zone {} in state {}",
+                        signing_status.zone_name, signing_status.status));
+                }
+            }
         }
         self.zones_being_signed.push_back(NamedZoneSigningStatus {
-            zone_name,
+            zone_name: zone_name.clone(),
             status: ZoneSigningStatus::new(),
         });
+
+        let zone_permit = self.zone_semaphores
+            .entry(zone_name.clone())
+            .or_insert(Arc::new(Semaphore::new(1)))
+            .clone()
+            .acquire_owned().await.map_err(|err| format!("Attempt to start signing zone '{zone_name}' failed: unable to acquire zone permit: {err}"))?;
+
+        Ok((approx_q_size, queue_permit, zone_permit))
     }
 
-    pub fn start(&mut self, zone_name: &StoredName, zone_serial: Serial) {
-        let res = self.get_mut(zone_name);
-        if matches!(
-            res,
-            Some(NamedZoneSigningStatus {
-                status: ZoneSigningStatus::Requested(..),
-                ..
-            })
-        ) {
-            let named_status = res.unwrap();
-            named_status.status = named_status.status.start(zone_serial);
+    /// Record the start of signing the specified zone.
+    ///
+    /// Note: Callers must call enqueue() before calling this function..
+    pub async fn start(
+        &mut self,
+        zone_name: &StoredName,
+        zone_serial: Serial,
+    ) -> Result<(), String> {
+        if let Some(NamedZoneSigningStatus {
+            status: status @ ZoneSigningStatus::Requested(..),
+            zone_name,
+        }) = self.get_mut(zone_name)
+        {
+            *status = status.start(zone_serial).map_err(|s| format!("Attempt to start signing serial {zone_serial} of zone '{zone_name} failed: queued request should be in the requested state but is in the {s} state"))?;
+            Ok(())
+        } else {
+            Err(format!("Attempt to start signing serial {zone_serial} of zone '{zone_name}' failed: no signing request found for this zone in the signing queue"))
         }
     }
 
@@ -1636,14 +1708,6 @@ impl ZoneSignerStatus {
         ) {
             let named_status = res.unwrap();
             named_status.status = named_status.status.finish();
-        }
-    }
-}
-
-impl Default for ZoneSignerStatus {
-    fn default() -> Self {
-        Self {
-            zones_being_signed: VecDeque::with_capacity(MAX_SIGNING_HISTORY),
         }
     }
 }

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -134,7 +134,7 @@ impl ZoneState {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub enum PipelineMode {
     /// Newly received zone data will flow through the pipeline.
     #[default]

--- a/src/zonemaintenance/types.rs
+++ b/src/zonemaintenance/types.rs
@@ -937,7 +937,7 @@ pub struct ZoneReport {
 }
 
 impl ZoneReport {
-    pub(super) fn new(
+    pub fn new(
         zone_id: ZoneId,
         details: ZoneReportDetails,
         timers: Vec<ZoneRefreshInstant>,


### PR DESCRIPTION
Investigating one bug led to another and another, I fixed them as I found them. But this grew bigger than I intended. Normally I wouldn't pack this all together in one PR but we're a bit short on time. Sorry for that.

- Halt the pipeline on zone loading error and report the error in the logs and in zone status.
- Show zone loading progress.
- Don't attempt to make a zone available for review if the pipeline is halted.
- Don't attempt to sign a zone if the pipeline is halted.
- Some minor Clippy fixes.
- Include the filesystem path associated with some errors.
- Run keyset commands on the Tokio blocking task pool to prevent blocking Tokio for long running tasks.
- Log the duration of keyset commands.
- Add some more debug logging during zone loading.
- Don't use the domain zone loading helpers, use the underlying code for more control and more reporting.
- Don't attempt to sign a zone for which signing is already in progress, instead leave it queueing.

Also resolves:
- https://github.com/orgs/NLnetLabs/projects/24/views/3?pane=issue&itemId=131442686