### PR TITLE
Report back what changes were made to logging and require at least one option set

### DIFF
--- a/crates/cli/src/commands/debug.rs
+++ b/crates/cli/src/commands/debug.rs
@@ -5,7 +5,6 @@ use futures_util::TryFutureExt;
 use crate::{
     api::{self, ChangeLogging, ChangeLoggingResult, TraceTarget},
     client::{CascadeApiClient, format_http_error},
-    println,
 };
 
 #[derive(Clone, Debug, clap::Args)]


### PR DESCRIPTION
Changes:
- Require at least one of the options to be present (otherwise the command doesn't do anything)
- Enable providing multiple trace targets in a single comma-separated argument to `--trace-targets`
- Print what has changed.

I got confused that `cascade debug change-logging` stated that it changed the logging, but I didn't give it any options, so I wondered what it changed to. Turns out it didn't actually change anything.

This PR changes the behaviour to require at least one of the options to be provided, and log what the changes submitted to the server are.

Arguably, now that at least one of the options is required, the verbosity is not really required anymore.

I opted to only set `level` to `required_unless_present_any ...`, as not to confuse users with clap's error message stating that _both_ would be required:

```
error: the following required arguments were not provided:
  --level <LEVEL>
  --trace-targets <TRACE_TARGETS>

Usage: cascade debug change-logging --level <LEVEL> --trace-targets <TRACE_TARGETS>

For more information, try '--help'.
```

Instead, it only shows `--level` as required, as that is the option most commonly used I assume.

```
error: the following required arguments were not provided:
  --level <LEVEL>

Usage: cascade debug change-logging --level <LEVEL>

For more information, try '--help'.
```

Additionally, the help text states that "at least on option of 'level' or 'trace-targets' is required".