### PR TITLE
Fix case used when loading dnst state file.

### DIFF
--- a/src/units/key_manager.rs
+++ b/src/units/key_manager.rs
@@ -258,7 +258,9 @@ impl KeyManager {
             return Err(ZoneAddError::Other(format!("zone {name} already exists")));
         }
 
-        let state_path = self.keys_dir.join(format!("{name}.state"));
+        let state_path = self
+            .keys_dir
+            .join(format!("{}.state", name.to_string().to_lowercase()));
 
         let mut cmd = self.keyset_cmd(name.clone());
 
@@ -924,7 +926,7 @@ impl KeySetCommand {
         #[allow(clippy::boxed_local)] keys_dir: Box<Utf8Path>,
         #[allow(clippy::boxed_local)] dnst_binary_path: Box<Utf8Path>,
     ) -> Self {
-        let cfg_path = keys_dir.join(format!("{name}.cfg"));
+        let cfg_path = keys_dir.join(format!("{}.cfg", name.to_string().to_lowercase()));
         let mut cmd = Command::new(dnst_binary_path.as_std_path());
         cmd.arg("keyset").arg("-c").arg(&cfg_path);
         Self { cmd, name, center }

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -528,7 +528,7 @@ impl ZoneSigner {
         trace!("Reading dnst keyset DNSKEY RRs and RRSIG RRs");
         // Read the DNSKEY RRs and DNSKEY RRSIG RR from the keyset state.
         let apex_name = zone.apex_name().to_string();
-        let state_path = self.keys_dir.join(format!("{apex_name}.state"));
+        let state_path = self.keys_dir.join(format!("{}.state", apex_name.to_string().to_lowercase()));
         let state = std::fs::read_to_string(&state_path)
             .map_err(|err| format!("Unable to read `dnst keyset` state file '{state_path}' while signing zone {zone_name}: {err}"))?;
         let state: KeySetState = serde_json::from_str(&state).unwrap();


### PR DESCRIPTION
This PR fixes an issue when a zone origin is uppercase in a zone file:

```
[2025-10-05T12:34:36.758Z] ERROR cascade::units::zone_signer: [ZS]: Signing of zone 'COM' failed: Unable to read `dnst keyset` state file './cascade-data/keys/COM.state' while signing zone COM: No such file or directory (os error 2)
[2025-10-05T12:34:36.758Z] INFO cascade::targets::central_command: [CC]: Event received: ZoneSigningFailedEvent { zone_name: Name(COM.), zone_serial: Some(Serial(1567657265)), trigger: ZoneChangesApproved, reason: "Unable to read `dnst keyset` state file './cascade-data/k
eys/COM.state' while signing zone COM: No such file or directory (os error 2)" }
```