### PR TITLE
Track and report zone loading progress and loading errors.

### DIFF
--- a/src/cli/commands/zone.rs
+++ b/src/cli/commands/zone.rs
@@ -528,31 +528,57 @@ impl Progress {
     fn print_zone_received(&self, zone: &ZoneStatus) {
         // TODO: we have no indication of whether a zone is currently being
         // received or not, we can only say if it was received after the fact.
-        println!(
-            "{} Loaded {}",
-            status_icon(true),
-            serial_to_string(zone.unsigned_serial),
-        );
-
         // Print how receival of the zone went.
         let Some(report) = &zone.receipt_report else {
-            unreachable!();
+            // This shouldn't happen.
+            println!(
+                "{}\u{78} The receipt report for this zone is unavailable.{}",
+                ansi::RED,
+                ansi::RESET
+            );
+            return;
         };
-        let (loaded_fetched, filesystem_network) = match zone.source {
+
+        let (loading_fetching, loaded_fetched, filesystem_network) = match zone.source {
             ZoneSource::None => unreachable!(),
-            ZoneSource::Zonefile { .. } => ("Loaded", "filesystem"),
-            ZoneSource::Server { .. } => ("Fetched", "network"),
+            ZoneSource::Zonefile { .. } => ("Loading", "Loaded", "filesystem"),
+            ZoneSource::Server { .. } => ("Fetching", "Fetched", "network"),
         };
-        println!("  Loaded at {}", to_rfc3339_ago(report.finished_at));
-        println!(
-            "  {loaded_fetched} {} from the {filesystem_network} in {} seconds",
-            format_size(report.byte_count, " ", "B"),
-            report
-                .finished_at
-                .duration_since(report.started_at)
-                .unwrap()
-                .as_secs()
-        );
+
+        match report.finished_at {
+            None => {
+                println!("{} {loading_fetching} ..", status_icon(false),);
+
+                println!(
+                    "  {loaded_fetched} {} and {} in {} seconds",
+                    format_size(report.byte_count, " ", "B"),
+                    format_size(report.record_count, "", " records"),
+                    SystemTime::now()
+                        .duration_since(report.started_at)
+                        .unwrap()
+                        .as_secs()
+                );
+            }
+            Some(finished_at) => {
+                println!(
+                    "{} Loaded {}",
+                    status_icon(true),
+                    serial_to_string(zone.unsigned_serial),
+                );
+
+                println!("  Loaded at {}", to_rfc3339_ago(report.finished_at));
+
+                println!(
+                    "  {loaded_fetched} {} and {} from the {filesystem_network} in {} seconds",
+                    format_size(report.byte_count, " ", "B"),
+                    format_size(report.record_count, "", " records"),
+                    finished_at
+                        .duration_since(report.started_at)
+                        .unwrap()
+                        .as_secs()
+                );
+            }
+        }
     }
 
     fn print_pending_unsigned_review(&self, zone: &ZoneStatus, policy: &PolicyInfo) {
@@ -662,10 +688,16 @@ impl Progress {
         if let Some(report) = &zone.signing_report {
             match report {
                 SigningReport::Requested(r) => {
-                    println!("  Signing requested at {}", to_rfc3339_ago(r.requested_at));
+                    println!(
+                        "  Signing requested at {}",
+                        to_rfc3339_ago(Some(r.requested_at))
+                    );
                 }
                 SigningReport::InProgress(r) => {
-                    println!("  Signing started at {}", to_rfc3339_ago(r.started_at));
+                    println!(
+                        "  Signing started at {}",
+                        to_rfc3339_ago(Some(r.started_at))
+                    );
                     if let (Some(unsigned_rr_count), Some(total_time)) =
                         (r.unsigned_rr_count, r.total_time)
                     {
@@ -677,7 +709,7 @@ impl Progress {
                     }
                 }
                 SigningReport::Finished(r) => {
-                    println!("  Signed at {}", to_rfc3339_ago(r.finished_at));
+                    println!("  Signed at {}", to_rfc3339_ago(Some(r.finished_at)));
                     println!(
                         "  Signed {} in {}",
                         format_size(r.unsigned_rr_count, "", " records"),
@@ -711,11 +743,16 @@ fn serial_to_string(serial: Option<Serial>) -> String {
     }
 }
 
-fn to_rfc3339_ago(v: SystemTime) -> String {
-    let now = SystemTime::now();
-    let diff = now.duration_since(v).unwrap();
-    let rfc3339 = to_rfc3339(v);
-    format!("{rfc3339} ({} ago)", format_duration(diff))
+fn to_rfc3339_ago(v: Option<SystemTime>) -> String {
+    match v {
+        Some(v) => {
+            let now = SystemTime::now();
+            let diff = now.duration_since(v).unwrap();
+            let rfc3339 = to_rfc3339(v);
+            format!("{rfc3339} ({} ago)", format_duration(diff))
+        }
+        None => "Not yet finished".to_string(),
+    }
 }
 
 fn to_rfc3339(v: SystemTime) -> String {

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -240,9 +240,11 @@ impl HttpServer {
         state: Arc<HttpServerState>,
         name: Name<Bytes>,
     ) -> Result<ZoneStatus, ZoneStatusError> {
+        let mut zone_started_at = None;
         let mut zone_loaded_at = None;
         let mut zone_loaded_in = None;
         let mut zone_loaded_bytes = 0;
+        let mut zone_loaded_record_count = 0;
         let dnst_binary_path;
         let cfg_path;
         let state_path;
@@ -409,10 +411,26 @@ impl HttpServer {
             match zone_maintainer_report.details() {
                 ZoneReportDetails::Primary => {
                     if let Some(report) = zone_loader_report {
-                        if let Ok(duration) = report.finished_at.duration_since(report.started_at) {
-                            zone_loaded_in = Some(duration);
-                            zone_loaded_at = Some(report.finished_at);
+                        zone_started_at = Some(report.started_at);
+                        if let Some(finished_at) = report.finished_at {
+                            if let Ok(duration) = finished_at.duration_since(report.started_at) {
+                                zone_loaded_in = Some(duration);
+                                zone_loaded_at = Some(finished_at);
+                                zone_loaded_bytes = report.byte_count;
+                                zone_loaded_record_count = report.record_count;
+                            } else {
+                                zone_loaded_in = Some(
+                                    SystemTime::now().duration_since(report.started_at).unwrap(),
+                                );
+                                zone_loaded_at = None;
+                                zone_loaded_bytes = report.byte_count;
+                                zone_loaded_record_count = report.record_count;
+                            }
+                        } else {
+                            zone_loaded_in = None;
+                            zone_loaded_at = None;
                             zone_loaded_bytes = report.byte_count;
+                            zone_loaded_record_count = report.record_count;
                         }
                     }
                 }
@@ -479,17 +497,30 @@ impl HttpServer {
             }
         }
 
-        let receipt_report =
-            if let (Some(finished_at), Some(zone_loaded_in)) = (zone_loaded_at, zone_loaded_in) {
-                let started_at = finished_at.checked_sub(zone_loaded_in).unwrap();
+        let receipt_report = match (zone_loaded_at, zone_loaded_in, zone_started_at) {
+            (Some(finished_at), Some(zone_loaded_in), started_at) => {
+                let started_at = match started_at {
+                    Some(started_at) => started_at,
+                    None => finished_at.checked_sub(zone_loaded_in).unwrap(),
+                };
                 Some(ZoneLoaderReport {
                     started_at,
-                    finished_at,
+                    finished_at: Some(finished_at),
                     byte_count: zone_loaded_bytes,
+                    record_count: zone_loaded_record_count,
                 })
-            } else {
+            }
+            (finished_at, None, Some(started_at)) => Some(ZoneLoaderReport {
+                started_at,
+                finished_at,
+                byte_count: zone_loaded_bytes,
+                record_count: zone_loaded_record_count,
+            }),
+            other => {
+                warn!("Unable to provide receipt report for zone '{name}': {other:?}");
                 None
-            };
+            }
+        };
 
         // Query zone serials
         let mut unsigned_serial = None;

--- a/src/units/zone_loader.rs
+++ b/src/units/zone_loader.rs
@@ -11,14 +11,17 @@ use std::time::SystemTime;
 use bytes::{BufMut, Bytes};
 use camino::Utf8Path;
 use domain::base::iana::{Class, Rcode};
+use domain::base::name::FlattenInto;
 use domain::base::{Name, Rtype, Serial};
 use domain::net::server::middleware::notify::Notifiable;
 use domain::rdata::ZoneRecordData;
 use domain::tsig::KeyStore;
-use domain::zonefile::inplace;
+use domain::zonefile::inplace::{self, Entry};
+use domain::zonetree::error::RecordError;
+use domain::zonetree::parsed::Zonefile;
 use domain::zonetree::{
     AnswerContent, InMemoryZoneDiff, ReadableZone, StoredName, WritableZone, WritableZoneNode,
-    Zone, ZoneStore,
+    Zone, ZoneBuilder, ZoneStore,
 };
 use foldhash::HashMap;
 use futures::Future;
@@ -31,7 +34,7 @@ use tokio::time::Instant;
 #[cfg(feature = "tls")]
 use tokio_rustls::rustls::ServerConfig;
 
-use crate::center::{Center, Change};
+use crate::center::{halt_zone, Center, Change};
 use crate::common::light_weight_zone::LightWeightZone;
 use crate::comms::{ApplicationCommand, Terminated};
 use crate::payload::Update;
@@ -40,14 +43,16 @@ use crate::zonemaintenance::maintainer::{
     Config, ConnectionFactory, DefaultConnFactory, TypedZone, ZoneMaintainer,
 };
 use crate::zonemaintenance::types::{
-    NotifyConfig, TransportStrategy, XfrConfig, XfrStrategy, ZoneConfig, ZoneId,
+    NotifyConfig, TransportStrategy, XfrConfig, XfrStrategy, ZoneConfig, ZoneId, ZoneInfo,
+    ZoneReport, ZoneReportDetails,
 };
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ZoneLoaderReport {
     pub started_at: SystemTime,
-    pub finished_at: SystemTime,
+    pub finished_at: Option<SystemTime>,
     pub byte_count: usize,
+    pub record_count: usize,
 }
 
 #[derive(Debug)]
@@ -99,6 +104,7 @@ impl ZoneLoader {
             let max_zones_loading_at_once = max_zones_loading_at_once.clone();
             let zone_updated_tx = zone_updated_tx.clone();
             let receipt_info = receipt_info.clone();
+            let center = self.center.clone();
             tokio::spawn(async move {
                 info!("[ZL]: Waiting to add zone '{name}' with source '{source:?}'");
                 let _permit = max_zones_loading_at_once.acquire().await.unwrap();
@@ -111,8 +117,14 @@ impl ZoneLoader {
                     }
 
                     ZoneLoadSource::Zonefile { path } => {
-                        match Self::register_primary_zone(name.clone(), &path, &zone_updated_tx)
-                            .await
+                        match Self::register_primary_zone(
+                            center,
+                            name.clone(),
+                            &path,
+                            &zone_updated_tx,
+                            receipt_info.clone(),
+                        )
+                        .await
                         {
                             Ok((zone, ri)) => {
                                 receipt_info.lock().unwrap().insert(name.clone(), ri);
@@ -200,6 +212,7 @@ impl ZoneLoader {
                 };
                 zone_maintainer.remove_zone(id).await;
                 let zone_maintainer = zone_maintainer.clone();
+                let center = self.center.clone();
 
                 tokio::spawn(async move {
                     let zone = match source {
@@ -209,8 +222,14 @@ impl ZoneLoader {
                         }
 
                         ZoneLoadSource::Zonefile { path } => {
-                            match Self::register_primary_zone(name.clone(), &path, &zone_updated_tx)
-                                .await
+                            match Self::register_primary_zone(
+                                center,
+                                name.clone(),
+                                &path,
+                                &zone_updated_tx,
+                                receipt_info.clone(),
+                            )
+                            .await
                             {
                                 Ok((zone, ri)) => {
                                     receipt_info.lock().unwrap().insert(name.clone(), ri);
@@ -271,13 +290,30 @@ impl ZoneLoader {
                 if let Ok(report) = zone_maintainer.zone_status(&zone_name, Class::IN).await {
                     let zone_loader_report = receipt_info.lock().unwrap().get(&zone_name).cloned();
                     report_tx.send((report, zone_loader_report)).unwrap();
+                } else {
+                    let report = ZoneReport::new(
+                        ZoneId::new(zone_name.clone(), Class::IN),
+                        ZoneReportDetails::Primary,
+                        vec![],
+                        ZoneInfo::default(),
+                    );
+                    let zone_loader_report = receipt_info.lock().unwrap().get(&zone_name).cloned();
+                    report_tx.send((report, zone_loader_report)).unwrap();
                 }
             }
 
             Some(ApplicationCommand::ReloadZone { zone_name, source }) => match source {
                 ZoneLoadSource::None => return Ok(()),
                 ZoneLoadSource::Zonefile { path } => {
-                    Self::remove_and_add(zone_name, path, zone_maintainer, &zone_updated_tx).await?
+                    Self::remove_and_add(
+                        self.center.clone(),
+                        zone_name,
+                        path,
+                        zone_maintainer,
+                        &zone_updated_tx,
+                        receipt_info,
+                    )
+                    .await?
                 }
                 ZoneLoadSource::Server { .. } => {
                     zone_maintainer
@@ -295,10 +331,12 @@ impl ZoneLoader {
     }
 
     async fn remove_and_add<KS, CF>(
+        center: Arc<Center>,
         name: StoredName,
         path: Box<Utf8Path>,
         zone_maintainer: Arc<ZoneMaintainer<KS, CF>>,
         zone_updated_tx: &Sender<(StoredName, Serial)>,
+        receipt_info: Arc<Mutex<HashMap<StoredName, ZoneLoaderReport>>>,
     ) -> Result<(), Terminated>
     where
         KS: Deref + Send + Sync + 'static,
@@ -313,7 +351,9 @@ impl ZoneLoader {
         };
         zone_maintainer.remove_zone(id).await;
 
-        let (zone, _) = Self::register_primary_zone(name.clone(), &path, zone_updated_tx).await?;
+        let (zone, _) =
+            Self::register_primary_zone(center, name.clone(), &path, zone_updated_tx, receipt_info)
+                .await?;
 
         // TODO: Handle (or iron out) potential errors here.
         let _ = zone_maintainer.insert_zone(zone).await;
@@ -321,19 +361,22 @@ impl ZoneLoader {
     }
 
     async fn register_primary_zone(
+        center: Arc<Center>,
         zone_name: StoredName,
         zone_path: &Utf8Path,
         zone_updated_tx: &Sender<(Name<Bytes>, Serial)>,
+        receipt_info: Arc<Mutex<HashMap<StoredName, ZoneLoaderReport>>>,
     ) -> Result<(TypedZone, ZoneLoaderReport), Terminated> {
-        let started_at = SystemTime::now();
-        let (zone, byte_count) = {
+        let (zone, _byte_count) = {
             let zone_name = zone_name.clone();
             let zone_path: Box<Utf8Path> = zone_path.into();
-            tokio::task::spawn_blocking(move || load_file_into_zone(&zone_name, &zone_path))
-                .await
-                .unwrap_or(Err(Terminated))?
+            let cloned_receipt_info = receipt_info.clone();
+            tokio::task::spawn_blocking(move || {
+                load_file_into_zone(center, &zone_name, &zone_path, cloned_receipt_info)
+            })
+            .await
+            .unwrap_or(Err(Terminated))?
         };
-        let duration = SystemTime::now().duration_since(started_at).unwrap();
         let Some(serial) = get_zone_serial(zone_name.clone(), &zone).await else {
             error!("[ZL]: Zone file '{zone_path}' lacks a SOA record. Skipping zone.");
             return Err(Terminated);
@@ -345,12 +388,13 @@ impl ZoneLoader {
             .await
             .unwrap();
         let zone = Zone::new(NotifyOnWriteZone::new(zone, zone_updated_tx.clone()));
-        let receipt_info = ZoneLoaderReport {
-            started_at,
-            finished_at: started_at.checked_add(duration).unwrap(),
-            byte_count,
-        };
-        Ok((TypedZone::new(zone, zone_cfg), receipt_info))
+        let report = receipt_info
+            .lock()
+            .unwrap()
+            .get(&zone_name)
+            .cloned()
+            .unwrap();
+        Ok((TypedZone::new(zone, zone_cfg), report))
     }
 
     fn register_secondary_zone(
@@ -406,11 +450,13 @@ async fn get_zone_serial(apex_name: Name<Bytes>, zone: &Zone) -> Option<Serial> 
 }
 
 fn load_file_into_zone(
+    center: Arc<Center>,
     zone_name: &StoredName,
     zone_path: &Utf8Path,
+    receipt_info: Arc<Mutex<HashMap<StoredName, ZoneLoaderReport>>>,
 ) -> Result<(Zone, usize), Terminated> {
     let before = Instant::now();
-    info!("[ZL]: Loading primary zone '{zone_name}' from '{zone_path}'..",);
+    log::info!("[ZL]: Loading primary zone '{zone_name}' from '{zone_path}'..");
     let mut zone_file = File::open(zone_path)
         .inspect_err(|err| error!("[ZL]: Failed to open zone file '{zone_path}': {err}",))
         .map_err(|_| Terminated)?;
@@ -420,26 +466,103 @@ fn load_file_into_zone(
         .map_err(|_| Terminated)?
         .len();
 
+    let report = ZoneLoaderReport {
+        started_at: SystemTime::now(),
+        finished_at: None,
+        byte_count: zone_file_len.try_into().unwrap_or_default(),
+        record_count: 0,
+    };
+    let _ = receipt_info
+        .lock()
+        .unwrap()
+        .insert(zone_name.clone(), report);
+
+    debug!("[ZL]: Allocating {zone_file_len} bytes to read zone '{zone_name}' from '{zone_path}");
     let mut buf = inplace::Zonefile::with_capacity(zone_file_len as usize).writer();
+
+    debug!("[ZL]: Reading {zone_file_len} bytes for zone '{zone_name}' from '{zone_path}");
     std::io::copy(&mut zone_file, &mut buf)
         .inspect_err(|err| error!("[ZL]: Failed to read data from file '{zone_path}': {err}",))
         .map_err(|_| Terminated)?;
     let mut reader = buf.into_inner();
     reader.set_origin(zone_name.clone());
-    let res = Zone::try_from(reader);
-    let Ok(zone) = res else {
-        let errors = res.unwrap_err();
-        let mut msg = format!("Got {} errors", errors.len());
-        for (name, err) in errors.into_iter() {
-            msg.push_str(&format!("  {name}: {err}\n"));
+
+    debug!("[ZL]: Parsing stage 1 {zone_file_len} bytes of zone '{zone_name}' data");
+    let mut parsed_zone_file = Zonefile::default();
+    let mut rr_count = 0;
+    let mut loading_error = None;
+
+    for res in reader {
+        match res.map_err(RecordError::MalformedRecord) {
+            Ok(Entry::Record(r)) => {
+                let stored_rec = r.flatten_into();
+                // let name = stored_rec.owner().clone();
+                if let Err(err) = parsed_zone_file.insert(stored_rec) {
+                    error!("[ZL]: Unable to parse record in '{zone_name}': {err}");
+                    loading_error = Some(err.to_string());
+                    break;
+                }
+
+                rr_count += 1;
+                if rr_count % 1000 == 0 {
+                    if let Some(ri) = receipt_info.lock().unwrap().get_mut(zone_name) {
+                        ri.record_count = rr_count;
+                    }
+                }
+            }
+
+            Ok(Entry::Include { .. }) => {
+                // Not supported at this time.
+                error!("[ZL] Zone file $INCLUDE directive in zone '{zone_name}' is not supported");
+                loading_error =
+                    Some("Zone file contains unsupported $INCLUDE directive".to_string());
+                break;
+            }
+
+            Err(err) => {
+                // The inplace::Zonefile parser is not capable of
+                // continuing after an error, so we immediately return for
+                // now.
+                error!("[ZL]: Fatal error while parsing zone '{zone_name}': {err}");
+                loading_error = Some(err.to_string());
+                break;
+            }
         }
-        error!("[ZL]: Failed to parse zone '{zone_name}': {msg}");
+    }
+
+    if let Some(err) = loading_error {
+        halt_zone(
+            &center,
+            zone_name,
+            true,
+            &format!("Encountered an error while loading the zone: {err}"),
+        );
+        return Err(Terminated);
+    }
+
+    debug!("[ZL]: Parsing stage 2 of zone '{zone_name}' data");
+    let res = ZoneBuilder::try_from(parsed_zone_file).map(Zone::from);
+    let Ok(zone) = res else {
+        let err = format!("{}", res.unwrap_err());
+        error!("[ZL]: Failed to build a zone tree for '{zone_name}': {err}");
+        halt_zone(
+            &center,
+            zone_name,
+            true,
+            &format!("Encountered an error while loading the zone: {err}"),
+        );
         return Err(Terminated);
     };
     info!(
         "Loaded {zone_file_len} bytes from '{zone_path}' in {} secs",
         before.elapsed().as_secs()
     );
+
+    if let Some(ri) = receipt_info.lock().unwrap().get_mut(zone_name) {
+        ri.record_count = rr_count;
+        ri.finished_at = Some(SystemTime::now());
+    }
+
     Ok((zone, zone_file_len as usize))
 }
 

--- a/src/zonemaintenance/types.rs
+++ b/src/zonemaintenance/types.rs
@@ -937,7 +937,7 @@ pub struct ZoneReport {
 }
 
 impl ZoneReport {
-    pub(super) fn new(
+    pub fn new(
         zone_id: ZoneId,
         details: ZoneReportDetails,
         timers: Vec<ZoneRefreshInstant>,


### PR DESCRIPTION
Replaces the helper zone loading code from `domain` with the actual code inside the helpers, in order to track loading progress, and extends the CLI and API and Zone Loader unit to make this information available and report it.