### PR TITLE
Use MultiThreadedSorter for faster sorting before signing.

### DIFF
--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -809,6 +809,7 @@ impl ZoneSigner {
         status.write().await.current_action = "Sorting records".to_string();
         let sort_start = Instant::now();
         let mut records = spawn_blocking(|| {
+            // Note: This may briefly use lots of CPU and many CPU cores.
             MultiThreadedSorter::sort_by(&mut records, CanonicalOrd::canonical_cmp);
             records.dedup();
             records


### PR DESCRIPTION
Decreases sorting time for an old copy of the `nl` zone from 29 seconds on my machine to 5 seconds.