### PR TITLE
Fix "unix-time" in comment in default policy

### DIFF
--- a/etc/policy.template.toml
+++ b/etc/policy.template.toml
@@ -264,7 +264,7 @@ algorithm = "ECDSAP256SHA256"
 # Supported options:
 # - 'keep': use the same serial number as the unsigned zone.
 # - 'counter': increment the serial number every time.
-# - 'unixtime': use the current Unix time, in seconds.
+# - 'unix-time': use the current Unix time, in seconds.
 # - 'date-counter': format the number as '<YYYY><MM><DD><xx>' in decimal.
 #     '<xx>' is a simple counter to allow up to 100 versions per day.
 serial-policy = "date-counter"


### PR DESCRIPTION
`unix-time` (needs a dash)