### PR TITLE
Trigger global state save on zone add

### DIFF
--- a/src/center.rs
+++ b/src/center.rs
@@ -179,6 +179,11 @@ pub async fn add_zone(
         // NOTE: The zone is marked as dirty by the above operation.
     }
 
+    {
+        let mut state = center.state.lock().unwrap();
+        state.mark_dirty(center);
+    }
+
     info!("Added zone '{name}'");
     Ok(())
 }


### PR DESCRIPTION
I noticed that cascade wouldn't persist global state when adding a zone. This meant that I had cascade running, added a zone, and after 6 minutes there was still no `state.db` file. The zone's state file did exist though.