### PR TITLE
Reduce CLI client timeout to 30 seconds

### DIFF
--- a/crates/cli/src/client.rs
+++ b/crates/cli/src/client.rs
@@ -4,7 +4,7 @@ use reqwest::{IntoUrl, Method, RequestBuilder};
 use tracing::debug;
 use url::Url;
 
-const HTTP_CLIENT_TIMEOUT: Duration = Duration::from_secs(120);
+const HTTP_CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
 static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
 
 #[derive(Clone)]


### PR DESCRIPTION
Currently, the CLI client timeout is set to 2 minutes. That is a really long time to wait for a TCP connection timeout or other timeouts.

Are our HTTP endpoints fast or do we block on some long running processes still? 
I remember that earlier zone loading would block the CLI and wait for as long as the zone needs loading, and now it reports back quickly that the zone has been added.