### PR TITLE
Fix `cargo install` build by enabling `axum`'s `http1` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ futures            = "0.3.17"
 futures-util       = "0.3"
 octseq             = { version = "0.5.2", default-features = false }
 serde              = { workspace = true, features = ["derive", "rc"] }
-axum               = { version = "0.8.4", default-features = false, features = ["http2", "query", "original-uri", "json", "tokio"] }
+axum               = { version = "0.8.4", default-features = false, features = ["http1", "http2", "query", "original-uri", "json", "tokio"] }
 
 # From Rotonda
 crossbeam-utils    = "0.8"


### PR DESCRIPTION
Previously, when all our binaries were a single crate, `reqwest` would reliably enable Hyper's `http1` feature. However, we weren't enabling that feature via Axum. Therefore, Cargo wasn't enabling that feature when you do `cargo install`. We didn't notice this because `cargo build` tries to take the entire workspace into account for feature selection as an optimization and therefore it kept working for us while testing.

This PR simply adds the `http1` feature to Axum, which will enable Hyper's `http1` feature.

Quick rundown of how I tracked down the issue (omitting a lot of dead ends and standing on the shoulders of Ximon's exploration):
- When doing a `cargo install` and then a `cargo build` on the same commit, I noticed that Hyper and its dependents were being rebuilt.
- With the hint that the workspace splitting introduced the issue, I put reqwest back in cascaded, which made it work again.
- Now I knew that it must have something to do with hyper and reqwest.
- `cargo tree --edges features hyper` then showed me which features were only enabled via reqwest: `http1`.

Closes #441 