### PR TITLE
Refactor many get_zone instances away

### DIFF
--- a/integration-tests/system-tests.yml
+++ b/integration-tests/system-tests.yml
@@ -54,7 +54,6 @@ defaults:
   run:
     # see: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defaultsrunshell
     shell: bash --noprofile --norc -eo pipefail -x {0}
-  
 
 jobs:
   test-release-version:
@@ -154,4 +153,9 @@ jobs:
         rust: [stable]
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/set-build-profile
+        with:
+          build-profile: release
       - uses: ./integration-tests/tests/notify-in-for-unknown-zone
+        with:
+          log-level: ${{ inputs.log-level }}

--- a/integration-tests/system-tests.yml
+++ b/integration-tests/system-tests.yml
@@ -145,3 +145,13 @@ jobs:
       - uses: ./integration-tests/tests/ixfr-in
         with:
           log-level: ${{ inputs.log-level }}
+
+  notify-in-for-unknown-zone:
+    name: 
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./integration-tests/tests/notify-in-for-unknown-zone

--- a/integration-tests/system-tests.yml
+++ b/integration-tests/system-tests.yml
@@ -54,7 +54,6 @@ defaults:
   run:
     # see: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defaultsrunshell
     shell: bash --noprofile --norc -eo pipefail -x {0}
-  
 
 jobs:
   test-release-version:
@@ -143,5 +142,20 @@ jobs:
         with:
           build-profile: ${{ inputs.build-profile }}
       - uses: ./integration-tests/tests/ixfr-in
+        with:
+          log-level: ${{ inputs.log-level }}
+
+  notify-in-for-unknown-zone:
+    name: 
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/set-build-profile
+        with:
+          build-profile: release
+      - uses: ./integration-tests/tests/notify-in-for-unknown-zone
         with:
           log-level: ${{ inputs.log-level }}

--- a/integration-tests/tests/notify-in-for-unknown-zone/action.yml
+++ b/integration-tests/tests/notify-in-for-unknown-zone/action.yml
@@ -1,0 +1,44 @@
+# Making reusable composite actions documented at
+# https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action#creating-a-composite-action-within-the-same-repository
+name: 'Receive a NOTIFY for a zone that is unknown to Cascade.'
+description: 'Receive a NOTIFY for a zone that is unknown to Cascade.'
+defaults:
+  # see: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defaultsrunshell
+  run:
+    shell: bash --noprofile --norc -eo pipefail -x {0}
+inputs:
+  log-level:
+    description: The level of logging that Cascade should output.
+    required: false
+    default: debug
+    type: choice
+    options:
+      - error
+      - warning
+      - info
+      - debug
+      - trace
+runs:
+  using: "composite"
+  steps:
+    - uses: ./.github/actions/prepare-systest-env
+    - uses: ./.github/actions/setup-and-start-cascade
+      with:
+        log-level: ${{ inputs.log-level }}
+
+    # If Cascade started quickly enough it may already have received a NOTIFY
+    # from NSD, but if NSD stopped trying to send a NOTIFY already force it to
+    # do so now.
+    - name: Force NSD to send a NOTIFY to Cascade for example.test
+      run: |
+        ./integration-tests/scripts/manage-test-environment.sh control nsd-primary notify example.test
+
+    - name: Check that Cascade didn't crash
+      run: |
+        # If we check the health immediately it might not have crashed yet
+        sleep 4
+        cascade health
+
+    - name: Print log files on any failure in this job
+      uses: ./.github/actions/print-logfiles
+      if: failure()

--- a/integration-tests/tests/notify-in-for-unknown-zone/action.yml
+++ b/integration-tests/tests/notify-in-for-unknown-zone/action.yml
@@ -33,18 +33,11 @@ runs:
       run: |
         ./integration-tests/scripts/manage-test-environment.sh control nsd-primary notify example.test
 
-    - name: Check Cascade status
+    - name: Check that Cascade didn't crash
       run: |
-        timeout=10 # seconds
-        start=$(date +%s)
-        until cascade status | grep -q "Published zone available"; do
-          if (($(date +%s) > (start + timeout))); then
-            cascade status 
-            echo "::error:: timeout: Cascade status did not report published zone available"
-            exit 1
-          fi
-          sleep 1
-        done
+        # If we check the health immediately it might not have crashed yet
+        sleep 4
+        cascade health
 
     - name: Print log files on any failure in this job
       uses: ./.github/actions/print-logfiles

--- a/integration-tests/tests/notify-in-for-unknown-zone/action.yml
+++ b/integration-tests/tests/notify-in-for-unknown-zone/action.yml
@@ -1,0 +1,51 @@
+# Making reusable composite actions documented at
+# https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action#creating-a-composite-action-within-the-same-repository
+name: 'Receive a NOTIFY for a zone that is unknown to Cascade.'
+description: 'Receive a NOTIFY for a zone that is unknown to Cascade.'
+defaults:
+  # see: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defaultsrunshell
+  run:
+    shell: bash --noprofile --norc -eo pipefail -x {0}
+inputs:
+  log-level:
+    description: The level of logging that Cascade should output.
+    required: false
+    default: debug
+    type: choice
+    options:
+      - error
+      - warning
+      - info
+      - debug
+      - trace
+runs:
+  using: "composite"
+  steps:
+    - uses: ./.github/actions/prepare-systest-env
+    - uses: ./.github/actions/setup-and-start-cascade
+      with:
+        log-level: ${{ inputs.log-level }}
+
+    # If Cascade started quickly enough it may already have received a NOTIFY
+    # from NSD, but if NSD stopped trying to send a NOTIFY already force it to
+    # do so now.
+    - name: Force NSD to send a NOTIFY to Cascade for example.test
+      run: |
+        ./integration-tests/scripts/manage-test-environment.sh control nsd-primary notify example.test
+
+    - name: Check Cascade status
+      run: |
+        timeout=10 # seconds
+        start=$(date +%s)
+        until cascade status | grep -q "Published zone available"; do
+          if (($(date +%s) > (start + timeout))); then
+            cascade status 
+            echo "::error:: timeout: Cascade status did not report published zone available"
+            exit 1
+          fi
+          sleep 1
+        done
+
+    - name: Print log files on any failure in this job
+      uses: ./.github/actions/print-logfiles
+      if: failure()

--- a/src/center.rs
+++ b/src/center.rs
@@ -146,7 +146,7 @@ pub async fn add_zone(
         return Err(err);
     }
 
-    record_zone_event(center, &name, HistoricalEvent::Added, None);
+    record_zone_event(center, &zone, HistoricalEvent::Added, None);
 
     {
         let mut state = zone.state.lock().unwrap();
@@ -260,20 +260,18 @@ pub fn get_zone(center: &Arc<Center>, name: &StoredName) -> Option<Arc<Zone>> {
     state.zones.get(name).map(|zone| zone.0.clone())
 }
 
-pub fn halt_zone(center: &Arc<Center>, zone_name: &StoredName, hard: bool, reason: &str) {
+pub fn halt_zone(center: &Arc<Center>, zone: &Arc<Zone>, hard: bool, reason: &str) {
     let mut state = center.state.lock().unwrap();
-    if let Some(zone) = state.zones.get(zone_name) {
-        let mut zone_state = zone.0.state.lock().unwrap();
-        if hard {
-            if !matches!(zone_state.pipeline_mode, PipelineMode::HardHalt(_)) {
-                zone_state.hard_halt(reason.to_string());
-            }
-        } else if !matches!(
-            zone_state.pipeline_mode,
-            PipelineMode::SoftHalt(_) | PipelineMode::HardHalt(_)
-        ) {
-            zone_state.soft_halt(reason.to_string());
+    let mut zone_state = zone.state.lock().unwrap();
+    if hard {
+        if !matches!(zone_state.pipeline_mode, PipelineMode::HardHalt(_)) {
+            zone_state.hard_halt(reason.to_string());
         }
+    } else if !matches!(
+        zone_state.pipeline_mode,
+        PipelineMode::SoftHalt(_) | PipelineMode::HardHalt(_)
+    ) {
+        zone_state.soft_halt(reason.to_string());
     }
     state.mark_dirty(center);
 }

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -17,7 +17,7 @@ use std::{
 use camino::Utf8Path;
 use cascade_api::ZoneReloadError;
 use cascade_zonedata::LoadedZoneBuilder;
-use domain::{new::base::Serial, tsig, zonetree::StoredName};
+use domain::{new::base::Serial, tsig};
 use tracing::{debug, error, info};
 
 use crate::{
@@ -85,11 +85,10 @@ impl Loader {
         }))
     }
 
-    pub fn on_refresh_zone(&self, center: &Arc<Center>, zone_name: StoredName) {
-        let zone = crate::center::get_zone(center, &zone_name).expect("zone exists");
+    pub fn on_refresh_zone(&self, center: &Arc<Center>, zone: &Arc<Zone>) {
         let mut state = zone.state.lock().expect("lock is not poisoned");
         ZoneHandle {
-            zone: &zone,
+            zone,
             state: &mut state,
             center,
         }
@@ -100,10 +99,8 @@ impl Loader {
     pub fn on_reload_zone(
         &self,
         center: &Arc<Center>,
-        zone_name: StoredName,
+        zone: &Arc<Zone>,
     ) -> Result<(), ZoneReloadError> {
-        let zone =
-            crate::center::get_zone(center, &zone_name).ok_or(ZoneReloadError::ZoneDoesNotExist)?;
         let mut zone_state = zone.state.lock().expect("lock is not poisoned");
         if let Some(reason) = zone_state.halted(true) {
             return Err(ZoneReloadError::ZoneHalted(reason));
@@ -112,7 +109,7 @@ impl Loader {
             return Err(ZoneReloadError::ZoneWithoutSource);
         }
         ZoneHandle {
-            zone: &zone,
+            zone,
             state: &mut zone_state,
             center,
         }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use crate::center::{Center, get_zone};
+use crate::center::Center;
 use crate::daemon::SocketProvider;
 use crate::loader::Loader;
 use crate::metrics::MetricsCollection;
@@ -12,10 +12,9 @@ use crate::units::key_manager::KeyManager;
 use crate::units::zone_server::{self, ZoneServer};
 use crate::units::zone_signer::ZoneSigner;
 use crate::util::AbortOnDrop;
-use crate::zone::HistoricalEvent;
+use crate::zone::{HistoricalEvent, Zone};
 use daemonbase::process::EnvSocketsError;
 use domain::base::Serial;
-use domain::zonetree::StoredName;
 use tracing::{debug, error, info};
 
 //----------- Manager ----------------------------------------------------------
@@ -124,15 +123,13 @@ impl Manager {
 
 pub fn record_zone_event(
     center: &Arc<Center>,
-    name: &StoredName,
+    zone: &Arc<Zone>,
     event: HistoricalEvent,
     serial: Option<Serial>,
 ) {
-    if let Some(zone) = get_zone(center, name) {
-        let mut zone_state = zone.state.lock().unwrap();
-        zone_state.record_event(event, serial);
-        zone.mark_dirty(&mut zone_state, center);
-    }
+    let mut zone_state = zone.state.lock().unwrap();
+    zone_state.record_event(event, serial);
+    zone.mark_dirty(&mut zone_state, center);
 }
 
 //----------- Error ------------------------------------------------------------

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -105,7 +105,7 @@ async fn sign(
             std::mem::drop(state);
 
             // TODO: Inline.
-            halt_zone(&center, &zone.name, true, &error.to_string());
+            halt_zone(&center, &zone, true, &error.to_string());
         }
     }
 }

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -29,7 +29,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use tokio::net::TcpListener;
 use tokio::task::JoinSet;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::api;
 use crate::api::KeyInfo;
@@ -325,15 +325,19 @@ impl HttpServer {
         let unsigned_review_status;
         let signed_review_status;
         let pipeline_mode;
+        let zone;
         {
             let locked_state = state.center.state.lock().unwrap();
             let keys_dir = &state.center.config.keys_dir;
             state_path = mk_dnst_keyset_state_file_path(keys_dir, &name);
-            let zone = locked_state
+            zone = locked_state
                 .zones
                 .get(&name)
-                .ok_or(ZoneStatusError::ZoneDoesNotExist)?;
-            let zone_state = zone.0.state.lock().unwrap();
+                .ok_or(ZoneStatusError::ZoneDoesNotExist)?
+                .0
+                .clone();
+
+            let zone_state = zone.state.lock().unwrap();
             pipeline_mode = zone_state.pipeline_mode.clone();
             policy = zone_state
                 .policy
@@ -489,14 +493,13 @@ impl HttpServer {
         // Query signing status
         let signing_report = if stage >= ZoneStage::Signed {
             let center = &state.center;
-            center.signer.on_signing_report(center, name.clone())
+            center.signer.on_signing_report(&zone)
         } else {
             None
         };
 
         // TODO: Report separate information for ongoing and completed loads.
         let receipt_report = {
-            let zone = get_zone(&state.center, &name).unwrap();
             let state = zone.state.lock().unwrap();
             let active = state.loader.active_load_metrics.as_ref();
             let last = state.loader.last_load_metrics.as_ref();
@@ -592,23 +595,31 @@ impl HttpServer {
 
     fn do_zone_reload(
         api_state: Arc<HttpServer>,
-        name: Name<Bytes>,
+        zone_name: Name<Bytes>,
     ) -> Result<ZoneReloadResult, ZoneReloadError> {
         let center = &api_state.center;
-        center.loader.on_reload_zone(center, name.clone())?;
-        Ok(ZoneReloadResult { name })
+        let zone =
+            crate::center::get_zone(center, &zone_name).ok_or(ZoneReloadError::ZoneDoesNotExist)?;
+        center.loader.on_reload_zone(center, &zone)?;
+        Ok(ZoneReloadResult { name: zone_name })
     }
 
     /// Approve an unsigned version of a zone.
     async fn approve_unsigned(
         State(state): State<Arc<HttpServer>>,
-        Path((name, serial)): Path<(Name<Bytes>, Serial)>,
+        Path((zone_name, zone_serial)): Path<(Name<Bytes>, Serial)>,
     ) -> Json<ZoneReviewResult> {
         let center = &state.center;
+        let Some(zone) = get_zone(center, &zone_name) else {
+            debug!(
+                "[{HTTP_UNIT_NAME}] Got a review approval for unsigned {zone_name}/{zone_serial}, but the zone does not exist"
+            );
+            return Json(Err(ZoneReviewError::NoSuchZone));
+        };
         let result = center.unsigned_review_server.on_zone_review(
             center,
-            name,
-            serial,
+            &zone,
+            zone_serial,
             ZoneReviewDecision::Approve,
         );
 
@@ -618,13 +629,19 @@ impl HttpServer {
     /// Reject an unsigned version of a zone.
     async fn reject_unsigned(
         State(state): State<Arc<HttpServer>>,
-        Path((name, serial)): Path<(Name<Bytes>, Serial)>,
+        Path((zone_name, zone_serial)): Path<(Name<Bytes>, Serial)>,
     ) -> Json<ZoneReviewResult> {
         let center = &state.center;
+        let Some(zone) = get_zone(center, &zone_name) else {
+            debug!(
+                "[{HTTP_UNIT_NAME}] Got a review rejection for unsigned {zone_name}/{zone_serial}, but the zone does not exist"
+            );
+            return Json(Err(ZoneReviewError::NoSuchZone));
+        };
         let result = center.unsigned_review_server.on_zone_review(
             center,
-            name,
-            serial,
+            &zone,
+            zone_serial,
             ZoneReviewDecision::Reject,
         );
 
@@ -634,13 +651,19 @@ impl HttpServer {
     /// Approve a signed version of a zone.
     async fn approve_signed(
         State(state): State<Arc<HttpServer>>,
-        Path((name, serial)): Path<(Name<Bytes>, Serial)>,
+        Path((zone_name, zone_serial)): Path<(Name<Bytes>, Serial)>,
     ) -> Json<ZoneReviewResult> {
         let center = &state.center;
+        let Some(zone) = get_zone(center, &zone_name) else {
+            debug!(
+                "[{HTTP_UNIT_NAME}] Got a review approval for signed {zone_name}/{zone_serial}, but the zone does not exist"
+            );
+            return Json(Err(ZoneReviewError::NoSuchZone));
+        };
         let result = center.signed_review_server.on_zone_review(
             center,
-            name,
-            serial,
+            &zone,
+            zone_serial,
             ZoneReviewDecision::Approve,
         );
 
@@ -650,13 +673,19 @@ impl HttpServer {
     /// Reject a signed version of a zone.
     async fn reject_signed(
         State(state): State<Arc<HttpServer>>,
-        Path((name, serial)): Path<(Name<Bytes>, Serial)>,
+        Path((zone_name, zone_serial)): Path<(Name<Bytes>, Serial)>,
     ) -> Json<ZoneReviewResult> {
         let center = &state.center;
+        let Some(zone) = get_zone(center, &zone_name) else {
+            debug!(
+                "[{HTTP_UNIT_NAME}] Got a review rejection for signed {zone_name}/{zone_serial}, but the zone does not exist"
+            );
+            return Json(Err(ZoneReviewError::NoSuchZone));
+        };
         let result = center.signed_review_server.on_zone_review(
             center,
-            name,
-            serial,
+            &zone,
+            zone_serial,
             ZoneReviewDecision::Reject,
         );
 

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -612,7 +612,7 @@ impl HttpServer {
         let center = &state.center;
         let Some(zone) = get_zone(center, &zone_name) else {
             debug!(
-                "[{HTTP_UNIT_NAME}] Got a review for {zone_name}/{zone_serial}, but the zone does not exist"
+                "[{HTTP_UNIT_NAME}] Got a review approval for unsigned {zone_name}/{zone_serial}, but the zone does not exist"
             );
             return Json(Err(ZoneReviewError::NoSuchZone));
         };
@@ -634,7 +634,7 @@ impl HttpServer {
         let center = &state.center;
         let Some(zone) = get_zone(center, &zone_name) else {
             debug!(
-                "[{HTTP_UNIT_NAME}] Got a review for {zone_name}/{zone_serial}, but the zone does not exist"
+                "[{HTTP_UNIT_NAME}] Got a review rejection for unsigned {zone_name}/{zone_serial}, but the zone does not exist"
             );
             return Json(Err(ZoneReviewError::NoSuchZone));
         };
@@ -656,7 +656,7 @@ impl HttpServer {
         let center = &state.center;
         let Some(zone) = get_zone(center, &zone_name) else {
             debug!(
-                "[{HTTP_UNIT_NAME}] Got a review for {zone_name}/{zone_serial}, but the zone does not exist"
+                "[{HTTP_UNIT_NAME}] Got a review approval for signed {zone_name}/{zone_serial}, but the zone does not exist"
             );
             return Json(Err(ZoneReviewError::NoSuchZone));
         };
@@ -678,7 +678,7 @@ impl HttpServer {
         let center = &state.center;
         let Some(zone) = get_zone(center, &zone_name) else {
             debug!(
-                "[{HTTP_UNIT_NAME}] Got a review for {zone_name}/{zone_serial}, but the zone does not exist"
+                "[{HTTP_UNIT_NAME}] Got a review rejection for signed {zone_name}/{zone_serial}, but the zone does not exist"
             );
             return Json(Err(ZoneReviewError::NoSuchZone));
         };

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -29,7 +29,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use tokio::net::TcpListener;
 use tokio::task::JoinSet;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::api;
 use crate::api::KeyInfo;
@@ -325,15 +325,19 @@ impl HttpServer {
         let unsigned_review_status;
         let signed_review_status;
         let pipeline_mode;
+        let zone;
         {
             let locked_state = state.center.state.lock().unwrap();
             let keys_dir = &state.center.config.keys_dir;
             state_path = mk_dnst_keyset_state_file_path(keys_dir, &name);
-            let zone = locked_state
+            zone = locked_state
                 .zones
                 .get(&name)
-                .ok_or(ZoneStatusError::ZoneDoesNotExist)?;
-            let zone_state = zone.0.state.lock().unwrap();
+                .ok_or(ZoneStatusError::ZoneDoesNotExist)?
+                .0
+                .clone();
+
+            let zone_state = zone.state.lock().unwrap();
             pipeline_mode = zone_state.pipeline_mode.clone();
             policy = zone_state
                 .policy
@@ -489,14 +493,13 @@ impl HttpServer {
         // Query signing status
         let signing_report = if stage >= ZoneStage::Signed {
             let center = &state.center;
-            center.signer.on_signing_report(center, name.clone())
+            center.signer.on_signing_report(&zone)
         } else {
             None
         };
 
         // TODO: Report separate information for ongoing and completed loads.
         let receipt_report = {
-            let zone = get_zone(&state.center, &name).unwrap();
             let state = zone.state.lock().unwrap();
             let active = state.loader.active_load_metrics.as_ref();
             let last = state.loader.last_load_metrics.as_ref();
@@ -592,23 +595,31 @@ impl HttpServer {
 
     fn do_zone_reload(
         api_state: Arc<HttpServer>,
-        name: Name<Bytes>,
+        zone_name: Name<Bytes>,
     ) -> Result<ZoneReloadResult, ZoneReloadError> {
         let center = &api_state.center;
-        center.loader.on_reload_zone(center, name.clone())?;
-        Ok(ZoneReloadResult { name })
+        let zone =
+            crate::center::get_zone(center, &zone_name).ok_or(ZoneReloadError::ZoneDoesNotExist)?;
+        center.loader.on_reload_zone(center, &zone)?;
+        Ok(ZoneReloadResult { name: zone_name })
     }
 
     /// Approve an unsigned version of a zone.
     async fn approve_unsigned(
         State(state): State<Arc<HttpServer>>,
-        Path((name, serial)): Path<(Name<Bytes>, Serial)>,
+        Path((zone_name, zone_serial)): Path<(Name<Bytes>, Serial)>,
     ) -> Json<ZoneReviewResult> {
         let center = &state.center;
+        let Some(zone) = get_zone(center, &zone_name) else {
+            debug!(
+                "[{HTTP_UNIT_NAME}] Got a review for {zone_name}/{zone_serial}, but the zone does not exist"
+            );
+            return Json(Err(ZoneReviewError::NoSuchZone));
+        };
         let result = center.unsigned_review_server.on_zone_review(
             center,
-            name,
-            serial,
+            &zone,
+            zone_serial,
             ZoneReviewDecision::Approve,
         );
 
@@ -618,13 +629,19 @@ impl HttpServer {
     /// Reject an unsigned version of a zone.
     async fn reject_unsigned(
         State(state): State<Arc<HttpServer>>,
-        Path((name, serial)): Path<(Name<Bytes>, Serial)>,
+        Path((zone_name, zone_serial)): Path<(Name<Bytes>, Serial)>,
     ) -> Json<ZoneReviewResult> {
         let center = &state.center;
+        let Some(zone) = get_zone(center, &zone_name) else {
+            debug!(
+                "[{HTTP_UNIT_NAME}] Got a review for {zone_name}/{zone_serial}, but the zone does not exist"
+            );
+            return Json(Err(ZoneReviewError::NoSuchZone));
+        };
         let result = center.unsigned_review_server.on_zone_review(
             center,
-            name,
-            serial,
+            &zone,
+            zone_serial,
             ZoneReviewDecision::Reject,
         );
 
@@ -634,13 +651,19 @@ impl HttpServer {
     /// Approve a signed version of a zone.
     async fn approve_signed(
         State(state): State<Arc<HttpServer>>,
-        Path((name, serial)): Path<(Name<Bytes>, Serial)>,
+        Path((zone_name, zone_serial)): Path<(Name<Bytes>, Serial)>,
     ) -> Json<ZoneReviewResult> {
         let center = &state.center;
+        let Some(zone) = get_zone(center, &zone_name) else {
+            debug!(
+                "[{HTTP_UNIT_NAME}] Got a review for {zone_name}/{zone_serial}, but the zone does not exist"
+            );
+            return Json(Err(ZoneReviewError::NoSuchZone));
+        };
         let result = center.signed_review_server.on_zone_review(
             center,
-            name,
-            serial,
+            &zone,
+            zone_serial,
             ZoneReviewDecision::Approve,
         );
 
@@ -650,13 +673,19 @@ impl HttpServer {
     /// Reject a signed version of a zone.
     async fn reject_signed(
         State(state): State<Arc<HttpServer>>,
-        Path((name, serial)): Path<(Name<Bytes>, Serial)>,
+        Path((zone_name, zone_serial)): Path<(Name<Bytes>, Serial)>,
     ) -> Json<ZoneReviewResult> {
         let center = &state.center;
+        let Some(zone) = get_zone(center, &zone_name) else {
+            debug!(
+                "[{HTTP_UNIT_NAME}] Got a review for {zone_name}/{zone_serial}, but the zone does not exist"
+            );
+            return Json(Err(ZoneReviewError::NoSuchZone));
+        };
         let result = center.signed_review_server.on_zone_review(
             center,
-            name,
-            serial,
+            &zone,
+            zone_serial,
             ZoneReviewDecision::Reject,
         );
 

--- a/src/units/key_manager.rs
+++ b/src/units/key_manager.rs
@@ -1,6 +1,6 @@
 use crate::api;
 use crate::api::{FileKeyImport, KeyImport, KmipKeyImport};
-use crate::center::{Center, ZoneAddError};
+use crate::center::{Center, ZoneAddError, get_zone};
 use crate::manager::record_zone_event;
 use crate::policy::{KeyParameters, PolicyVersion};
 use crate::units::http_server::KmipServerState;
@@ -391,15 +391,19 @@ impl KeyManager {
     }
 
     async fn tick(&self, center: &Arc<Center>) {
-        let zone_tree = &center.unsigned_zones;
         let Ok(mut ks_info) = self.ks_info.try_lock() else {
             // An existing call to tick() is still busy, don't do anything.
             return;
         };
-        for zone in zone_tree.load().iter_zones() {
-            let apex_name = zone.apex_name().to_string();
-            let state_path =
-                mk_dnst_keyset_state_file_path(&center.config.keys_dir, zone.apex_name());
+        #[allow(clippy::mutable_key_type)]
+        let zones = {
+            let state = center.state.lock().unwrap();
+            state.zones.clone()
+        };
+        for zone in zones {
+            let zone = &zone.0;
+            let apex_name = zone.name.to_string();
+            let state_path = mk_dnst_keyset_state_file_path(&center.config.keys_dir, &zone.name);
             if !state_path.exists() {
                 continue;
             }
@@ -440,7 +444,7 @@ impl KeyManager {
                 info!("[CC]: Instructing zone signer to re-sign the zone");
                 center.signer.on_sign_zone(
                     center,
-                    zone.apex_name().clone(),
+                    zone,
                     None,
                     SigningTrigger::ExternallyModifiedKeySetState,
                 );
@@ -456,11 +460,10 @@ impl KeyManager {
                 // keyset times out trying to contact nameservers. This will
                 // block the loop so we won't check the keyset state for the
                 // next zone till after the call to cron finishes.
-                let Ok(res) =
-                    Self::keyset_cmd(center, zone.apex_name().clone(), RecordingMode::Record)
-                        .arg("cron")
-                        .output()
-                        .await
+                let Ok(res) = Self::keyset_cmd(center, zone.name.clone(), RecordingMode::Record)
+                    .arg("cron")
+                    .output()
+                    .await
                 else {
                     info.clear_cron_next();
                     continue;
@@ -485,7 +488,7 @@ impl KeyManager {
                         info!("[CC]: Instructing zone signer to re-sign the zone");
                         center.signer.on_sign_zone(
                             center,
-                            zone.apex_name().clone(),
+                            zone,
                             None,
                             SigningTrigger::KeySetModifiedAfterCron,
                         );
@@ -1135,7 +1138,8 @@ impl KeySetCommand {
 
         if let Some(history_event) = history_event {
             // Record the error in the zone history
-            record_zone_event(&self.center, &self.name, history_event, None);
+            let zone = get_zone(&self.center, &self.name).unwrap();
+            record_zone_event(&self.center, &zone, history_event, None);
         }
 
         res

--- a/src/units/key_manager.rs
+++ b/src/units/key_manager.rs
@@ -33,7 +33,7 @@ use tracing::{debug, error, warn};
 /// The key manager.
 #[derive(Debug)]
 pub struct KeyManager {
-    ks_info: Mutex<HashMap<String, KeySetInfo>>,
+    ks_info: Mutex<HashMap<Name<Bytes>, KeySetInfo>>,
 }
 
 impl KeyManager {
@@ -392,27 +392,31 @@ impl KeyManager {
     }
 
     async fn tick(&self, center: &Arc<Center>) {
-        let zone_tree = &center.unsigned_zones;
         let Ok(mut ks_info) = self.ks_info.try_lock() else {
             // An existing call to tick() is still busy, don't do anything.
             return;
         };
-        for zone in zone_tree.load().iter_zones() {
-            let apex_name = zone.apex_name().to_string();
-            let state_path =
-                mk_dnst_keyset_state_file_path(&center.config.keys_dir, zone.apex_name());
+        #[allow(clippy::mutable_key_type)]
+        let zones = {
+            let state = center.state.lock().unwrap();
+            state.zones.clone()
+        };
+        for zone in zones {
+            let zone = &zone.0;
+            let state_path = mk_dnst_keyset_state_file_path(&center.config.keys_dir, &zone.name);
             if !state_path.exists() {
                 continue;
             }
 
-            let info = match ks_info.entry(apex_name.clone()) {
+            let info = match ks_info.entry(zone.name.clone()) {
                 std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
                 std::collections::hash_map::Entry::Vacant(entry) => {
                     match KeySetInfo::try_from(&state_path) {
                         Ok(new_info) => entry.insert(new_info.clone()),
                         Err(err) => {
                             error!(
-                                "[KM]: Failed to load key set state for zone '{apex_name}': {err}"
+                                "[KM]: Failed to load key set state for zone '{}': {err}",
+                                zone.name,
                             );
                             continue;
                         }
@@ -437,11 +441,10 @@ impl KeyManager {
                         continue;
                     }
                 };
-                let _ = ks_info.insert(apex_name, new_info);
-                let zone = get_zone(center, zone.apex_name()).unwrap();
+                let _ = ks_info.insert(zone.name.clone(), new_info);
                 let mut state = zone.state.lock().unwrap();
                 ZoneHandle {
-                    zone: &zone,
+                    zone,
                     state: &mut state,
                     center,
                 }
@@ -459,11 +462,10 @@ impl KeyManager {
                 // keyset times out trying to contact nameservers. This will
                 // block the loop so we won't check the keyset state for the
                 // next zone till after the call to cron finishes.
-                let Ok(res) =
-                    Self::keyset_cmd(center, zone.apex_name().clone(), RecordingMode::Record)
-                        .arg("cron")
-                        .output()
-                        .await
+                let Ok(res) = Self::keyset_cmd(center, zone.name.clone(), RecordingMode::Record)
+                    .arg("cron")
+                    .output()
+                    .await
                 else {
                     info.clear_cron_next();
                     continue;
@@ -484,11 +486,10 @@ impl KeyManager {
                         // Something happened. Update ks_info and signal the
                         // signer.
                         // let new_info = get_keyset_info(&state_path);
-                        let _ = ks_info.insert(apex_name, new_info);
-                        let zone = get_zone(center, zone.apex_name()).unwrap();
+                        let _ = ks_info.insert(zone.name.clone(), new_info);
                         let mut state = zone.state.lock().unwrap();
                         ZoneHandle {
-                            zone: &zone,
+                            zone,
                             state: &mut state,
                             center,
                         }
@@ -1140,7 +1141,8 @@ impl KeySetCommand {
 
         if let Some(history_event) = history_event {
             // Record the error in the zone history
-            record_zone_event(&self.center, &self.name, history_event, None);
+            let zone = get_zone(&self.center, &self.name).unwrap();
+            record_zone_event(&self.center, &zone, history_event, None);
         }
 
         res

--- a/src/units/key_manager.rs
+++ b/src/units/key_manager.rs
@@ -32,7 +32,7 @@ use tracing::{debug, error, info, warn};
 /// The key manager.
 #[derive(Debug)]
 pub struct KeyManager {
-    ks_info: Mutex<HashMap<String, KeySetInfo>>,
+    ks_info: Mutex<HashMap<Name<Bytes>, KeySetInfo>>,
 }
 
 impl KeyManager {
@@ -402,20 +402,20 @@ impl KeyManager {
         };
         for zone in zones {
             let zone = &zone.0;
-            let apex_name = zone.name.to_string();
             let state_path = mk_dnst_keyset_state_file_path(&center.config.keys_dir, &zone.name);
             if !state_path.exists() {
                 continue;
             }
 
-            let info = match ks_info.entry(apex_name.clone()) {
+            let info = match ks_info.entry(zone.name.clone()) {
                 std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
                 std::collections::hash_map::Entry::Vacant(entry) => {
                     match KeySetInfo::try_from(&state_path) {
                         Ok(new_info) => entry.insert(new_info.clone()),
                         Err(err) => {
                             error!(
-                                "[KM]: Failed to load key set state for zone '{apex_name}': {err}"
+                                "[KM]: Failed to load key set state for zone '{}': {err}",
+                                zone.name,
                             );
                             continue;
                         }
@@ -440,7 +440,7 @@ impl KeyManager {
                         continue;
                     }
                 };
-                let _ = ks_info.insert(apex_name, new_info);
+                let _ = ks_info.insert(zone.name.clone(), new_info);
                 info!("[CC]: Instructing zone signer to re-sign the zone");
                 center.signer.on_sign_zone(
                     center,
@@ -484,7 +484,7 @@ impl KeyManager {
                         // Something happened. Update ks_info and signal the
                         // signer.
                         // let new_info = get_keyset_info(&state_path);
-                        let _ = ks_info.insert(apex_name, new_info);
+                        let _ = ks_info.insert(zone.name.clone(), new_info);
                         info!("[CC]: Instructing zone signer to re-sign the zone");
                         center.signer.on_sign_zone(
                             center,

--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -825,10 +825,10 @@ impl Notifiable for LoaderNotifier {
             // do a SOA query to our configured upstreams.
             let center = &self.center;
             if let Some(zone) = crate::center::get_zone(center, apex_name) {
-                info!("[CC]: Instructing zone loader to refresh the zone");
+                info!("Instructing zone loader to refresh zone '{apex_name}");
                 center.loader.on_refresh_zone(center, &zone);
             } else {
-                error!("Got a NOTIFY for non-existent zone '{apex_name}'");
+                warn!("Ignoring NOTIFY for unknown zone '{apex_name}'");
             }
         }
 

--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -38,7 +38,7 @@ use tracing::{debug, error, info, trace, warn};
 use crate::api::{
     ZoneReviewDecision, ZoneReviewError, ZoneReviewOutput, ZoneReviewResult, ZoneReviewStatus,
 };
-use crate::center::{Center, get_zone};
+use crate::center::Center;
 use crate::common::tsig::TsigKeyStore;
 use crate::config::SocketConfig;
 use crate::daemon::SocketProvider;
@@ -240,16 +240,16 @@ impl ZoneServer {
     pub fn on_publish_signed_zone(
         &self,
         center: &Arc<Center>,
-        zone_name: Name<Bytes>,
+        zone: &Arc<Zone>,
         zone_serial: Serial,
     ) {
         let unit_name = self.unit_name();
-        info!("[{unit_name}]: Publishing signed zone '{zone_name}' at serial {zone_serial}.");
+        let zone_name = &zone.name;
+        info!("[{unit_name}]: Publishing signed zone '{zone_name}' at serial {zone_serial}.",);
 
         // Move next_min_expiration to min_expiration, and determine policy.
         let policy = {
             // Use a block to make sure that the mutex is clearly dropped.
-            let zone = get_zone(center, &zone_name).unwrap();
             let mut zone_state = zone.state.lock().unwrap();
 
             // Save as next_min_expiration. After the signed zone is approved
@@ -264,7 +264,8 @@ impl ZoneServer {
         // Move the zone from the signed collection to the published collection.
         // TODO: Bump the zone serial?
         let signed_zones = center.signed_zones.load();
-        if let Some(zone) = signed_zones.get_zone(&zone_name, Class::IN) {
+
+        if let Some(zone) = signed_zones.get_zone(&zone.name, Class::IN) {
             // Create a deep copy of the set of
             // published zones. We will add the
             // new zone to that copied set and
@@ -318,7 +319,7 @@ impl ZoneServer {
     pub fn on_seek_approval_for_zone(
         &self,
         center: &Arc<Center>,
-        zone_name: Name<Bytes>,
+        zone: &Arc<Zone>,
         zone_serial: Serial,
     ) -> Option<Result<(), Terminated>> {
         let unit_name = self.unit_name();
@@ -327,8 +328,6 @@ impl ZoneServer {
             Source::Signed => "signed",
             Source::Published => unreachable!(),
         };
-
-        let zone = get_zone(center, &zone_name).unwrap();
 
         let review = {
             let zone_state = zone.state.lock().unwrap();
@@ -355,23 +354,24 @@ impl ZoneServer {
             }
         };
 
+        let zone_name = &zone.name;
         if !review.required {
             // Approve immediately.
             match self.source {
                 Source::Unsigned => {
                     info!("[{unit_name}]: Adding '{zone_name}' to the set of signable zones.");
                     if let Err(err) =
-                        ZoneServer::promote_zone_to_signable(center.clone(), &zone_name)
+                        ZoneServer::promote_zone_to_signable(center.clone(), zone_name)
                     {
                         error!(
                             "[{unit_name}]: Cannot promote unsigned zone '{zone_name}' to the signable set of zones: {err}"
                         );
                     } else {
-                        self.on_unsigned_zone_approved(center, &zone, zone_serial);
+                        self.on_unsigned_zone_approved(center, zone, zone_serial);
                     }
                 }
                 Source::Signed => {
-                    self.on_signed_zone_approved(center, zone_name, zone_serial);
+                    self.on_signed_zone_approved(center, zone, zone_serial);
                 }
                 Source::Published => unreachable!(),
             }
@@ -414,7 +414,7 @@ impl ZoneServer {
             }
         }
 
-        record_zone_event(center, &zone_name, pending_event, Some(zone_serial));
+        record_zone_event(center, zone, pending_event, Some(zone_serial));
 
         if review.cmd_hook.is_none() || review_server.is_none() {
             match (review_server, review.cmd_hook) {
@@ -475,6 +475,7 @@ impl ZoneServer {
                 tokio::spawn(async move {
                     let _: Result<_, _> = Self::process_output(stderr, true).await;
                 });
+                let zone = zone.clone();
                 tokio::spawn(async move {
                     let status = match child.wait().await {
                         Ok(status) => status,
@@ -496,7 +497,7 @@ impl ZoneServer {
                         "signed" => &center.signed_review_server,
                         _ => unreachable!(),
                     };
-                    let _ = server.on_zone_review(&center, zone_name, zone_serial, decision);
+                    let _ = server.on_zone_review(&center, &zone, zone_serial, decision);
                 });
             }
             Err(err) => {
@@ -540,15 +541,10 @@ impl ZoneServer {
         .approve_loaded();
     }
 
-    fn on_signed_zone_approved(
-        &self,
-        center: &Arc<Center>,
-        zone_name: Name<Bytes>,
-        zone_serial: Serial,
-    ) {
+    fn on_signed_zone_approved(&self, center: &Arc<Center>, zone: &Arc<Zone>, zone_serial: Serial) {
         record_zone_event(
             center,
-            &zone_name,
+            zone,
             HistoricalEvent::SignedZoneReview {
                 status: crate::api::ZoneReviewStatus::Approved,
             },
@@ -562,7 +558,7 @@ impl ZoneServer {
         info!("[CC]: Instructing publication server to publish the signed zone");
         center
             .publication_server
-            .on_publish_signed_zone(center, zone_name, zone_serial);
+            .on_publish_signed_zone(center, zone, zone_serial);
     }
 
     async fn process_output(
@@ -586,19 +582,14 @@ impl ZoneServer {
     pub fn on_zone_review(
         &self,
         center: &Arc<Center>,
-        zone_name: Name<Bytes>,
+        zone: &Arc<Zone>,
         zone_serial: Serial,
         decision: ZoneReviewDecision,
     ) -> ZoneReviewResult {
         let unit_name = self.unit_name();
+        let zone_name = &zone.name;
 
         // Look up the zone.
-        let Some(zone) = get_zone(center, &zone_name) else {
-            debug!(
-                "[{unit_name}] Got a review for {zone_name}/{zone_serial}, but the zone does not exist"
-            );
-            return Err(ZoneReviewError::NoSuchZone);
-        };
 
         let new_review_state = match decision {
             ZoneReviewDecision::Approve => ZoneVersionReviewState::Approved,
@@ -636,9 +627,9 @@ impl ZoneServer {
                     info!(
                         "Unsigned zone '{zone_name}' with serial {zone_serial} has been approved."
                     );
-                    match Self::promote_zone_to_signable(center.clone(), &zone_name) {
+                    match Self::promote_zone_to_signable(center.clone(), zone_name) {
                         Ok(()) => {
-                            self.on_unsigned_zone_approved(center, &zone, zone_serial);
+                            self.on_unsigned_zone_approved(center, zone, zone_serial);
                         }
                         Err(err) => {
                             error!(
@@ -652,7 +643,7 @@ impl ZoneServer {
                     );
                     record_zone_event(
                         center,
-                        &zone_name,
+                        zone,
                         HistoricalEvent::UnsignedZoneReview {
                             status: crate::api::ZoneReviewStatus::Rejected,
                         },
@@ -688,14 +679,14 @@ impl ZoneServer {
                 }
                 if matches!(decision, ZoneReviewDecision::Approve) {
                     info!("Signed zone '{zone_name}' with serial {zone_serial} has been approved.");
-                    self.on_signed_zone_approved(center, zone_name, zone_serial);
+                    self.on_signed_zone_approved(center, zone, zone_serial);
                 } else {
                     error!(
                         "Signed zone '{zone_name}' with serial {zone_serial} has been rejected."
                     );
                     record_zone_event(
                         center,
-                        &zone_name,
+                        zone,
                         HistoricalEvent::SignedZoneReview {
                             status: crate::api::ZoneReviewStatus::Rejected,
                         },
@@ -818,9 +809,13 @@ impl Notifiable for LoaderNotifier {
             // Propagate a request for the zone refresh.
             // This request ignores the serial and source because we will just
             // do a SOA query to our configured upstreams.
-            info!("[CC]: Instructing zone loader to refresh the zone");
             let center = &self.center;
-            center.loader.on_refresh_zone(center, apex_name.clone());
+            if let Some(zone) = crate::center::get_zone(center, apex_name) {
+                info!("Instructing zone loader to refresh zone '{apex_name}");
+                center.loader.on_refresh_zone(center, &zone);
+            } else {
+                warn!("Ignoring NOTIFY for unknown zone '{apex_name}'");
+            }
         }
 
         Box::pin(std::future::ready(Ok(())))

--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -823,10 +823,13 @@ impl Notifiable for LoaderNotifier {
             // Propagate a request for the zone refresh.
             // This request ignores the serial and source because we will just
             // do a SOA query to our configured upstreams.
-            info!("[CC]: Instructing zone loader to refresh the zone");
             let center = &self.center;
-            let zone = crate::center::get_zone(center, apex_name).expect("zone exists");
-            center.loader.on_refresh_zone(center, &zone);
+            if let Some(zone) = crate::center::get_zone(center, apex_name) {
+                info!("[CC]: Instructing zone loader to refresh the zone");
+                center.loader.on_refresh_zone(center, &zone);
+            } else {
+                error!("Got a NOTIFY for non-existent zone '{apex_name}'");
+            }
         }
 
         Box::pin(std::future::ready(Ok(())))

--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -38,7 +38,7 @@ use tracing::{debug, error, info, trace, warn};
 use crate::api::{
     ZoneReviewDecision, ZoneReviewError, ZoneReviewOutput, ZoneReviewResult, ZoneReviewStatus,
 };
-use crate::center::{Center, get_zone};
+use crate::center::Center;
 use crate::common::tsig::TsigKeyStore;
 use crate::config::SocketConfig;
 use crate::daemon::SocketProvider;
@@ -240,16 +240,16 @@ impl ZoneServer {
     pub fn on_publish_signed_zone(
         &self,
         center: &Arc<Center>,
-        zone_name: Name<Bytes>,
+        zone: &Arc<Zone>,
         zone_serial: Serial,
     ) {
         let unit_name = self.unit_name();
-        info!("[{unit_name}]: Publishing signed zone '{zone_name}' at serial {zone_serial}.");
+        let zone_name = &zone.name;
+        info!("[{unit_name}]: Publishing signed zone '{zone_name}' at serial {zone_serial}.",);
 
         // Move next_min_expiration to min_expiration, and determine policy.
         let policy = {
             // Use a block to make sure that the mutex is clearly dropped.
-            let zone = get_zone(center, &zone_name).unwrap();
             let mut zone_state = zone.state.lock().unwrap();
 
             // Save as next_min_expiration. After the signed zone is approved
@@ -264,7 +264,8 @@ impl ZoneServer {
         // Move the zone from the signed collection to the published collection.
         // TODO: Bump the zone serial?
         let signed_zones = center.signed_zones.load();
-        if let Some(zone) = signed_zones.get_zone(&zone_name, Class::IN) {
+
+        if let Some(zone) = signed_zones.get_zone(&zone.name, Class::IN) {
             // Create a deep copy of the set of
             // published zones. We will add the
             // new zone to that copied set and
@@ -318,7 +319,7 @@ impl ZoneServer {
     pub fn on_seek_approval_for_zone(
         &self,
         center: &Arc<Center>,
-        zone_name: Name<Bytes>,
+        zone: &Arc<Zone>,
         zone_serial: Serial,
     ) -> Option<Result<(), Terminated>> {
         let unit_name = self.unit_name();
@@ -327,8 +328,6 @@ impl ZoneServer {
             Source::Signed => "signed",
             Source::Published => unreachable!(),
         };
-
-        let zone = get_zone(center, &zone_name).unwrap();
 
         let review = {
             let zone_state = zone.state.lock().unwrap();
@@ -355,23 +354,24 @@ impl ZoneServer {
             }
         };
 
+        let zone_name = &zone.name;
         if !review.required {
             // Approve immediately.
             match self.source {
                 Source::Unsigned => {
                     info!("[{unit_name}]: Adding '{zone_name}' to the set of signable zones.");
                     if let Err(err) =
-                        ZoneServer::promote_zone_to_signable(center.clone(), &zone_name)
+                        ZoneServer::promote_zone_to_signable(center.clone(), zone_name)
                     {
                         error!(
                             "[{unit_name}]: Cannot promote unsigned zone '{zone_name}' to the signable set of zones: {err}"
                         );
                     } else {
-                        self.on_unsigned_zone_approved(center, &zone, zone_serial);
+                        self.on_unsigned_zone_approved(center, zone, zone_serial);
                     }
                 }
                 Source::Signed => {
-                    self.on_signed_zone_approved(center, zone_name, zone_serial);
+                    self.on_signed_zone_approved(center, zone, zone_serial);
                 }
                 Source::Published => unreachable!(),
             }
@@ -414,7 +414,7 @@ impl ZoneServer {
             }
         }
 
-        record_zone_event(center, &zone_name, pending_event, Some(zone_serial));
+        record_zone_event(center, zone, pending_event, Some(zone_serial));
 
         if review.cmd_hook.is_none() || review_server.is_none() {
             match (review_server, review.cmd_hook) {
@@ -475,6 +475,7 @@ impl ZoneServer {
                 tokio::spawn(async move {
                     let _: Result<_, _> = Self::process_output(stderr, true).await;
                 });
+                let zone = zone.clone();
                 tokio::spawn(async move {
                     let status = match child.wait().await {
                         Ok(status) => status,
@@ -496,7 +497,7 @@ impl ZoneServer {
                         "signed" => &center.signed_review_server,
                         _ => unreachable!(),
                     };
-                    let _ = server.on_zone_review(&center, zone_name, zone_serial, decision);
+                    let _ = server.on_zone_review(&center, &zone, zone_serial, decision);
                 });
             }
             Err(err) => {
@@ -548,21 +549,16 @@ impl ZoneServer {
         info!("[CC]: Instructing zone signer to sign the approved zone");
         center.signer.on_sign_zone(
             center,
-            zone.name.clone(),
+            zone,
             Some(zone_serial),
             SigningTrigger::ZoneChangesApproved,
         );
     }
 
-    fn on_signed_zone_approved(
-        &self,
-        center: &Arc<Center>,
-        zone_name: Name<Bytes>,
-        zone_serial: Serial,
-    ) {
+    fn on_signed_zone_approved(&self, center: &Arc<Center>, zone: &Arc<Zone>, zone_serial: Serial) {
         record_zone_event(
             center,
-            &zone_name,
+            zone,
             HistoricalEvent::SignedZoneReview {
                 status: crate::api::ZoneReviewStatus::Approved,
             },
@@ -576,7 +572,7 @@ impl ZoneServer {
         info!("[CC]: Instructing publication server to publish the signed zone");
         center
             .publication_server
-            .on_publish_signed_zone(center, zone_name, zone_serial);
+            .on_publish_signed_zone(center, zone, zone_serial);
     }
 
     async fn process_output(
@@ -600,19 +596,14 @@ impl ZoneServer {
     pub fn on_zone_review(
         &self,
         center: &Arc<Center>,
-        zone_name: Name<Bytes>,
+        zone: &Arc<Zone>,
         zone_serial: Serial,
         decision: ZoneReviewDecision,
     ) -> ZoneReviewResult {
         let unit_name = self.unit_name();
+        let zone_name = &zone.name;
 
         // Look up the zone.
-        let Some(zone) = get_zone(center, &zone_name) else {
-            debug!(
-                "[{unit_name}] Got a review for {zone_name}/{zone_serial}, but the zone does not exist"
-            );
-            return Err(ZoneReviewError::NoSuchZone);
-        };
 
         let new_review_state = match decision {
             ZoneReviewDecision::Approve => ZoneVersionReviewState::Approved,
@@ -650,9 +641,9 @@ impl ZoneServer {
                     info!(
                         "Unsigned zone '{zone_name}' with serial {zone_serial} has been approved."
                     );
-                    match Self::promote_zone_to_signable(center.clone(), &zone_name) {
+                    match Self::promote_zone_to_signable(center.clone(), zone_name) {
                         Ok(()) => {
-                            self.on_unsigned_zone_approved(center, &zone, zone_serial);
+                            self.on_unsigned_zone_approved(center, zone, zone_serial);
                         }
                         Err(err) => {
                             error!(
@@ -666,7 +657,7 @@ impl ZoneServer {
                     );
                     record_zone_event(
                         center,
-                        &zone_name,
+                        zone,
                         HistoricalEvent::UnsignedZoneReview {
                             status: crate::api::ZoneReviewStatus::Rejected,
                         },
@@ -702,14 +693,14 @@ impl ZoneServer {
                 }
                 if matches!(decision, ZoneReviewDecision::Approve) {
                     info!("Signed zone '{zone_name}' with serial {zone_serial} has been approved.");
-                    self.on_signed_zone_approved(center, zone_name, zone_serial);
+                    self.on_signed_zone_approved(center, zone, zone_serial);
                 } else {
                     error!(
                         "Signed zone '{zone_name}' with serial {zone_serial} has been rejected."
                     );
                     record_zone_event(
                         center,
-                        &zone_name,
+                        zone,
                         HistoricalEvent::SignedZoneReview {
                             status: crate::api::ZoneReviewStatus::Rejected,
                         },
@@ -834,7 +825,8 @@ impl Notifiable for LoaderNotifier {
             // do a SOA query to our configured upstreams.
             info!("[CC]: Instructing zone loader to refresh the zone");
             let center = &self.center;
-            center.loader.on_refresh_zone(center, apex_name.clone());
+            let zone = crate::center::get_zone(center, apex_name).expect("zone exists");
+            center.loader.on_refresh_zone(center, &zone);
         }
 
         Box::pin(std::future::ready(Ok(())))

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -192,7 +192,7 @@ impl ZoneSigner {
 
     fn mk_signing_report(
         &self,
-        status: Arc<RwLock<NamedZoneSigningStatus>>,
+        status: Arc<RwLock<SigningStatusPerZone>>,
     ) -> Option<SigningReport> {
         let status = status.read().unwrap();
         let now = Instant::now();
@@ -385,7 +385,7 @@ impl ZoneSigner {
         zone: &Arc<Zone>,
         resign_last_signed_zone_content: bool,
         trigger: SigningTrigger,
-        status: Arc<RwLock<NamedZoneSigningStatus>>,
+        status: Arc<RwLock<SigningStatusPerZone>>,
     ) -> Result<(), SignerError> {
         let zone_name = &zone.name;
         info!("[ZS]: Starting signing operation for zone '{zone_name}'");
@@ -1685,7 +1685,7 @@ impl std::fmt::Display for ZoneSigningStatus {
 
 const SIGNING_QUEUE_SIZE: usize = 100;
 
-struct NamedZoneSigningStatus {
+struct SigningStatusPerZone {
     zone: Arc<Zone>,
     current_action: String,
     status: ZoneSigningStatus,
@@ -1698,7 +1698,7 @@ struct ZoneSignerStatus {
     //
     // TODO: Separate out signing request queuing from signing statistics
     // tracking.
-    zones_being_signed: Arc<RwLock<VecDeque<Arc<RwLock<NamedZoneSigningStatus>>>>>,
+    zones_being_signed: Arc<RwLock<VecDeque<Arc<RwLock<SigningStatusPerZone>>>>>,
 
     // Sign each zone only once at a time.
     zone_semaphores: Arc<RwLock<HashMap<StoredName, Arc<Semaphore>>>>,
@@ -1717,7 +1717,7 @@ impl ZoneSignerStatus {
         }
     }
 
-    pub fn get(&self, wanted_zone: &Arc<Zone>) -> Option<Arc<RwLock<NamedZoneSigningStatus>>> {
+    pub fn get(&self, wanted_zone: &Arc<Zone>) -> Option<Arc<RwLock<SigningStatusPerZone>>> {
         self.dump_queue();
 
         let zones_being_signed = self.zones_being_signed.read().unwrap();
@@ -1764,13 +1764,13 @@ impl ZoneSignerStatus {
             usize,
             OwnedSemaphorePermit,
             OwnedSemaphorePermit,
-            Arc<RwLock<NamedZoneSigningStatus>>,
+            Arc<RwLock<SigningStatusPerZone>>,
         ),
         SignerError,
     > {
         let zone_name = &zone.name;
         debug!("SIGNER[{zone_name}]: Adding to the queue");
-        let status = Arc::new(RwLock::new(NamedZoneSigningStatus {
+        let status = Arc::new(RwLock::new(SigningStatusPerZone {
             zone: zone.clone(),
             current_action: "Waiting for any existing signing operation for this zone to finish"
                 .to_string(),

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -25,7 +25,7 @@ use domain::rdata::{Dnskey, Nsec3param, Rrsig, Soa, ZoneRecordData};
 use domain::zonefile::inplace::{Entry, Zonefile};
 use domain::zonetree::types::{StoredRecordData, ZoneUpdate};
 use domain::zonetree::update::ZoneUpdater;
-use domain::zonetree::{StoredName, StoredRecord, Zone};
+use domain::zonetree::{self, StoredName, StoredRecord};
 use domain_kmip::KeyUrl;
 use domain_kmip::dep::kmip::client::pool::{ConnectionManager, KmipConnError, SyncConnPool};
 use domain_kmip::{self, ClientCertificate, ConnectionSettings};
@@ -43,7 +43,7 @@ use crate::api::{
     SigningFinishedReport, SigningInProgressReport, SigningQueueReport, SigningReport,
     SigningRequestedReport, SigningStageReport,
 };
-use crate::center::{Center, get_zone, halt_zone};
+use crate::center::{Center, halt_zone};
 use crate::common::light_weight_zone::LightWeightZone;
 use crate::manager::{Terminated, record_zone_event};
 use crate::policy::{PolicyVersion, SignerDenialPolicy, SignerSerialPolicy};
@@ -55,7 +55,7 @@ use crate::util::{
     AbortOnDrop, serialize_duration_as_secs, serialize_instant_as_duration_secs,
     serialize_opt_duration_as_secs,
 };
-use crate::zone::{HistoricalEvent, HistoricalEventType, PipelineMode, SigningTrigger};
+use crate::zone::{HistoricalEvent, HistoricalEventType, PipelineMode, SigningTrigger, Zone};
 
 // Re-signing zones before signatures expire works as follows:
 // - compute when the first zone needs to be re-signed. Loop over unsigned
@@ -253,15 +253,17 @@ impl ZoneSigner {
     pub fn on_sign_zone(
         &self,
         center: &Arc<Center>,
-        zone_name: StoredName,
+        zone: &Arc<Zone>,
         zone_serial: Option<Serial>,
         trigger: SigningTrigger,
     ) {
         let center = center.clone();
+        let zone = zone.clone();
         tokio::spawn(async move {
+            let zone_name = &zone.name;
             if let Err(err) = center
                 .signer
-                .join_sign_zone_queue(&center, &zone_name, zone_serial.is_none(), trigger)
+                .join_sign_zone_queue(&center, &zone, zone_serial.is_none(), trigger)
                 .await
             {
                 if err.is_benign() {
@@ -277,11 +279,11 @@ impl ZoneSigner {
                 } else {
                     error!("[ZS]: Signing of zone '{zone_name}' failed: {err}");
 
-                    halt_zone(&center, &zone_name, true, &err.to_string());
+                    halt_zone(&center, &zone, true, &err.to_string());
 
                     record_zone_event(
                         &center,
-                        &zone_name,
+                        &zone,
                         HistoricalEvent::SigningFailed {
                             trigger,
                             reason: err.to_string(),
@@ -293,13 +295,9 @@ impl ZoneSigner {
         });
     }
 
-    pub fn on_signing_report(
-        &self,
-        _center: &Arc<Center>,
-        zone_name: StoredName,
-    ) -> Option<SigningReport> {
+    pub fn on_signing_report(&self, zone: &Arc<Zone>) -> Option<SigningReport> {
         self.signer_status
-            .get(&zone_name)
+            .get(zone)
             .and_then(|status| self.mk_signing_report(status))
     }
 
@@ -310,7 +308,7 @@ impl ZoneSigner {
         for q_item in q.iter().rev() {
             if let Some(stage_report) = self.mk_signing_report(q_item.clone()) {
                 report.push(SigningQueueReport {
-                    zone_name: q_item.read().unwrap().zone_name.clone(),
+                    zone_name: q_item.read().unwrap().zone.name.clone(),
                     signing_report: stage_report,
                 });
             }
@@ -334,17 +332,18 @@ impl ZoneSigner {
     async fn join_sign_zone_queue(
         &self,
         center: &Arc<Center>,
-        zone_name: &StoredName,
+        zone: &Arc<Zone>,
         resign_last_signed_zone_content: bool,
         trigger: SigningTrigger,
     ) -> Result<(), SignerError> {
+        let zone_name = &zone.name;
         info!("[ZS]: Waiting to enqueue signing operation for zone '{zone_name}'.");
 
         self.signer_status.dump_queue();
 
         let (q_size, _q_permit, _zone_permit, status) = {
             let signer_status = &self.signer_status;
-            signer_status.enqueue(zone_name.clone()).await?
+            signer_status.enqueue(zone).await?
         };
 
         let num_ops_in_progress =
@@ -361,7 +360,7 @@ impl ZoneSigner {
         let res = self
             .sign_zone(
                 center,
-                zone_name,
+                zone,
                 resign_last_signed_zone_content,
                 trigger,
                 status.clone(),
@@ -383,19 +382,18 @@ impl ZoneSigner {
     async fn sign_zone(
         &self,
         center: &Arc<Center>,
-        zone_name: &StoredName,
+        zone: &Arc<Zone>,
         resign_last_signed_zone_content: bool,
         trigger: SigningTrigger,
         status: Arc<RwLock<NamedZoneSigningStatus>>,
     ) -> Result<(), SignerError> {
+        let zone_name = &zone.name;
         info!("[ZS]: Starting signing operation for zone '{zone_name}'");
         let start = Instant::now();
 
         let (last_signed_serial, policy) = {
             // Use a block to make sure that the mutex is clearly dropped.
-            let state = center.state.lock().unwrap();
-            let zone = state.zones.get(zone_name).unwrap();
-            let zone_state = zone.0.state.lock().unwrap();
+            let zone_state = zone.state.lock().unwrap();
 
             // Do NOT sign a zone that is halted.
             if zone_state.pipeline_mode != PipelineMode::Running {
@@ -528,14 +526,13 @@ impl ZoneSigner {
         // Lookup the signed zone to update, or create a new empty zone to
         // sign into.
         //
-        let zone = self.get_or_insert_signed_zone(center, zone_name);
+        let signed_zone = self.get_or_insert_signed_zone(center, zone_name);
 
         //
         // Create a signing configuration.
         //
         // Ensure that the Mutexes are locked only in this block;
         let policy = {
-            let zone = get_zone(center, zone_name).unwrap();
             let zone_state = zone.state.lock().unwrap();
             zone_state.policy.clone()
         };
@@ -568,7 +565,7 @@ impl ZoneSigner {
         status.write().unwrap().current_action =
             "Fetching apex RRs from the key manager".to_string();
         // Read the DNSKEY RRs and DNSKEY RRSIG RR from the keyset state.
-        let state_path = mk_dnst_keyset_state_file_path(&center.config.keys_dir, zone.apex_name());
+        let state_path = mk_dnst_keyset_state_file_path(&center.config.keys_dir, zone_name);
         let state = std::fs::read_to_string(&state_path)
             .map_err(|_| SignerError::CannotReadStateFile(state_path.into_string()))?;
         let state: KeySetState = serde_json::from_str(&state).unwrap();
@@ -856,7 +853,7 @@ impl ZoneSigner {
         // incremental signing (i.e. only regenerate, add and remove RRSIGs,
         // and update the NSEC(3) chain as needed, we can capture a diff of
         // the changes we make).
-        let mut updater = ZoneUpdater::new(zone.clone()).await.unwrap();
+        let mut updater = ZoneUpdater::new(signed_zone.clone()).await.unwrap();
 
         // Clear out any RRs in the current version of the signed zone. If the zone
         // supports versioning this is a NO OP.
@@ -1003,7 +1000,7 @@ impl ZoneSigner {
         updater.apply(ZoneUpdate::Finished(soa_rr)).await.unwrap();
 
         debug!("SIGNER: Determining min expiration time");
-        let reader = zone.read();
+        let reader = signed_zone.read();
         let apex_name = zone_name.clone();
         let min_expiration = Arc::new(MinTimestamp::new());
         let saved_min_expiration = min_expiration.clone();
@@ -1027,7 +1024,6 @@ impl ZoneSigner {
         // Save the minimum of the expiration times.
         {
             // Use a block to make sure that the mutex is clearly dropped.
-            let zone = get_zone(center, zone_name).unwrap();
             let mut zone_state = zone.state.lock().unwrap();
 
             // Save as next_min_expiration. After the signed zone is approved
@@ -1074,18 +1070,16 @@ impl ZoneSigner {
 
         record_zone_event(
             center,
-            zone_name,
+            zone,
             HistoricalEvent::SigningSucceeded { trigger },
             Some(zone_serial),
         );
 
         // Notify the review server that the zone is ready.
         info!("Instructing review server to publish the signed zone");
-        center.signed_review_server.on_seek_approval_for_zone(
-            center,
-            zone_name.clone(),
-            zone_serial,
-        );
+        center
+            .signed_review_server
+            .on_seek_approval_for_zone(center, zone, zone_serial);
 
         Ok(())
     }
@@ -1105,7 +1099,11 @@ impl ZoneSigner {
         (parallelism, chunk_size)
     }
 
-    fn get_or_insert_signed_zone(&self, center: &Arc<Center>, zone_name: &StoredName) -> Zone {
+    fn get_or_insert_signed_zone(
+        &self,
+        center: &Arc<Center>,
+        zone_name: &StoredName,
+    ) -> zonetree::Zone {
         // Create an empty zone to sign into if no existing signed zone exists.
         let signed_zones = center.signed_zones.load();
 
@@ -1116,7 +1114,7 @@ impl ZoneSigner {
                 // Use a LightWeightZone as it is able to fix RRSIG TTLs to
                 // be the same when walked as the record they sign, rather
                 // than being forced into a common RRSET with a common TTL.
-                let new_zone = Zone::new(LightWeightZone::new(zone_name.clone(), false));
+                let new_zone = zonetree::Zone::new(LightWeightZone::new(zone_name.clone(), false));
 
                 center.signed_zones.rcu(|zones| {
                     let mut new_zones = Arc::unwrap_or_clone(zones.clone());
@@ -1213,17 +1211,15 @@ impl ZoneSigner {
     }
 
     fn resign_zones(&self, center: &Arc<Center>) {
-        let zone_tree = &center.unsigned_zones;
+        let state = &center.state.lock().unwrap();
         let now = SystemTime::now();
-        for zone in zone_tree.load().iter_zones() {
-            let zone_name = zone.apex_name();
+        for zone in &state.zones {
+            let zone = &zone.0;
+            let zone_name = &zone.name;
 
             let min_expiration = {
                 // Use a block to make sure that the mutex is clearly dropped.
-                let state = center.state.lock().unwrap();
-                let zone = state.zones.get(zone_name).unwrap();
-                let zone_state = zone.0.state.lock().unwrap();
-
+                let zone_state = zone.state.lock().unwrap();
                 zone_state.min_expiration
             };
 
@@ -1245,9 +1241,7 @@ impl ZoneSigner {
 
             // Ensure that the Mutexes are locked only in this block;
             let remain_time = {
-                let state = center.state.lock().unwrap();
-                let zone = state.zones.get(zone_name).unwrap();
-                let zone_state = zone.0.state.lock().unwrap();
+                let zone_state = zone.state.lock().unwrap();
                 // What if there is no policy?
                 zone_state.policy.as_ref().unwrap().signer.sig_remain_time
             };
@@ -1264,12 +1258,7 @@ impl ZoneSigner {
                     resign_busy.insert(zone_name.clone(), min_expiration);
                 }
                 info!("[CC]: Instructing zone signer to re-sign the zone");
-                self.on_sign_zone(
-                    center,
-                    zone_name.clone(),
-                    None,
-                    SigningTrigger::SignatureExpiration,
-                );
+                self.on_sign_zone(center, zone, None, SigningTrigger::SignatureExpiration);
             }
         }
     }
@@ -1448,7 +1437,7 @@ impl SignTask<'_> {
 
 #[allow(clippy::result_large_err)]
 fn get_zone_soa(
-    zone: Zone,
+    zone: zonetree::Zone,
     zone_name: StoredName,
 ) -> Result<Record<StoredName, StoredRecordData>, SignerError> {
     let answer = zone
@@ -1462,7 +1451,7 @@ fn get_zone_soa(
     Ok(Record::new(zone_name.clone(), Class::IN, soa_ttl, soa_data))
 }
 
-fn collect_zone(zone: Zone) -> Vec<StoredRecord> {
+fn collect_zone(zone: zonetree::Zone) -> Vec<StoredRecord> {
     // Temporary: Accumulate the zone into a vec as we can only sign over a
     // slice at the moment, not over an iterator yet (nor can we iterate over
     // a zone yet, only walk it ...).
@@ -1696,9 +1685,8 @@ impl std::fmt::Display for ZoneSigningStatus {
 
 const SIGNING_QUEUE_SIZE: usize = 100;
 
-#[derive(Serialize)]
 struct NamedZoneSigningStatus {
-    zone_name: StoredName,
+    zone: Arc<Zone>,
     current_action: String,
     status: ZoneSigningStatus,
 }
@@ -1729,16 +1717,13 @@ impl ZoneSignerStatus {
         }
     }
 
-    pub fn get(
-        &self,
-        wanted_zone_name: &StoredName,
-    ) -> Option<Arc<RwLock<NamedZoneSigningStatus>>> {
+    pub fn get(&self, wanted_zone: &Arc<Zone>) -> Option<Arc<RwLock<NamedZoneSigningStatus>>> {
         self.dump_queue();
 
         let zones_being_signed = self.zones_being_signed.read().unwrap();
         for q_item in zones_being_signed.iter().rev() {
             let readable_q_item = q_item.read().unwrap();
-            if readable_q_item.zone_name == wanted_zone_name
+            if Arc::ptr_eq(&readable_q_item.zone, wanted_zone)
                 && !matches!(readable_q_item.status, ZoneSigningStatus::Aborted)
             {
                 return Some(q_item.clone());
@@ -1754,16 +1739,16 @@ impl ZoneSignerStatus {
                 let q_item = q_item.read().unwrap();
                 match q_item.status {
                     ZoneSigningStatus::Requested(_) => {
-                        debug!("[ZS]: Queue item: {} => requested", q_item.zone_name)
+                        debug!("[ZS]: Queue item: {} => requested", q_item.zone.name)
                     }
                     ZoneSigningStatus::InProgress(_) => {
-                        debug!("[ZS]: Queue item: {} => in-progress", q_item.zone_name)
+                        debug!("[ZS]: Queue item: {} => in-progress", q_item.zone.name)
                     }
                     ZoneSigningStatus::Finished(_) => {
-                        debug!("[ZS]: Queue item: {} => finished", q_item.zone_name)
+                        debug!("[ZS]: Queue item: {} => finished", q_item.zone.name)
                     }
                     ZoneSigningStatus::Aborted => {
-                        debug!("[ZS]: Queue item: {} => aborted", q_item.zone_name)
+                        debug!("[ZS]: Queue item: {} => aborted", q_item.zone.name)
                     }
                 };
             }
@@ -1773,7 +1758,7 @@ impl ZoneSignerStatus {
     /// Enqueue a zone for signing.
     pub async fn enqueue(
         &self,
-        zone_name: StoredName,
+        zone: &Arc<Zone>,
     ) -> Result<
         (
             usize,
@@ -1783,9 +1768,10 @@ impl ZoneSignerStatus {
         ),
         SignerError,
     > {
+        let zone_name = &zone.name;
         debug!("SIGNER[{zone_name}]: Adding to the queue");
         let status = Arc::new(RwLock::new(NamedZoneSigningStatus {
-            zone_name: zone_name.clone(),
+            zone: zone.clone(),
             current_action: "Waiting for any existing signing operation for this zone to finish"
                 .to_string(),
             status: ZoneSigningStatus::new(),

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -190,7 +190,7 @@ impl ZoneSigner {
 
     fn mk_signing_report(
         &self,
-        status: Arc<RwLock<NamedZoneSigningStatus>>,
+        status: Arc<RwLock<SigningStatusPerZone>>,
     ) -> Option<SigningReport> {
         let status = status.read().unwrap();
         let now = Instant::now();
@@ -246,13 +246,9 @@ impl ZoneSigner {
         })
     }
 
-    pub fn on_signing_report(
-        &self,
-        _center: &Arc<Center>,
-        zone_name: StoredName,
-    ) -> Option<SigningReport> {
+    pub fn on_signing_report(&self, zone: &Arc<Zone>) -> Option<SigningReport> {
         self.signer_status
-            .get(&zone_name)
+            .get(zone)
             .and_then(|status| self.mk_signing_report(status))
     }
 
@@ -263,7 +259,7 @@ impl ZoneSigner {
         for q_item in q.iter().rev() {
             if let Some(stage_report) = self.mk_signing_report(q_item.clone()) {
                 report.push(SigningQueueReport {
-                    zone_name: q_item.read().unwrap().zone_name.clone(),
+                    zone_name: q_item.read().unwrap().zone.name.clone(),
                     signing_report: stage_report,
                 });
             }
@@ -280,10 +276,7 @@ impl ZoneSigner {
     pub async fn wait_to_sign(
         &self,
         zone: &Arc<Zone>,
-    ) -> (
-        Arc<RwLock<NamedZoneSigningStatus>>,
-        [OwnedSemaphorePermit; 3],
-    ) {
+    ) -> (Arc<RwLock<SigningStatusPerZone>>, [OwnedSemaphorePermit; 3]) {
         let zone_name = &zone.name;
         info!("[ZS]: Waiting to enqueue signing operation for zone '{zone_name}'.");
 
@@ -293,7 +286,7 @@ impl ZoneSigner {
             let signer_status = &self.signer_status;
             // TODO: Propagate the error properly.
             signer_status
-                .enqueue(zone_name.clone())
+                .enqueue(zone)
                 .await
                 .unwrap_or_else(|err| panic!("{err}"))
         };
@@ -322,7 +315,7 @@ impl ZoneSigner {
         zone: &Arc<Zone>,
         builder: &mut SignedZoneBuilder,
         trigger: SigningTrigger,
-        status: Arc<RwLock<NamedZoneSigningStatus>>,
+        status: Arc<RwLock<SigningStatusPerZone>>,
     ) -> Result<(), SignerError> {
         let zone_name = &zone.name;
         info!("[ZS]: Starting signing operation for zone '{zone_name}'");
@@ -858,7 +851,6 @@ impl ZoneSigner {
         // Save the minimum of the expiration times.
         {
             // Use a block to make sure that the mutex is clearly dropped.
-            let zone = get_zone(center, zone_name).unwrap();
             let mut zone_state = zone.state.lock().unwrap();
 
             // Save as next_min_expiration. After the signed zone is approved
@@ -902,7 +894,7 @@ impl ZoneSigner {
 
         record_zone_event(
             center,
-            zone_name,
+            zone,
             HistoricalEvent::SigningSucceeded {
                 trigger: trigger.into(),
             },
@@ -913,7 +905,7 @@ impl ZoneSigner {
         info!("Instructing review server to publish the signed zone");
         center.signed_review_server.on_seek_approval_for_zone(
             center,
-            zone_name.clone(),
+            zone,
             domain::base::Serial(serial.into()),
         );
 
@@ -1005,17 +997,15 @@ impl ZoneSigner {
     }
 
     fn resign_zones(&self, center: &Arc<Center>) {
-        let zone_tree = &center.unsigned_zones;
+        let state = &center.state.lock().unwrap();
         let now = SystemTime::now();
-        for zone in zone_tree.load().iter_zones() {
-            let zone_name = zone.apex_name();
+        for zone in &state.zones {
+            let zone = &zone.0;
+            let zone_name = &zone.name;
 
             let min_expiration = {
                 // Use a block to make sure that the mutex is clearly dropped.
-                let state = center.state.lock().unwrap();
-                let zone = state.zones.get(zone_name).unwrap();
-                let zone_state = zone.0.state.lock().unwrap();
-
+                let zone_state = zone.state.lock().unwrap();
                 zone_state.min_expiration
             };
 
@@ -1037,9 +1027,7 @@ impl ZoneSigner {
 
             // Ensure that the Mutexes are locked only in this block;
             let remain_time = {
-                let state = center.state.lock().unwrap();
-                let zone = state.zones.get(zone_name).unwrap();
-                let zone_state = zone.0.state.lock().unwrap();
+                let zone_state = zone.state.lock().unwrap();
                 // What if there is no policy?
                 zone_state.policy.as_ref().unwrap().signer.sig_remain_time
             };
@@ -1286,9 +1274,8 @@ impl std::fmt::Display for ZoneSigningStatus {
 
 const SIGNING_QUEUE_SIZE: usize = 100;
 
-#[derive(Serialize)]
-pub struct NamedZoneSigningStatus {
-    pub zone_name: StoredName,
+pub struct SigningStatusPerZone {
+    pub zone: Arc<Zone>,
     pub current_action: String,
     pub status: ZoneSigningStatus,
 }
@@ -1300,7 +1287,7 @@ struct ZoneSignerStatus {
     //
     // TODO: Separate out signing request queuing from signing statistics
     // tracking.
-    zones_being_signed: Arc<RwLock<VecDeque<Arc<RwLock<NamedZoneSigningStatus>>>>>,
+    zones_being_signed: Arc<RwLock<VecDeque<Arc<RwLock<SigningStatusPerZone>>>>>,
 
     // Sign each zone only once at a time.
     zone_semaphores: Arc<RwLock<HashMap<StoredName, Arc<Semaphore>>>>,
@@ -1319,16 +1306,13 @@ impl ZoneSignerStatus {
         }
     }
 
-    pub fn get(
-        &self,
-        wanted_zone_name: &StoredName,
-    ) -> Option<Arc<RwLock<NamedZoneSigningStatus>>> {
+    pub fn get(&self, wanted_zone: &Arc<Zone>) -> Option<Arc<RwLock<SigningStatusPerZone>>> {
         self.dump_queue();
 
         let zones_being_signed = self.zones_being_signed.read().unwrap();
         for q_item in zones_being_signed.iter().rev() {
             let readable_q_item = q_item.read().unwrap();
-            if readable_q_item.zone_name == wanted_zone_name
+            if Arc::ptr_eq(&readable_q_item.zone, wanted_zone)
                 && !matches!(readable_q_item.status, ZoneSigningStatus::Aborted)
             {
                 return Some(q_item.clone());
@@ -1344,16 +1328,16 @@ impl ZoneSignerStatus {
                 let q_item = q_item.read().unwrap();
                 match q_item.status {
                     ZoneSigningStatus::Requested(_) => {
-                        debug!("[ZS]: Queue item: {} => requested", q_item.zone_name)
+                        debug!("[ZS]: Queue item: {} => requested", q_item.zone.name)
                     }
                     ZoneSigningStatus::InProgress(_) => {
-                        debug!("[ZS]: Queue item: {} => in-progress", q_item.zone_name)
+                        debug!("[ZS]: Queue item: {} => in-progress", q_item.zone.name)
                     }
                     ZoneSigningStatus::Finished(_) => {
-                        debug!("[ZS]: Queue item: {} => finished", q_item.zone_name)
+                        debug!("[ZS]: Queue item: {} => finished", q_item.zone.name)
                     }
                     ZoneSigningStatus::Aborted => {
-                        debug!("[ZS]: Queue item: {} => aborted", q_item.zone_name)
+                        debug!("[ZS]: Queue item: {} => aborted", q_item.zone.name)
                     }
                 };
             }
@@ -1363,19 +1347,20 @@ impl ZoneSignerStatus {
     /// Enqueue a zone for signing.
     pub async fn enqueue(
         &self,
-        zone_name: StoredName,
+        zone: &Arc<Zone>,
     ) -> Result<
         (
             usize,
             OwnedSemaphorePermit,
             OwnedSemaphorePermit,
-            Arc<RwLock<NamedZoneSigningStatus>>,
+            Arc<RwLock<SigningStatusPerZone>>,
         ),
         SignerError,
     > {
+        let zone_name = &zone.name;
         debug!("SIGNER[{zone_name}]: Adding to the queue");
-        let status = Arc::new(RwLock::new(NamedZoneSigningStatus {
-            zone_name: zone_name.clone(),
+        let status = Arc::new(RwLock::new(SigningStatusPerZone {
+            zone: zone.clone(),
             current_action: "Waiting for any existing signing operation for this zone to finish"
                 .to_string(),
             status: ZoneSigningStatus::new(),

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -47,7 +47,7 @@ use crate::api::{
     SigningFinishedReport, SigningInProgressReport, SigningQueueReport, SigningReport,
     SigningRequestedReport, SigningStageReport,
 };
-use crate::center::{Center, get_zone};
+use crate::center::Center;
 use crate::manager::{Terminated, record_zone_event};
 use crate::policy::{PolicyVersion, SignerDenialPolicy, SignerSerialPolicy};
 use crate::signer::{ResigningTrigger, SigningTrigger};
@@ -997,9 +997,15 @@ impl ZoneSigner {
     }
 
     fn resign_zones(&self, center: &Arc<Center>) {
-        let state = &center.state.lock().unwrap();
         let now = SystemTime::now();
-        for zone in &state.zones {
+
+        #[allow(clippy::mutable_key_type)]
+        let zones = {
+            let state = center.state.lock().unwrap();
+            state.zones.clone()
+        };
+
+        for zone in zones {
             let zone = &zone.0;
             let zone_name = &zone.name;
 
@@ -1043,10 +1049,9 @@ impl ZoneSigner {
                     let mut resign_busy = center.resign_busy.lock().expect("should not fail");
                     resign_busy.insert(zone_name.clone(), min_expiration);
                 }
-                let zone = get_zone(center, zone_name).unwrap();
                 let mut state = zone.state.lock().unwrap();
                 ZoneHandle {
-                    zone: &zone,
+                    zone,
                     state: &mut state,
                     center,
                 }

--- a/src/zone/storage.rs
+++ b/src/zone/storage.rs
@@ -246,7 +246,7 @@ impl StorageZoneHandle<'_> {
 
                 center.unsigned_review_server.on_seek_approval_for_zone(
                     &center,
-                    zone.name.clone(),
+                    &zone,
                     domain::base::Serial(serial.into()),
                 );
 

--- a/src/zone/storage.rs
+++ b/src/zone/storage.rs
@@ -254,7 +254,7 @@ impl StorageZoneHandle<'_> {
 
                 center.unsigned_review_server.on_seek_approval_for_zone(
                     &center,
-                    zone.name.clone(),
+                    &zone,
                     domain::base::Serial(serial.into()),
                 );
 
@@ -517,7 +517,7 @@ impl StorageZoneHandle<'_> {
 
             center.signed_review_server.on_seek_approval_for_zone(
                 &center,
-                zone.name.clone(),
+                &zone,
                 domain::base::Serial(serial.into()),
             );
 


### PR DESCRIPTION
This should reduce the possibility for deadlocks a bit and reduces the contention on the `center.state` mutex.

Some calls are just move from the callee to the caller, because then they happen more at the "edge". For example, the http server now does more of these calls because it needs to translate the names from the API to actual zones and it makes sense to do that there.

Builds on https://github.com/NLnetLabs/cascade/pull/504 but doesn't merge into it because I think that shouldn't be merged directly.