### PR TITLE
Split `KeyRollCommand` between CLI and API

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -671,7 +671,7 @@ pub mod keyset {
         Algorithm,
     }
 
-    #[derive(Deserialize, Serialize, Clone, Debug, clap::Subcommand)]
+    #[derive(Deserialize, Serialize, Clone, Debug)]
     pub enum KeyRollCommand {
         /// Start a key roll.
         StartRoll,


### PR DESCRIPTION
This is a subtle but valuable change: the CLI and API will evolve differently over time and sharing definitions across them will cause problems in the long run.