### PR TITLE
Use 'jiff' instead of 'chrono' and 'humantime'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,6 @@ dependencies = [
  "axum",
  "bytes",
  "camino",
- "chrono",
  "clap",
  "crossbeam-utils",
  "daemonbase",
@@ -266,7 +265,6 @@ dependencies = [
  "futures",
  "futures-util",
  "hostname",
- "humantime",
  "jiff",
  "octseq",
  "rayon",
@@ -878,12 +876,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "humantime"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/main.rs"
 [dependencies]
 arc-swap           = "1.7.0"
 bytes              = "1.0"
-chrono             = "0.4.11"
 clap               = { version = "4.5", features = [ "cargo", "wrap_help", "derive" ] }
 daemonbase         = "0.1.4"
 domain             = { git = "https://github.com/NLnetLabs/domain", branch = "patches-for-nameshed-prototype", features = [
@@ -34,7 +33,6 @@ domain             = { git = "https://github.com/NLnetLabs/domain", branch = "pa
 ] }
 futures            = "0.3.17"
 futures-util       = "0.3"
-humantime          = "2.3.0"
 octseq             = { version = "0.5.2", default-features = false }
 tokio              = { version = "1.40", features = ["fs", "io-util", "macros", "net", "process", "rt", "rt-multi-thread", "signal", "sync", "test-util", "time", "tracing"] }
 serde              = { version = "1.0", features = ["derive", "rc"] }

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use futures::TryFutureExt;
 
 use crate::api::{KeyMsg, KeyStatusResult, KeysPerZone, ServerStatusResult, SigningStageReport};
@@ -116,8 +115,10 @@ impl Status {
                                 (ansi::GREEN, "\u{2714}", r.finished_at)
                             }
                         };
-                        let when = DateTime::<Utc>::from(when)
-                            .to_rfc3339_opts(chrono::SecondsFormat::Secs, false);
+                        let when = jiff::Timestamp::try_from(when)
+                            .unwrap()
+                            .round(jiff::Unit::Second)
+                            .unwrap();
                         println!(
                             "  {i:>2}: {colour}{state}{} {when:<25} {zone_name:<16} {action}",
                             ansi::RESET

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -21,12 +21,12 @@
 //! type can be created as constants.
 
 use arc_swap::ArcSwap;
-use chrono::Utc;
 use clap::{crate_name, crate_version};
 use std::fmt::Write;
 use std::fmt::{self, Debug};
 use std::sync::{Arc, Mutex, Weak};
 
+use std::time::Instant;
 #[cfg(test)]
 use std::{cmp::Ordering, collections::BTreeMap};
 
@@ -95,7 +95,7 @@ impl Collection {
     /// Produces an output of all the sources in the collection in the given
     /// format and returns it as a string.
     pub fn assemble(&self, format: OutputFormat) -> String {
-        let start_time = Utc::now();
+        let start_time = Instant::now();
         let sources = self.sources.load();
         let mut target = Target::new(format);
         for item in sources.iter() {
@@ -103,7 +103,7 @@ impl Collection {
                 source.append(&item.name, &mut target)
             }
         }
-        let assemble_ms = (Utc::now() - start_time).num_milliseconds();
+        let assemble_ms = start_time.elapsed().as_millis();
         target.append_simple(&Self::ASSEMBLE_TIME_MS_METRIC, None, assemble_ms);
         target.into_string()
     }


### PR DESCRIPTION
At the moment, we use all three crates.  This commit removes 'chrono' and 'humantime', as 'jiff' covers all our use cases.