### PR TITLE
[cli] Use `tracing_subscriber` for logging

### DIFF
--- a/src/bin/cascade.rs
+++ b/src/bin/cascade.rs
@@ -1,10 +1,6 @@
 use std::process::ExitCode;
 
-use cascade::{
-    cli::args::Args,
-    config::{LogTarget, LoggingConfig, Setting},
-    log::Logger,
-};
+use cascade::cli::args::Args;
 use clap::Parser;
 use tracing::error;
 
@@ -12,13 +8,9 @@ use tracing::error;
 async fn main() -> ExitCode {
     let args = Args::parse();
 
-    let log_config = LoggingConfig {
-        level: Setting::new(args.log_level),
-        target: Setting::new(LogTarget::Stdout),
-        trace_targets: Default::default(),
-    };
-
-    Logger::launch(&log_config).unwrap();
+    tracing_subscriber::FmtSubscriber::builder()
+        .with_max_level(args.log_level)
+        .init();
 
     match args.execute().await {
         Ok(_) => ExitCode::SUCCESS,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,8 +1,9 @@
+use std::fmt;
 use std::net::SocketAddr;
 
+use clap::builder::PossibleValue;
 use clap::Parser;
-
-use crate::config::LogLevel;
+use tracing::level_filters::LevelFilter;
 
 use super::client::CascadeApiClient;
 use super::commands::Command;
@@ -37,5 +38,79 @@ impl Args {
     pub async fn execute(self) -> Result<(), String> {
         let client = CascadeApiClient::new(format!("http://{}", self.server));
         self.command.execute(client).await
+    }
+}
+
+//----------- LogLevel ---------------------------------------------------------
+
+/// A severity level for logging.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum LogLevel {
+    /// A function or variable was interacted with, for debugging.
+    Trace,
+
+    /// Something occurred that may be relevant to debugging.
+    Debug,
+
+    /// Things are proceeding as expected.
+    Info,
+
+    /// Something does not appear to be correct.
+    Warning,
+
+    /// Something is wrong (but Cascade can recover).
+    Error,
+
+    /// Something is wrong and Cascade can't function at all.
+    Critical,
+}
+
+impl LogLevel {
+    /// Represent a [`LogLevel`] as a string.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            LogLevel::Trace => "trace",
+            LogLevel::Debug => "debug",
+            LogLevel::Info => "info",
+            LogLevel::Warning => "warning",
+            LogLevel::Error => "error",
+            LogLevel::Critical => "critical",
+        }
+    }
+}
+
+impl fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl clap::ValueEnum for LogLevel {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[
+            LogLevel::Trace,
+            LogLevel::Debug,
+            LogLevel::Info,
+            LogLevel::Warning,
+            LogLevel::Error,
+            LogLevel::Critical,
+        ]
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        Some(PossibleValue::new(self.as_str()))
+    }
+}
+
+impl From<LogLevel> for LevelFilter {
+    fn from(value: LogLevel) -> Self {
+        match value {
+            LogLevel::Trace => LevelFilter::TRACE,
+            LogLevel::Debug => LevelFilter::DEBUG,
+            LogLevel::Info => LevelFilter::INFO,
+            LogLevel::Warning => LevelFilter::WARN,
+            LogLevel::Error => LevelFilter::ERROR,
+            LogLevel::Critical => LevelFilter::ERROR,
+        }
     }
 }


### PR DESCRIPTION
The daemon's logger is a bit overkill for the CLI (e.g. syslog/file output, live reloading).  Using the standard `tracing_subscriber` logger eliminates complexity and improves the separation between the CLI and daemon codebases.

I've confirmed that the `--log-level` option works as before.  There is no user-visible change to the CLI.