### PR TITLE
Support using BIND as a secondary nameserver.

### DIFF
--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -846,6 +846,7 @@ fn zone_server_service(
             // temporary "fix", strictly speaking this is incorrect as not all
             // queries should be responded to with the AA flag set, e.g. we
             // cannot respond authoritatively for glue records.
+            // TODO: Implement a proper fix.
             answer.set_authoritative(true);
             answer
         }


### PR DESCRIPTION
See #435 for the original bug report that this PR works around.

In manual testing with BIND 9.18.44 this resolves the issue described in #435 concerning failure to transfer the signed zone to BIND from Cascade.

As an automated test may take some time to develop and this is a blocking issue for users of BIND as a secondary I have not attempted to include an integration test in this PR, but believe we should develop such a test to prevent this and similar issues in future.

Note that this issue may not be expected because https://github.com/NLnetLabs/domain/pull/400 resolved this problem in `domain`. However, to work around another issue I earlier modified Cascade to use `LightWeightZone` instead of `ZoneApex` and only the latter contains the fix from [#400](https://github.com/NLnetLabs/domain/pull/400).