### PR TITLE
Initialize the loader within Tokio

### DIFF
--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -51,7 +51,7 @@ impl Loader {
     }
 
     /// Initialize the loader, synchronously.
-    pub fn init(&self, center: &Arc<Center>, state: &mut State) {
+    pub fn init(center: &Arc<Center>, state: &mut State) {
         // Enqueue refreshes for all known zones.
         for zone in &state.zones {
             let mut state = zone.0.state.lock().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,12 +185,6 @@ fn main() -> ExitCode {
         update_tx,
     });
 
-    // Perform pre-async initialization.
-    {
-        let mut state = center.state.lock().unwrap();
-        center.loader.init(&center, &mut state);
-    }
-
     // Set up the rayon threadpool
     rayon::ThreadPoolBuilder::new()
         .thread_name(|_| "cascade-signer".into())
@@ -213,7 +207,7 @@ fn main() -> ExitCode {
     // Enter the runtime.
     let result = runtime.block_on(async {
         // Spawn Cascade's units.
-        let manager = match Manager::spawn(center.clone(), socket_provider).await {
+        let manager = match Manager::spawn(center.clone(), socket_provider) {
             Ok(manager) => manager,
             Err(err) => {
                 error!("Failed to spawn units: {err}");

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -57,11 +57,14 @@ pub struct Manager {
 
 impl Manager {
     /// Spawn all targets.
-    pub async fn spawn(
-        center: Arc<Center>,
-        mut socket_provider: SocketProvider,
-    ) -> Result<Self, Error> {
+    pub fn spawn(center: Arc<Center>, mut socket_provider: SocketProvider) -> Result<Self, Error> {
         let mut metrics = MetricsCollection::new();
+
+        // Initialize the components.
+        {
+            let mut state = center.state.lock().unwrap();
+            Loader::init(&center, &mut state);
+        }
 
         // Spawn the zone loader.
         info!("Starting unit 'ZL'");


### PR DESCRIPTION
Turns out `Loader::init` causes `tokio::task::spawn()`, but it was running before Tokio was initialized.

Fixes #437.