### PR TITLE
Canonicalize zonefile path before sending it to the server, and show zonefile loading errors in cascate zone status.

### DIFF
--- a/src/cli/commands/zone.rs
+++ b/src/cli/commands/zone.rs
@@ -2,7 +2,7 @@ use std::ops::ControlFlow;
 use std::time::{Duration, SystemTime};
 
 use bytes::Bytes;
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8PathBuf;
 use chrono::{DateTime, Utc};
 use domain::base::{Name, Serial};
 use futures::TryFutureExt;
@@ -655,6 +655,19 @@ impl Progress {
             waiting_waited,
             zone.name
         );
+
+        if let ZoneSource::Zonefile { path } = &zone.source {
+            if zone.receipt_report.is_none() {
+                println!("\u{78} Cascade has not yet started loading the zonefile.");
+                println!(
+                    "  Check that '{path}' is readable by Cascade at this path on the server."
+                );
+                println!(
+                    "  If the zone does not begin loading check for errors in the Cascade log."
+                );
+            }
+        }
+
         // TODO: When complete, show how long we waited.
     }
 

--- a/src/cli/commands/zone.rs
+++ b/src/cli/commands/zone.rs
@@ -2,7 +2,7 @@ use std::ops::ControlFlow;
 use std::time::{Duration, SystemTime};
 
 use bytes::Bytes;
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use chrono::{DateTime, Utc};
 use domain::base::{Name, Serial};
 use futures::TryFutureExt;
@@ -151,7 +151,7 @@ impl Zone {
         match self.command {
             ZoneCommand::Add {
                 name,
-                source,
+                mut source,
                 policy,
                 import_public_key,
                 import_ksk_file,
@@ -192,6 +192,16 @@ impl Zone {
                     .chain(import_csk_kmip)
                     .chain(import_zsk_kmip)
                     .collect();
+
+                if let ZoneSource::Zonefile { path } = &mut source {
+                    let canonicalized_path = path.canonicalize().map_err(|err| {
+                        format!("Failed to canonicalize zonefile path '{}': {err}", path)
+                    })?;
+                    let path_str = canonicalized_path.to_str().ok_or_else(|| {
+                        format!("Failed to convert path '{}'", canonicalized_path.display())
+                    })?;
+                    *path = Utf8PathBuf::from(path_str).into_boxed_path();
+                }
 
                 let res: Result<ZoneAddResult, ZoneAddError> = client
                     .post("zone/add")

--- a/src/units/zone_loader.rs
+++ b/src/units/zone_loader.rs
@@ -365,14 +365,21 @@ impl ZoneLoader {
         receipt_info: Arc<Mutex<HashMap<StoredName, ZoneLoaderReport>>>,
     ) -> Result<(TypedZone, ZoneLoaderReport), Terminated> {
         let (zone, _byte_count) = {
-            let zone_name = zone_name.clone();
-            let zone_path: Box<Utf8Path> = zone_path.into();
+            let cloned_zone_name = zone_name.clone();
+            let cloned_zone_path: Box<Utf8Path> = zone_path.into();
             let cloned_receipt_info = receipt_info.clone();
             tokio::task::spawn_blocking(move || {
-                load_file_into_zone(center, &zone_name, &zone_path, cloned_receipt_info)
+                load_file_into_zone(&cloned_zone_name, &cloned_zone_path, cloned_receipt_info)
             })
             .await
-            .unwrap_or(Err(Terminated))?
+            .map_err(|_| Terminated)?
+            .inspect_err(|err| {
+                let err_msg =
+                    format!("Failed to load zone '{zone_name}' from '{zone_path}': {err}");
+                halt_zone(&center, &zone_name, true, &err_msg);
+                error!("[ZL]: {err_msg}");
+            })
+            .map_err(|_| Terminated)?
         };
         let Some(serial) = get_zone_serial(zone_name.clone(), &zone).await else {
             error!("[ZL]: Zone file '{zone_path}' lacks a SOA record. Skipping zone.");
@@ -447,20 +454,17 @@ async fn get_zone_serial(apex_name: Name<Bytes>, zone: &Zone) -> Option<Serial> 
 }
 
 fn load_file_into_zone(
-    center: Arc<Center>,
     zone_name: &StoredName,
     zone_path: &Utf8Path,
     receipt_info: Arc<Mutex<HashMap<StoredName, ZoneLoaderReport>>>,
-) -> Result<(Zone, usize), Terminated> {
+) -> Result<(Zone, usize), String> {
     let before = Instant::now();
     log::info!("[ZL]: Loading primary zone '{zone_name}' from '{zone_path}'..");
     let mut zone_file = File::open(zone_path)
-        .inspect_err(|err| error!("[ZL]: Failed to open zone file '{zone_path}': {err}",))
-        .map_err(|_| Terminated)?;
+        .map_err(|err| format!("[ZL]: Failed to open zone file '{zone_path}': {err}"))?;
     let zone_file_len = zone_file
         .metadata()
-        .inspect_err(|err| error!("[ZL]: Failed to read metadata for file '{zone_path}': {err}",))
-        .map_err(|_| Terminated)?
+        .map_err(|err| format!("[ZL]: Failed to read metadata for file '{zone_path}': {err}"))?
         .len();
 
     let report = ZoneLoaderReport {
@@ -479,8 +483,7 @@ fn load_file_into_zone(
 
     debug!("[ZL]: Reading {zone_file_len} bytes for zone '{zone_name}' from '{zone_path}");
     std::io::copy(&mut zone_file, &mut buf)
-        .inspect_err(|err| error!("[ZL]: Failed to read data from file '{zone_path}': {err}",))
-        .map_err(|_| Terminated)?;
+        .map_err(|err| format!("[ZL]: Failed to read data from file '{zone_path}': {err}"))?;
     let mut reader = buf.into_inner();
     reader.set_origin(zone_name.clone());
 
@@ -528,13 +531,9 @@ fn load_file_into_zone(
     }
 
     if let Some(err) = loading_error {
-        halt_zone(
-            &center,
-            zone_name,
-            true,
-            &format!("Encountered an error while loading the zone: {err}"),
-        );
-        return Err(Terminated);
+        return Err(format!(
+            "Encountered an error while loading the zone: {err}"
+        ));
     }
 
     debug!("[ZL]: Parsing stage 2 of zone '{zone_name}' data");
@@ -542,13 +541,9 @@ fn load_file_into_zone(
     let Ok(zone) = res else {
         let err = format!("{}", res.unwrap_err());
         error!("[ZL]: Failed to build a zone tree for '{zone_name}': {err}");
-        halt_zone(
-            &center,
-            zone_name,
-            true,
-            &format!("Encountered an error while loading the zone: {err}"),
-        );
-        return Err(Terminated);
+        return Err(format!(
+            "Encountered an error while loading the zone: {err}"
+        ));
     };
     info!(
         "Loaded {zone_file_len} bytes from '{zone_path}' in {} secs",


### PR DESCRIPTION
To support adding zone files without requiring absolute paths, and for files that don't exist add reporting of errors.

If the file exists at that path on the client, it may not be readable by or accessible to the server. Currently there is no easy way to pass an error back from the point where the zone is loaded to the client when it issues the add zone command. Instead we store an error in the zone history and show it via the zone status command like so:

```
$ ./cascade zone status nl
Status report for zone 'nl' using policy 'default'
• Waiting for a new version of the nl zone
x The pipeline for this zone is halted due to a serious error:
x Failed to open zone file '/home/ximon/nl.zone': Permission denied (os error 13)
```