### PR TITLE
Fix panic if cascade was restarted after initially having no log-level set in config

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -108,10 +108,9 @@ fn main() -> ExitCode {
     } else {
         // If continuing from state update the configured logging setup.
         // Only update logger if a log setting has been persistet in state before
-        match logger.prepare(&state.config.daemon.logging).unwrap() {
-            Some(x) => logger.apply(x),
-            None => {}
-        };
+        if let Some(x) = logger.prepare(&state.config.daemon.logging).unwrap() {
+            logger.apply(x)
+        }
 
         log::info!("Successfully loaded the global state file");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,12 +107,11 @@ fn main() -> ExitCode {
         // TODO: Fail if any zone state files exist.
     } else {
         // If continuing from state update the configured logging setup.
-        logger.apply(
-            logger
-                .prepare(&state.config.daemon.logging)
-                .unwrap()
-                .unwrap(),
-        );
+        // Only update logger if a log setting has been persistet in state before
+        match logger.prepare(&state.config.daemon.logging).unwrap() {
+            Some(x) => logger.apply(x),
+            None => {}
+        };
 
         log::info!("Successfully loaded the global state file");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ fn main() -> ExitCode {
         // TODO: Fail if any zone state files exist.
     } else {
         // If continuing from state update the configured logging setup.
-        // Only update logger if a log setting has been persistet in state before
+        // Only update logger if a log setting was persisted in state before
         if let Some(x) = logger.prepare(&state.config.daemon.logging).unwrap() {
             logger.apply(x)
         }


### PR DESCRIPTION
Steps to issue:
- Start cascade from scratch and have no log-level set in config
- Restart cascade
- Observe panic:
```
$ cascaded --config config.toml --state state.db --log-level info
[2025-10-04T16:06:27.409Z] INFO cascade::state::v1: Adding policy 'some' from global state

thread 'main' panicked at src/main.rs:114:18:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Fixing the underlying problem might be that the state should not persist `{"logging":{"level":null,...` and instead persist the default log level (that is also used for the running instance), but I did not want to investigate how to do that right now, so I just fixed the panic itself.