### PR TITLE
Add a CLI intro to the quick start docs.

### DIFF
--- a/doc/manual/source/quick-start.rst
+++ b/doc/manual/source/quick-start.rst
@@ -75,8 +75,6 @@ systemd features used instead.
 
             cascaded --config /etc/cascade/config.toml --state /var/lib/cascade/state.db
 
-.. _defining-policy:
-
 Interacting with Cascade
 ------------------------
 
@@ -123,6 +121,8 @@ the CLI to adjust the verbosity of an already running daemon, for example:
 
    $ cascade debug change-logging --level debug
    Changed log-level to: debug
+
+.. _defining-policy:
 
 Defining Policy
 ---------------


### PR DESCRIPTION
Introduce the Cascade CLI before using it, and use the opportunity to show that Cascade starts empty before diving in to the creation of policies.