### PR TITLE
Add a test that verifies that DNSSEC signed zones are accepted and re-signed by Cascade.

### DIFF
--- a/integration-tests/strip-dnssec-rrs/example.test
+++ b/integration-tests/strip-dnssec-rrs/example.test
@@ -1,0 +1,15 @@
+; This zone contains DNSSEC records that the signer should strip out.
+example.test.           3600    IN      SOA     ns1.example.test. hostmaster.example.test. 2025121201 1800 900 604800 86400
+example.test.           3600    IN      NSEC3PARAM 1 0 0 -
+example.test.           3600    IN      DNSKEY  257 3 13 SRShlTdzLbprzl2Aq0m+CJP0/4iiVe2+sx0eFgjqb1oE4xa60DhJTEMJ KLkqLW56RaFAxQNGPYEnApUO3vs1+Q==
+example.test.           3600    IN      DNSKEY  256 3 13 HCCcpFX+vvzYzG9LSO4YBDNDxTGrnUN2XQ78ePWUD02mbjaWDnVjuf2a pwFU9CU85BzoKm3vExBzBMTn0BVbEw==
+example.test.           3600    IN      CDNSKEY  256 3 13 HCCcpFX+vvzYzG9LSO4YBDNDxTGrnUN2XQ78ePWUD02mbjaWDnVjuf2a pwFU9CU85BzoKm3vExBzBMTn0BVbEw==
+example.test.           3600    IN      A       192.0.2.2
+example.test.           3600    IN      NSEC    example.test. RRSIG NSEC DNSKEY
+example.test.           3600    IN      RRSIG   NSEC 13 2 3600 20251226122738 20251211122738 57126 example.test. M7QHqotbWbdqTbUNbq6cIUy+K9CBzKKs8L8MFOxJkyH7TDddafMhhvVC UkXOffr4qBiKzu7+3b/IRR0UEaZxRw==
+example.test.           3600    IN      RRSIG   SOA 13 2 3600 20251226122738 20251211122738 57126 example.test. eiky/Yc0oSc5zIjsz2tF9g709lzvJNkjK/trhE0AEM6fJX/9TC3EuGbp 06jOhNCJAM7chlLc9eRDlHsdv5Uf6Q==
+example.test.           3600    IN      RRSIG   NS 13 2 3600 20251226122738 20251211122738 57126 example.test. 8zXGu8WHW6BjOqu/H+tw5lh+Bijy06oIYeYEUD5fzqtvtCD79vh7Xkmp ixQ64MPavARwrwXkNrON03s73iaTkw==
+example.test.           3600    IN      RRSIG   A 13 2 3600 20251226122738 20251211122738 57126 example.test. BUSARjEuuDPOafZDD5aywTMWS+Ot4qfIPqcnkqgmcpEsTqC8gxK6GRMI 5HomAiqEU98pDIeg0YSMgK+3M3mpmQ==
+example.test.           3600    IN      RRSIG   DNSKEY 13 2 3600 20251226122737 20251211122737 50512 example.test. xAaqpNy3A+qKppMjWXgHoB+vwP1ahQCmPWob/kAGDS5KJo0t82zvfDnE pzs6c9G4l9WDHQv01wnzTMpTaawxiQ==
+jbas736chung3bb701jkjdhqkqlhvug7.example.test. 3600 IN NSEC3 1 0 0 - JBAS736CHUNG3BB701JKJDHQKQLHVUG7 A SOA RRSIG DNSKEY NSEC3PARAM
+jbas736chung3bb701jkjdhqkqlhvug7.example.test. 3600 IN RRSIG NSEC3 13 3 3600 20251226124452 20251211124452 53153 example.test. KNPpSVCinUnqDlylcspTt5HJ226Ktl927GXs7fo7Ml5lGStNlqnNgzjI fDle1WUIHHyK1EybszgZ9P/hM36o1A==  

--- a/integration-tests/system-tests.yml
+++ b/integration-tests/system-tests.yml
@@ -349,12 +349,12 @@ jobs:
 
   # Added for https://github.com/NLnetLabs/cascade/issues/105
   strip-dnssec-rrs:
-    name: Add a zone containing DNSSEC RRs and verify that they are not included in the signed zone
+    name: Sign using an already signed input zone.
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
-        rust: [stable] # see build job
+        rust: [stable]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/set-build-profile

--- a/integration-tests/system-tests.yml
+++ b/integration-tests/system-tests.yml
@@ -346,3 +346,20 @@ jobs:
       - uses: ./integration-tests/tests/sign-using-a-hsm
         with:
           log-level: ${{ inputs.log-level }}
+
+  # Added for https://github.com/NLnetLabs/cascade/issues/105
+  strip-dnssec-rrs:
+    name: Add a zone containing DNSSEC RRs and verify that they are not included in the signed zone
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        rust: [stable] # see build job
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/set-build-profile
+        with:
+          build-profile: ${{ inputs.build-profile }}
+      - uses: ./integration-tests/tests/strip-dnssec-rrs
+        with:
+          log-level: ${{ inputs.log-level }}

--- a/integration-tests/tests/strip-dnssec-rrs/action.yml
+++ b/integration-tests/tests/strip-dnssec-rrs/action.yml
@@ -31,12 +31,8 @@ runs:
 
     - name: Verify the NSEC signed zone
       run: |
-        dig @127.0.0.1 -p 4542 example.test AXFR | \
-          dnssec-verify -q -o example.test /dev/stdin
-
-    - name: Check for unexpected records in the signed zone
-      run: |
-        dig @127.0.0.1 -p 4542 example.test AXFR | grep -Ev '(NSEC3|CDNSKEY|CDS)'
+        dig +noall +answer +onesoa @127.0.0.1 -p 4542 example.test AXFR > example-test.axfr.log
+        dnssec-verify -o example.test example-test.axfr.log | tee dnssec-verify.log
 
     - name: Print log files on any failure in this job
       uses: ./.github/actions/print-logfiles

--- a/integration-tests/tests/strip-dnssec-rrs/action.yml
+++ b/integration-tests/tests/strip-dnssec-rrs/action.yml
@@ -1,0 +1,43 @@
+# Making reusable composite actions documented at
+# https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action#creating-a-composite-action-within-the-same-repository
+name: 'strip-dnssec-rrs'
+description: 'Add a zone containing DNSSEC RRs and verify that they are not included in the signed zone'
+runs:
+  using: "composite"
+  steps:
+    - name: Prepare the system test environment
+      uses: ./.github/actions/prepare-systest-env
+
+    - name: Setup and start the cascade daemon
+      uses: ./.github/actions/setup-and-start-cascade
+
+    - name: Load a zone that contains DNSSEC RRs.
+      run: |
+        INTEGRATION_TEST_DIR="${PWD}/integration-tests/strip-dnssec-rrs"
+        ZONE_FILE="${INTEGRATION_TEST_DIR}/example.test"
+        cascade zone add --policy default --source "${ZONE_FILE}" example.test
+
+    - name: Check zone status
+      run: |
+        timeout=10 # seconds
+        start=$(date +%s)
+        until cascade zone status example.test | grep -q "Published zone available"; do
+          if (($(date +%s) > (start + timeout))); then
+            echo "timeout: zone status did not report published zone available" >&2
+            exit 1
+          fi
+          sleep 1
+        done
+
+    - name: Verify the NSEC signed zone
+      run: |
+        dig @127.0.0.1 -p 4542 example.test AXFR | \
+          dnssec-verify -q -o example.test /dev/stdin
+
+    - name: Check for unexpected records in the signed zone
+      run: |
+        dig @127.0.0.1 -p 4542 example.test AXFR | grep -Ev '(NSEC3|CDNSKEY|CDS)'
+
+    - name: Print log files on any failure in this job
+      uses: ./.github/actions/print-logfiles
+      if: failure()

--- a/integration-tests/tests/strip-dnssec-rrs/action.yml
+++ b/integration-tests/tests/strip-dnssec-rrs/action.yml
@@ -1,7 +1,7 @@
 # Making reusable composite actions documented at
 # https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action#creating-a-composite-action-within-the-same-repository
 name: 'strip-dnssec-rrs'
-description: 'Add a zone containing DNSSEC RRs and verify that they are not included in the signed zone'
+description: 'Sign using an already signed input zone.'
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Includes `dnssec-verify` output that shows that the zone is DNSSEC valid.
```
| Loading zone 'example.test' from file 'example-test.axfr.log'
|
| Verifying the zone using the following algorithms:
| - ECDSAP256SHA256
| Zone fully signed:
| Algorithm: ECDSAP256SHA256: KSKs: 1 active, 0 stand-by, 0 revoked
|                             ZSKs: 1 active, 0 stand-by, 0 revoked
```

The test could check more things, e.g. that the original DNSSEC records are indeed gone and replaced by new ones.