### PR TITLE
Remove an out-of-context code comment.

### DIFF
--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -1891,9 +1891,6 @@ impl SignRaw for KeyPair {
 //------------ MultiThreadedSorter -------------------------------------------
 
 /// A parallelized sort implementation for use with [`SortedRecords`].
-///
-/// TODO: Should we add a `-j` (jobs) command line argument to override the
-/// default Rayon behaviour of using as many threads as their are CPU cores?
 struct MultiThreadedSorter;
 
 impl domain::dnssec::sign::records::Sorter for MultiThreadedSorter {


### PR DESCRIPTION
The comment which likely came from dnst signzone code.

If options were to be added to Cascade to control how much parallelism is wanted it would likely be done via config file entry, not command line argument.

This comment also has a language typo, their instead of there.

So, multiple reasons to remove it.