### PR TITLE
Do not halt pipeline on keyset errors

### DIFF
--- a/src/units/key_manager.rs
+++ b/src/units/key_manager.rs
@@ -1157,8 +1157,6 @@ impl KeySetCommand {
             Err(err) => {
                 let err_string = err.err.to_string();
 
-                // TODO: Possibly halt the zone depending on the keyset exit code
-
                 // Determine whether and what to record in zone history
                 let record = match self.recording_mode {
                     RecordingMode::DoNotRecord => false,


### PR DESCRIPTION
A step to resolving: https://github.com/NLnetLabs/cascade/issues/187

Keyset key roll errors are usually not fatal because they stem from simple user error. If there should be something that causes an actual error, we should adapt keyset to return more informative exit codes (e.g. 0 is success, 1 is fatal, 2 is user error, or something like that), but this PR is simply ignoring these errors.

It's hard to say whether this is enough for #187. The other issue mentioned there is a failing review script, which is already a soft error and therefore seems fine as it is.