### PR TITLE
Initialize logger from config until state is available

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,14 @@ fn main() -> ExitCode {
         }
     };
 
+    // Initially activate the logging with the setting from the config
+    logger.apply(
+        logger
+            .prepare(&config.daemon.logging)
+            .unwrap()
+            .unwrap(),
+    );
+
     if matches.get_flag("check_config") {
         // Try reading the configuration file.
         match config.init_from_file() {
@@ -92,6 +100,14 @@ fn main() -> ExitCode {
 
         // TODO: Fail if any zone state files exist.
     } else {
+        // If continuing from state update the configured logging setup.
+        logger.apply(
+            logger
+                .prepare(&state.config.daemon.logging)
+                .unwrap()
+                .unwrap(),
+        );
+
         log::info!("Successfully loaded the global state file");
 
         let zone_state_dir = &state.config.zone_state_dir;
@@ -127,14 +143,6 @@ fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
     }
-
-    // Activate the configured logging setup.
-    logger.apply(
-        logger
-            .prepare(&state.config.daemon.logging)
-            .unwrap()
-            .unwrap(),
-    );
 
     // Bind to listen addresses before daemonizing.
     let Ok(socket_provider) = bind_to_listen_sockets_as_needed(&state) else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,12 +47,7 @@ fn main() -> ExitCode {
     };
 
     // Initially activate the logging with the setting from the config
-    logger.apply(
-        logger
-            .prepare(&config.daemon.logging)
-            .unwrap()
-            .unwrap(),
-    );
+    logger.apply(logger.prepare(&config.daemon.logging).unwrap().unwrap());
 
     if matches.get_flag("check_config") {
         // Try reading the configuration file.


### PR DESCRIPTION
Logs with level higher than info were not logged during the continuing from existing state setup in main.rs.

Before:
```
$ cargo run -- --config config.toml --state state.db
   Compiling cascade v0.1.0-rc1 (/home/mozzie/repos/work/cascade.trees/main)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.95s
     Running `/home/mozzie/repos/work/cascade.trees/main/target/debug/cascaded --config config.toml --state state.db`
Adding policy 'default' from global state
Adding policy 'some' from global state
Adding zone 'example.com' from global state
Successfully loaded the global state file
[2025-10-03T09:39:48.152Z] INFO cascade::manager: Starting target 'CC'
```

After:
```
$ cargo run -- --config config.toml --state state.db
   Compiling cascade v0.1.0-rc1 (/home/mozzie/repos/work/cascade.trees/main)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.93s
     Running `/home/mozzie/repos/work/cascade.trees/main/target/debug/cascaded --config config.toml --state state.db`
[2025-10-03T09:47:16.514Z] INFO cascade::state::v1: Adding policy 'some' from global state
[2025-10-03T09:47:16.514Z] INFO cascade::state::v1: Adding policy 'default' from global state
[2025-10-03T09:47:16.514Z] INFO cascade::state::v1: Adding zone 'example.com' from global state
[2025-10-03T09:47:16.514Z] INFO cascaded: Successfully loaded the global state file
[2025-10-03T09:47:16.515Z] DEBUG cascaded: Loaded state of zone 'example.com' (from zone-state/example.com.db)
[2025-10-03T09:47:16.515Z] DEBUG cascaded: Loaded the TSIG store
[2025-10-03T09:47:16.516Z] INFO cascade::manager: Starting target 'CC'
```