### PR TITLE
Implement a dnst version check

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,11 @@ fn main() -> ExitCode {
             logger.apply(x)
         }
 
+        if !check_dnst_version(&state) {
+            // Error is already logged in the function
+            return ExitCode::FAILURE;
+        }
+
         // Create required subdirectories (and their parents) if they don't
         // exist. This is only needed for directories to which we write files
         // without using util::write_file() as that function creates the
@@ -114,6 +119,11 @@ fn main() -> ExitCode {
         // Update the configured logging setup from state.
         if let Some(x) = logger.prepare(&state.config.daemon.logging).unwrap() {
             logger.apply(x)
+        }
+
+        if !check_dnst_version(&state) {
+            // Error is already logged in the function
+            return ExitCode::FAILURE;
         }
 
         log::info!("Successfully loaded the global state file");
@@ -150,11 +160,6 @@ fn main() -> ExitCode {
             log::error!("Failed to load the TSIG store: {err}");
             return ExitCode::FAILURE;
         }
-    }
-
-    if !check_dnst_version(&state) {
-        // Error is already logged in the function
-        return ExitCode::FAILURE;
     }
 
     // Bind to listen addresses before daemonizing.


### PR DESCRIPTION
Uses string splitting to avoid including a new dependency on regex.

- Checking that the dnst binary is available
- Checking that the keyset subcommand is available
- Checking the version number (but currently ignoring any `-alpha`/`-rcX` suffixes)

Example output:
```
$ cascaded --config config.toml --state state.db --log-level trace
...
[2025-10-09T10:12:05.449Z] DEBUG cascaded: Checking dnst binary version ('dnst')       # yes, I have the dnst binary from the keyset branch in my PATH
[2025-10-09T10:12:05.452Z] DEBUG cascaded: Checking dnst keyset subcommand capability
[2025-10-09T10:12:05.454Z] DEBUG cascaded: Checking dnst version string '0.1.0'
[2025-10-09T10:12:05.454Z] INFO cascaded: Using dnst binary 'dnst' with name 'dnst' and version '0.1.0'

$ cascaded --config config.toml --state state.db --log-level trace
...
[2025-10-09T10:07:59.533Z] DEBUG cascaded: Checking dnst binary version ('/tmp/version.sh')
[2025-10-09T10:07:59.535Z] DEBUG cascaded: Checking dnst keyset subcommand capability
[2025-10-09T10:07:59.537Z] DEBUG cascaded: Checking dnst version string '0.1.2'
[2025-10-09T10:07:59.537Z] INFO cascaded: Using dnst binary '/tmp/version.sh' with name 'not-dnst' and version '0.1.2'

$ cascaded --config config.toml --state state.db --log-level trace
...
[2025-10-09T10:08:07.737Z] DEBUG cascaded: Checking dnst binary version ('/tmp/version.sh')
[2025-10-09T10:08:07.738Z] DEBUG cascaded: Checking dnst keyset subcommand capability
[2025-10-09T10:08:07.741Z] DEBUG cascaded: Checking dnst version string '0.0.2'
[2025-10-09T10:08:07.741Z] ERROR cascaded: Configured dnst binary '/tmp/version.sh' version (0.0.2) is unsupported. Expected >0.1.0
```

Fixes: #158 