### PR TITLE
Ensure keyset warnings are logged and included in zone history.

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -286,7 +286,7 @@ pub struct ZoneStatus {
     pub policy: String,
     pub stage: ZoneStage,
     pub keys: Vec<KeyInfo>,
-    pub key_status: Option<String>,
+    pub key_status: String,
     pub receipt_report: Option<ZoneLoaderReport>,
     pub unsigned_serial: Option<Serial>,
     pub unsigned_review_status: Option<TimestampedZoneReviewStatus>,
@@ -615,28 +615,6 @@ pub mod keyset {
         pub key: String,
         pub force: bool,
         pub continue_flag: bool,
-    }
-
-    #[derive(Deserialize, Serialize, Debug, Clone)]
-    pub struct KeySetCommandResult {
-        pub zone: Name<Bytes>,
-    }
-
-    #[derive(Deserialize, Serialize, Debug, Clone)]
-    pub enum KeySetCommandError {
-        DnstCommandError(String),
-        RxError,
-    }
-
-    impl std::fmt::Display for KeySetCommandError {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            match self {
-                KeySetCommandError::DnstCommandError(err) => write!(f, "dnst command error: {err}"),
-                KeySetCommandError::RxError => {
-                    f.write_str("Internal error: message receive failed")
-                }
-            }
-        }
     }
 
     #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/src/cli/commands/keyset.rs
+++ b/src/cli/commands/keyset.rs
@@ -87,7 +87,7 @@ async fn roll_command(
     cmd: KeyRollCommand,
     variant: KeyRollVariant,
 ) -> Result<(), String> {
-    let res: Result<KeySetCommandResult, KeySetCommandError> = client
+    let res: Result<(), String> = client
         .post(&format!("key/{zone}/roll"))
         .json(&KeyRoll { variant, cmd })
         .send()
@@ -99,14 +99,7 @@ async fn roll_command(
             println!("Manual key roll for {} successful", zone);
             Ok(())
         }
-        Err(e) => match e {
-            KeySetCommandError::DnstCommandError(err) => {
-                Err(format!("Failed manual key roll for {zone}: {err}"))
-            }
-            KeySetCommandError::RxError => Err(format!(
-                "Failed manual key roll for {zone}: Internal Server Error"
-            )),
-        },
+        Err(err) => Err(format!("Failed manual key roll for {zone}: {err}")),
     }
 }
 
@@ -117,7 +110,7 @@ async fn remove_key_command(
     force: bool,
     continue_flag: bool,
 ) -> Result<(), String> {
-    let res: Result<KeySetCommandResult, KeySetCommandError> = client
+    let res: Result<(), String> = client
         .post(&format!("key/{zone}/remove"))
         .json(&KeyRemove {
             key: key.clone(),
@@ -133,14 +126,7 @@ async fn remove_key_command(
             println!("Removed key {} from zone {}", key, zone);
             Ok(())
         }
-        Err(e) => match e {
-            KeySetCommandError::DnstCommandError(err) => {
-                Err(format!("Failed to remove key {key} from {zone}: {err}"))
-            }
-            KeySetCommandError::RxError => Err(format!(
-                "Failed to remove key {key} from {zone}: Internal Server Error"
-            )),
-        },
+        Err(err) => Err(format!("Failed to remove key {key} from {zone}: {err}")),
     }
 }
 

--- a/src/cli/commands/zone.rs
+++ b/src/cli/commands/zone.rs
@@ -533,11 +533,9 @@ impl Zone {
                     println!("    Actively used for signing");
                 }
             }
-            if let Some(key_status) = zone.key_status {
-                println!("  Details:");
-                for line in key_status.lines() {
-                    println!("    {line}");
-                }
+            println!("  Details:");
+            for line in zone.key_status.lines() {
+                println!("    {line}");
             }
         }
 

--- a/src/comms.rs
+++ b/src/comms.rs
@@ -71,7 +71,6 @@ use std::fmt::{self, Debug};
 use std::net::IpAddr;
 use tokio::sync::{mpsc, oneshot};
 
-use crate::api::keyset::KeySetCommandError;
 use crate::api::{self, KeyImport};
 use crate::center::{Change, ZoneAddError};
 use crate::units::zone_loader::ZoneLoaderReport;
@@ -220,16 +219,16 @@ pub enum ApplicationCommand {
     RollKey {
         zone: StoredName,
         key_roll: api::keyset::KeyRoll,
-        http_tx: mpsc::Sender<Result<(), KeySetCommandError>>,
+        http_tx: mpsc::Sender<Result<(), String>>,
     },
     RemoveKey {
         zone: StoredName,
         key_remove: api::keyset::KeyRemove,
-        http_tx: mpsc::Sender<Result<(), KeySetCommandError>>,
+        http_tx: mpsc::Sender<Result<(), String>>,
     },
 
     KeySetStatus {
         zone: StoredName,
-        http_tx: oneshot::Sender<Result<String, KeySetCommandError>>,
+        http_tx: oneshot::Sender<Result<String, String>>,
     },
 }

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -251,13 +251,13 @@ pub enum HistoricalEvent {
     },
     KeySetCommand {
         cmd: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        warning: Option<String>,
         #[serde(
             serialize_with = "serialize_duration_as_secs",
             deserialize_with = "deserialize_duration_from_secs"
         )]
         elapsed: Duration,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        warning: Option<String>,
     },
     KeySetError {
         cmd: String,


### PR DESCRIPTION
In #193 we saw that a `dnst keyset cron` invocation experienced a transient network error resulting in "Something went wrong transferring the zone to be verified." being shown by `dnst keyset status`. However there was no record of this transient problem anywhere because `dnst keyset cron` did not fail, it exited with code zero, but DID print to stderr. Capturing of stderr was only done if the exit code was non-zero, so the warning that was output was lost.

Additionally, while `dnst keyset` commands and errors are recorded in zone history, and logged as executed, if the command fails the error is not logged. only recorded in history.

This PR addresses these shortcomings.

Specifically it:

- Moves all dnst execution into KeyManager.
  - Merges KeyRollResult and KeyRemoveResult into new KeySetCommandResult.
  - Merges KeyRollError and KeyRollResult into new KetSetCommandError.
  - Adds new ApplicationCommand::KeySetStatus which KeyManager responds to.
  - Uses new ApplicationCommand::KeySetStatus from http_server instead of invoking dnst keyset directly.
- Captures stderr even for failed dnst keyset commands. Log and store it as a warning.
- Adds support for "silent" dnst keyset execution so that KeyManager can invoke `dnst keyset status` and only record it in the zone history of there were   warnings or errors, otherwise `cascade zone status` commands will spam the zone  history.

Other:
  - Replaces `log::` with imports.