### PR TITLE
Add a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,3 +8,7 @@ Provide your description here
 - If you are adding/deleting man pages:
   - [ ] Did you update the `man_pages` config in `doc/manual/source/conf.py`?
   - [ ] Did you update the packaged man pages in the `Cargo.toml`?
+  - [ ] Did you commit the freshly built man pages?
+
+- If you are modifying man pages:
+  - [ ] Did you commit the updated built man pages?


### PR DESCRIPTION
We had previously talked about forgetting to update the man page configuration when adding or removing pages; and now worry about forgetting to run the integration tests. This PR template would serve as a reminder for anyone opening PRs.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [ ] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?

- If you are adding/deleting man pages:
  - [ ] Did you update the `man_pages` config in `doc/manual/source/conf.py`?
  - [ ] Did you update the packaged man pages in the `Cargo.toml`?
  - [ ] Did you commit the freshly built man pages?

- If you are modifying man pages:
  - [ ] Did you commit the updated built man pages?