### PR TITLE
Allow disabling colors via anstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,7 @@ dependencies = [
 name = "cascade"
 version = "0.1.0-alpha2"
 dependencies = [
+ "anstream",
  "arc-swap",
  "assert-json-diff",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,9 @@ ring = "0.17.0"
 # 'tempfile' is used to generate temporary files as part of atomic file writes.
 tempfile = "3.21.0"
 
+# Anstream can strip ansi codes for TERM=dumb and other similar situations
+anstream = "0.6.21"
+
 # 'log' is a very popular logging crate, and is the primary means for Cascade
 # to indicate what it's doing at any time.
 [dependencies.log]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,7 @@
+[[disallowed-macros]]
+path = "std::println"
+reason = "this macro will always print color even when that is undesidered, use cascade::println instead"
+
+[[disallowed-macros]]
+path = "std::eprintln"
+reason = "this macro will always print color even when that is undesidered, use cascade::eprintln instead"

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -3,6 +3,7 @@ use futures::TryFutureExt;
 use crate::{
     api::{ConfigReload, ConfigReloadError, ConfigReloadOutput, ConfigReloadResult},
     cli::client::{format_http_error, CascadeApiClient},
+    println,
 };
 
 #[derive(Clone, Debug, clap::Args)]

--- a/src/cli/commands/hsm.rs
+++ b/src/cli/commands/hsm.rs
@@ -24,6 +24,7 @@ use crate::{
         HsmServerListResult, PolicyInfo, PolicyInfoError, PolicyListResult,
     },
     cli::client::{format_http_error, CascadeApiClient},
+    println,
     units::http_server::KmipServerState,
 };
 

--- a/src/cli/commands/keyset.rs
+++ b/src/cli/commands/keyset.rs
@@ -4,6 +4,7 @@ use futures::TryFutureExt;
 
 use crate::api::keyset::*;
 use crate::cli::client::{format_http_error, CascadeApiClient};
+use crate::println;
 
 #[derive(Clone, Debug, clap::Args)]
 pub struct KeySet {

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod template;
 pub mod zone;
 
 use crate::cli::client::format_http_error;
+use crate::println;
 
 use super::client::CascadeApiClient;
 

--- a/src/cli/commands/policy.rs
+++ b/src/cli/commands/policy.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     cli::client::{format_http_error, CascadeApiClient},
     common::ansi,
+    println,
 };
 
 #[derive(Clone, Debug, clap::Args)]

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -5,6 +5,7 @@ use crate::api::ServerStatusResult;
 use crate::cli::client::{format_http_error, CascadeApiClient};
 use crate::common::ansi;
 use crate::zonemaintenance::types::SigningStageReport;
+use crate::{eprintln, println};
 
 #[derive(Clone, Debug, clap::Args)]
 pub struct Status {

--- a/src/cli/commands/template.rs
+++ b/src/cli/commands/template.rs
@@ -1,4 +1,5 @@
 use crate::cli::client::CascadeApiClient;
+use crate::println;
 
 #[derive(Clone, Debug, clap::Args)]
 pub struct Template {

--- a/src/cli/commands/zone.rs
+++ b/src/cli/commands/zone.rs
@@ -11,6 +11,7 @@ use humantime::FormattedDuration;
 use crate::api::*;
 use crate::cli::client::{format_http_error, CascadeApiClient};
 use crate::common::ansi;
+use crate::println;
 use crate::zone::{HistoricalEvent, PipelineMode, SigningTrigger};
 use crate::zonemaintenance::types::SigningStageReport;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,3 +22,21 @@ pub mod zonemaintenance;
 
 #[cfg(test)]
 pub mod tests;
+
+#[macro_export]
+macro_rules! println {
+    ($($t:tt)*) => {{
+        #[allow(clippy::disallowed_macros)]
+        let x = anstream::println!($($t)*);
+        x
+    }};
+}
+
+#[macro_export]
+macro_rules! eprintln {
+    ($($t:tt)*) => {{
+        #[allow(clippy::disallowed_macros)]
+        let x = anstream::eprintln!($($t)*);
+        x
+    }};
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use cascade::{
     comms::ApplicationCommand,
     config::{Config, SocketConfig},
     daemon::{daemonize, PreBindError, SocketProvider},
+    eprintln,
     manager::{self, TargetCommand},
     policy,
 };


### PR DESCRIPTION
Closes #243 

Use `anstream` to disable terminal colors automagically. I made the regular `println` and `eprintln` disallowed in clippy so that we are forced to use the anstream versions. This required me to make my own wrappers that call the anstream macros with an `#[allow(clippy::disallowed_macros)]`, because they expand to something that calls `println`/`eprintln`.

Note that `anstream` is already in our dependency tree via `clap`.