### PR TITLE
Allow disabling colors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "supports-color",
  "syslog",
  "tempfile",
  "tokio",
@@ -1131,6 +1132,12 @@ dependencies = [
  "memchr",
  "serde",
 ]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2020,6 +2027,15 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ ring = "0.17.0"
 
 # 'tempfile' is used to generate temporary files as part of atomic file writes.
 tempfile = "3.21.0"
+supports-color = "3.0.2"
 
 # 'log' is a very popular logging crate, and is the primary means for Cascade
 # to indicate what it's doing at any time.

--- a/src/cli/commands/policy.rs
+++ b/src/cli/commands/policy.rs
@@ -7,7 +7,7 @@ use crate::{
         SignerSerialPolicyInfo,
     },
     cli::client::{format_http_error, CascadeApiClient},
-    common::ansi,
+    common::ansi::{self, println},
 };
 
 #[derive(Clone, Debug, clap::Args)]
@@ -93,16 +93,18 @@ impl Policy {
                     };
 
                     let color = match p.1 {
-                        PolicyChange::Added => ansi::GREEN,
-                        PolicyChange::Removed => ansi::RED,
-                        PolicyChange::Updated => ansi::BLUE,
-                        PolicyChange::Unchanged => ansi::GRAY,
+                        PolicyChange::Added => ansi::green,
+                        PolicyChange::Removed => ansi::red,
+                        PolicyChange::Updated => ansi::blue,
+                        PolicyChange::Unchanged => ansi::gray,
                     };
 
                     println!(
-                        "{color} - {name:<width$} {change}{reset}",
-                        width = max_width,
-                        reset = ansi::RESET
+                        "{}",
+                        color(format_args!(
+                            " - {name:<width$} {change}",
+                            width = max_width
+                        )),
                     );
                 }
             }

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -3,7 +3,7 @@ use futures::TryFutureExt;
 
 use crate::api::ServerStatusResult;
 use crate::cli::client::{format_http_error, CascadeApiClient};
-use crate::common::ansi;
+use crate::common::ansi::{self, eprintln, println};
 use crate::zonemaintenance::types::SigningStageReport;
 
 #[derive(Clone, Debug, clap::Args)]
@@ -39,7 +39,7 @@ impl Status {
                 if !response.hard_halted_zones.is_empty() {
                     eprintln!("The following zones are hard halted due to a serious problem:");
                     for (zone_name, err) in response.hard_halted_zones {
-                        eprintln!("   {}\u{78}{} {zone_name}: {err}", ansi::RED, ansi::RESET);
+                        eprintln!("   {} {zone_name}: {err}", ansi::red("\u{78}"));
                     }
                     eprintln!();
                 }
@@ -47,7 +47,7 @@ impl Status {
                 if !response.soft_halted_zones.is_empty() {
                     eprintln!("The following zones are halted due to resolvable issues:");
                     for (zone_name, err) in response.soft_halted_zones {
-                        eprintln!("   {}\u{78}{} {zone_name}: {err}", ansi::RED, ansi::RESET);
+                        eprintln!("   {} {zone_name}: {err}", ansi::red("\u{78}"));
                     }
                     eprintln!();
                 }
@@ -57,35 +57,29 @@ impl Status {
                     println!("  The signing queue is currently empty.");
                 } else {
                     println!(
-                        "  Key: {}In Progress (\u{23F5}){}, {}Pending (\u{23F8}){}, {}Finished (\u{2714}){}",
-                        ansi::YELLOW,
-                        ansi::RESET,
-                        ansi::GRAY,
-                        ansi::RESET,
-                        ansi::GREEN,
-                        ansi::RESET
+                        "  Key: {}, {}, {}",
+                        ansi::yellow("In Progress (\u{23F5})"),
+                        ansi::gray("Pending (\u{23F8})"),
+                        ansi::green("Finished (\u{2714})"),
                     );
                     println!("  {:>2}:   {:<25} {:<16} Action", "#", "When", "Zone");
                     for (i, report) in response.signing_queue.iter().enumerate() {
                         let zone_name = report.zone_name.to_string();
                         let action = &report.signing_report.current_action;
-                        let (colour, state, when) = match &report.signing_report.stage_report {
+                        let (state, when) = match &report.signing_report.stage_report {
                             SigningStageReport::Requested(r) => {
-                                (ansi::GRAY, "\u{23F8}", r.requested_at)
+                                (ansi::gray("\u{23F8}"), r.requested_at)
                             }
                             SigningStageReport::InProgress(r) => {
-                                (ansi::YELLOW, "\u{23F5}", r.started_at)
+                                (ansi::yellow("\u{23F5}"), r.started_at)
                             }
                             SigningStageReport::Finished(r) => {
-                                (ansi::GREEN, "\u{2714}", r.finished_at)
+                                (ansi::green("\u{2714}"), r.finished_at)
                             }
                         };
                         let when = DateTime::<Utc>::from(when)
                             .to_rfc3339_opts(chrono::SecondsFormat::Secs, false);
-                        println!(
-                            "  {i:>2}: {colour}{state}{} {when:<25} {zone_name:<16} {action}",
-                            ansi::RESET
-                        );
+                        println!("  {i:>2}: {} {when:<25} {zone_name:<16} {action}", state);
                     }
                 }
             }

--- a/src/cli/commands/zone.rs
+++ b/src/cli/commands/zone.rs
@@ -10,7 +10,7 @@ use humantime::FormattedDuration;
 
 use crate::api::*;
 use crate::cli::client::{format_http_error, CascadeApiClient};
-use crate::common::ansi;
+use crate::common::ansi::{self, println, Styled};
 use crate::zone::{HistoricalEvent, PipelineMode, SigningTrigger};
 use crate::zonemaintenance::types::SigningStageReport;
 
@@ -506,16 +506,17 @@ impl Zone {
         match zone.pipeline_mode {
             PipelineMode::Running => { /* Nothing to do */ }
             PipelineMode::SoftHalt(err) => {
-                println!("{}\u{78} An error occurred that prevents further processing of this zone version:{}", ansi::RED, ansi::RESET);
-                println!("{}\u{78} {err}{}", ansi::RED, ansi::RESET);
+                println!("{}", ansi::red("\u{78} An error occurred that prevents further processing of this zone version:"));
+                println!("{}", ansi::red(format_args!("\u{78} {err}")));
             }
             PipelineMode::HardHalt(err) => {
                 println!(
-                    "{}\u{78} The pipeline for this zone is hard halted due to a serious error:{}",
-                    ansi::RED,
-                    ansi::RESET
+                    "{}",
+                    ansi::red(
+                        "\u{78} The pipeline for this zone is hard halted due to a serious error:"
+                    )
                 );
-                println!("{}\u{78} {err}{}", ansi::RED, ansi::RESET);
+                println!("{}", ansi::red(format_args!("\u{78} {err}")));
             }
         }
 
@@ -691,9 +692,8 @@ impl Progress {
         let Some(report) = &zone.receipt_report else {
             // This shouldn't happen.
             println!(
-                "{}\u{78} The receipt report for this zone is unavailable.{}",
-                ansi::RED,
-                ansi::RESET
+                "{}",
+                ansi::red("\u{78} The receipt report for this zone is unavailable."),
             );
             return;
         };
@@ -790,13 +790,11 @@ impl Progress {
     fn print_signed(&self, zone: &ZoneStatus, succeeded: bool) {
         let (signed_failed, icon) = match succeeded {
             true => ("Signed", status_icon(true)),
-            false => (
-                "Signing failed",
-                format!("{}\u{78}{}", ansi::RED, ansi::RESET),
-            ),
+            false => ("Signing failed", ansi::red("\u{78}")),
         };
         println!(
-            "{icon} {signed_failed} {} as {}",
+            "{} {signed_failed} {} as {}",
+            icon,
             serial_to_string(zone.unsigned_serial),
             serial_to_string(zone.signed_serial)
         );
@@ -977,10 +975,10 @@ impl Progress {
     }
 }
 
-fn status_icon(done: bool) -> String {
+fn status_icon(done: bool) -> Styled<&'static str> {
     match done {
-        true => format!("{}\u{2714}{}", ansi::GREEN, ansi::RESET), // tick ✔
-        false => format!("{}\u{2022}{}", ansi::YELLOW, ansi::RESET), // bullet •
+        true => ansi::green("\u{2714}"),   // tick ✔
+        false => ansi::yellow("\u{2022}"), // bullet •
     }
 }
 

--- a/src/common/ansi.rs
+++ b/src/common/ansi.rs
@@ -1,12 +1,148 @@
 #![allow(unused)]
-pub const BLACK: &str = "\x1b[0;30m";
-pub const RED: &str = "\x1b[0;31m";
-pub const GREEN: &str = "\x1b[0;32m";
-pub const YELLOW: &str = "\x1b[0;33m";
-pub const BLUE: &str = "\x1b[0;34m";
-pub const PURPLE: &str = "\x1b[0;35m";
-pub const CYAN: &str = "\x1b[0;36m";
-pub const WHITE: &str = "\x1b[0;37m";
-pub const GRAY: &str = "\x1b[38;5;248m";
-pub const RESET: &str = "\x1b[0m";
-pub const ITALIC: &str = "\x1b[3m";
+
+use std::fmt::{self, Display};
+
+use supports_color::Stream;
+const BLACK: &str = "\x1b[0;30m";
+const RED: &str = "\x1b[0;31m";
+const GREEN: &str = "\x1b[0;32m";
+const YELLOW: &str = "\x1b[0;33m";
+const BLUE: &str = "\x1b[0;34m";
+const PURPLE: &str = "\x1b[0;35m";
+const CYAN: &str = "\x1b[0;36m";
+const WHITE: &str = "\x1b[0;37m";
+const GRAY: &str = "\x1b[38;5;248m";
+const RESET: &str = "\x1b[0m";
+const ITALIC: &str = "\x1b[3m";
+
+pub fn red<T: Display>(content: T) -> Styled<T> {
+    Styled {
+        style: RED,
+        content,
+    }
+}
+
+pub fn green<T: Display>(content: T) -> Styled<T> {
+    Styled {
+        style: GREEN,
+        content,
+    }
+}
+
+pub fn yellow<T: Display>(content: T) -> Styled<T> {
+    Styled {
+        style: YELLOW,
+        content,
+    }
+}
+
+pub fn blue<T: Display>(content: T) -> Styled<T> {
+    Styled {
+        style: BLUE,
+        content,
+    }
+}
+
+pub fn gray<T: Display>(content: T) -> Styled<T> {
+    Styled {
+        style: GRAY,
+        content,
+    }
+}
+
+pub trait Print: Sized {
+    fn print(&self, f: &mut fmt::Formatter<'_>, with_color: bool) -> fmt::Result;
+
+    fn display<'a>(&'a self, with_color: bool) -> impl Display {
+        struct Printable<'a, P: Print> {
+            with_color: bool,
+            content: &'a P,
+        }
+
+        impl<'a, P: Print> Display for Printable<'a, P> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.content.print(f, self.with_color)
+            }
+        }
+
+        Printable {
+            with_color,
+            content: self,
+        }
+    }
+}
+
+impl<T: Display> Print for T {
+    fn print(&self, f: &mut fmt::Formatter<'_>, with_color: bool) -> fmt::Result {
+        self.fmt(f)
+    }
+}
+
+pub struct Styled<T: Display> {
+    style: &'static str,
+    content: T,
+}
+
+impl<T: Display> Print for Styled<T> {
+    fn print(&self, f: &mut fmt::Formatter<'_>, with_color: bool) -> fmt::Result {
+        if with_color {
+            self.style.fmt(f)?;
+        }
+
+        self.content.fmt(f)?;
+
+        if with_color {
+            RESET.fmt(f)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[macro_export]
+macro_rules! println {
+    () => {
+        std::println!()
+    };
+    ($s:literal) => {
+        std::println!($s)
+    };
+    ($s:literal, $($arg:expr),*) => {
+        #[allow(unused_variables)]
+        let with_color = supports_color::on_cached(supports_color::Stream::Stdout)
+            .map_or(false, |l| l.has_basic);
+        std::println!($s, $(crate::common::ansi::Print::display(&$arg, with_color)),*)
+    };
+    ($s:literal, $($arg:expr),*,) => {
+        #[allow(unused_variables)]
+        let with_color = supports_color::on_cached(supports_color::Stream::Stdout)
+            .map_or(false, |l| l.has_basic);
+        std::println!($s, $(crate::common::ansi::Print::display(&$arg, with_color)),*)
+    };
+}
+
+pub use println;
+
+#[macro_export]
+macro_rules! eprintln {
+    () => {
+        std::eprintln!()
+    };
+    ($s:literal) => {
+        std::eprintln!($s)
+    };
+    ($s:literal, $($arg:expr),*) => {
+        #[allow(unused_variables)]
+        let with_color = supports_color::on_cached(supports_color::Stream::Stderr)
+            .map_or(false, |l| l.has_basic);
+        std::eprintln!($s, $(crate::common::ansi::Print::display(&$arg, with_color)),*)
+    };
+    ($s:literal, $($arg:expr),*,) => {
+        #[allow(unused_variables)]
+        let with_color = supports_color::on_cached(supports_color::Stream::Stderr)
+            .map_or(false, |l| l.has_basic);
+        std::eprintln!($s, $(crate::common::ansi::Print::display(&$arg, with_color)),*)
+    };
+}
+
+pub use eprintln;


### PR DESCRIPTION
Closes https://github.com/NLnetLabs/cascade/issues/243.

This might be a completely overengineered solution, but here's my thinking:
- We want to allow separate settings for stdout and stderr, so we can't just set a global "use color" variable.
- We want to ensure that we catch all cases where we print color and don't accidentally print color when we're not supposed to. That rules out [anstream](https://docs.rs/anstream), which wraps the `println!` macro to optionally strip all color. We can't ensure that we only use that macro instead of `std::println`.

So I made a new trait `Print` which is `Display` with a parameter for whether color should be printed. All `Display` types implement `Print` and a type `Styled` implements _only_ `Print` (and not `Display`). This `Styled` type can only be printed if it knows whether to print colors or not, which is information that we pass from our own `println!` and `eprintln!` macros.

The downside is that the wrapped `println!`/`eprintln!` macros are not quite as powerful as `std`'s macros. They don't support `println!("{x}", x = y)` and all the styled arguments cannot appear inside the string, so `println!("{x}")` doesn't work if `x` is a `Styled`, only `println!("{}", x)`.

To figure out whether the terminal supports colors we use [supports_color](https://docs.rs/supports_color), which gets a lot of things right out of the box.

<img width="740" height="585" alt="image" src="https://github.com/user-attachments/assets/04e2ce2d-9aa6-4802-9e09-055edbedf287" />

If this is too overengineered we could just replace all our uses of `println!` with the anstream equivalent instead.

