### PR TITLE
Correct log level filtering logic

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -132,9 +132,7 @@ impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for Filter {
         metadata: &tracing::Metadata<'_>,
         _ctx: tracing_subscriber::layer::Context<'_, S>,
     ) -> bool {
-        self.level >= *metadata.level()
-            || *metadata.level() < tracing::Level::TRACE
-            || self.trace_targets.contains(metadata.target())
+        self.level >= *metadata.level() || self.trace_targets.contains(metadata.target())
     }
 }
 


### PR DESCRIPTION
The intention was to enable non-trace logs that fell within the 'trace targets' variable; I had just gotten the ordering wrong in #330.

Fixes #366.