### PR TITLE
Zone instances and IDs

### DIFF
--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     common::scheduler::Scheduler,
     loader::zone::EnqueuedRefresh,
     util::AbortOnDrop,
-    zone::{Zone, ZoneByPtr, ZoneHandle},
+    zone::{Zone, ZoneByPtr, ZoneHandle, instance::LoadedInstanceID},
 };
 
 mod server;
@@ -131,13 +131,14 @@ impl Default for Loader {
 #[tracing::instrument(
     level = "debug",
     skip_all,
-    fields(zone = %zone.name, source = ?source),
+    fields(zone = %zone.name, source = ?source, ?id),
 )]
 async fn refresh(
     zone: Arc<Zone>,
     source: Source,
     refresh: EnqueuedRefresh,
     mut builder: LoadedZoneBuilder,
+    id: LoadedInstanceID,
     center: Arc<Center>,
     metrics: Arc<ActiveLoadMetrics>,
 ) {
@@ -231,6 +232,7 @@ async fn refresh(
             );
 
             // Cancel the load from the perspective of zone storage.
+            handle.state.instances.abandon_load(id);
             handle.storage().abandon_load(builder);
         }
 
@@ -249,7 +251,8 @@ async fn refresh(
                 unreachable!("source-specific loading succeeded and must have filled 'builder'")
             });
 
-            handle.storage().finish_load(built);
+            // TODO: Update something in 'handle.state.instances'?
+            handle.storage().finish_load(built, id);
         }
 
         Err(err) => {
@@ -259,6 +262,7 @@ async fn refresh(
             );
 
             // Cancel the load from the perspective of zone storage.
+            handle.state.instances.abandon_load(id);
             handle.storage().abandon_load(builder);
         }
     }

--- a/src/loader/zone.rs
+++ b/src/loader/zone.rs
@@ -140,12 +140,14 @@ impl LoaderZoneHandle<'_> {
     fn start(&mut self, refresh: EnqueuedRefresh, builder: LoadedZoneBuilder) {
         let source = self.state.loader.source.clone();
         let metrics = Arc::new(ActiveLoadMetrics::begin(source.clone()));
+        let id = self.state.instances.start_load();
 
         let handle = tokio::task::spawn(super::refresh(
             self.zone.clone(),
             source,
             refresh,
             builder,
+            id,
             self.center.clone(),
             metrics.clone(),
         ));

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -27,7 +27,7 @@ use tracing::error;
 
 use crate::{
     center::{Center, halt_zone},
-    zone::{HistoricalEvent, Zone, ZoneHandle},
+    zone::{HistoricalEvent, Zone, ZoneHandle, instance::SignedInstanceID},
 };
 
 pub mod zone;
@@ -48,12 +48,13 @@ pub mod zone;
 #[tracing::instrument(
     level = "debug",
     skip_all,
-    fields(zone = %zone.name, ?trigger),
+    fields(zone = %zone.name, ?trigger, ?id),
 )]
 async fn sign(
     center: Arc<Center>,
     zone: Arc<Zone>,
     mut builder: SignedZoneBuilder,
+    id: SignedInstanceID,
     trigger: SigningTrigger,
 ) {
     let (status, _permits) = center.signer.wait_to_sign(&zone).await;
@@ -65,7 +66,7 @@ async fn sign(
         move || {
             let result = center
                 .signer
-                .sign_zone(&center, &zone, &mut builder, trigger, status);
+                .sign_zone(&center, &zone, &mut builder, id, trigger, status);
             (result, builder)
         }
     })
@@ -84,12 +85,13 @@ async fn sign(
     match result {
         Ok(()) => {
             let built = builder.finish().unwrap_or_else(|_| unreachable!());
-            handle.storage().finish_sign(built);
+            handle.storage().finish_sign(built, id);
             status.status.finish(true);
             status.current_action = "Finished".to_string();
         }
         Err(error) => {
             error!("Signing failed: {error}");
+            handle.state.instances.abandon_sign(id);
             handle.storage().abandon_sign(builder);
             status.status.finish(false);
             status.current_action = "Aborted".to_string();

--- a/src/signer/zone.rs
+++ b/src/signer/zone.rs
@@ -9,7 +9,7 @@ use crate::{
     center::Center,
     signer::{ResigningTrigger, SigningTrigger},
     util::BackgroundTasks,
-    zone::{Zone, ZoneHandle, ZoneState},
+    zone::{Zone, ZoneHandle, ZoneState, instance::LoadedInstanceID},
 };
 
 //----------- SignerZoneHandle -------------------------------------------------
@@ -48,9 +48,9 @@ impl SignerZoneHandle<'_> {
     #[tracing::instrument(
         level = "trace",
         skip_all,
-        fields(zone = %self.zone.name)
+        fields(zone = %self.zone.name, ?loaded_id)
     )]
-    pub fn enqueue_new_sign(&mut self, builder: SignedZoneBuilder) {
+    pub fn enqueue_new_sign(&mut self, builder: SignedZoneBuilder, loaded_id: LoadedInstanceID) {
         info!("Enqueuing a sign operation");
 
         assert!(
@@ -70,6 +70,7 @@ impl SignerZoneHandle<'_> {
         // moment, this queue is opaque and is handled within the asynchronous
         // task.
 
+        let id = self.state.instances.start_new_sign(loaded_id);
         let span = tracing::Span::none();
         self.state.signer.ongoing.spawn(
             span,
@@ -77,6 +78,7 @@ impl SignerZoneHandle<'_> {
                 self.center.clone(),
                 self.zone.clone(),
                 builder,
+                id,
                 SigningTrigger::Load,
             ),
         );
@@ -145,6 +147,7 @@ impl SignerZoneHandle<'_> {
 
             assert!(self.state.signer.enqueued_new_sign.is_none());
 
+            let id = self.state.instances.start_resign();
             let span = tracing::Span::none();
             self.state.signer.ongoing.spawn(
                 span,
@@ -152,6 +155,7 @@ impl SignerZoneHandle<'_> {
                     self.center.clone(),
                     self.zone.clone(),
                     builder,
+                    id,
                     SigningTrigger::Resign(trigger),
                 ),
             );
@@ -218,6 +222,7 @@ impl SignerZoneHandle<'_> {
         // add the operation to the queue before starting the re-sign. If the
         // queue is too full to start the operation yet, leave it enqueued.
 
+        let id = self.state.instances.start_resign();
         let span = tracing::Span::none();
         self.state.signer.ongoing.spawn(
             span,
@@ -225,6 +230,7 @@ impl SignerZoneHandle<'_> {
                 self.center.clone(),
                 self.zone.clone(),
                 builder,
+                id,
                 SigningTrigger::Resign(trigger),
             ),
         );

--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -45,6 +45,7 @@ use crate::daemon::SocketProvider;
 use crate::manager::Terminated;
 use crate::manager::record_zone_event;
 use crate::util::AbortOnDrop;
+use crate::zone::instance::{LoadedInstanceID, SignedInstanceID};
 use crate::zone::{
     HistoricalEvent, SignedZoneVersionState, UnsignedZoneVersionState, Zone, ZoneHandle,
     ZoneVersionReviewState,
@@ -321,7 +322,11 @@ impl ZoneServer {
         center: &Arc<Center>,
         zone: &Arc<Zone>,
         zone_serial: Serial,
+        // TODO: Split up the function into a loaded and signed variant.
+        loaded_id: Option<LoadedInstanceID>,
+        signed_id: Option<SignedInstanceID>,
     ) -> Option<Result<(), Terminated>> {
+        let _ = signed_id; // TODO
         let unit_name = self.unit_name();
         let zone_type = match self.source {
             Source::Unsigned => "unsigned",
@@ -367,7 +372,7 @@ impl ZoneServer {
                             "[{unit_name}]: Cannot promote unsigned zone '{zone_name}' to the signable set of zones: {err}"
                         );
                     } else {
-                        self.on_unsigned_zone_approved(center, zone, zone_serial);
+                        self.on_unsigned_zone_approved(center, zone, loaded_id.unwrap());
                     }
                 }
                 Source::Signed => {
@@ -528,9 +533,8 @@ impl ZoneServer {
         &self,
         center: &Arc<Center>,
         zone: &Arc<Zone>,
-        zone_serial: Serial,
+        id: LoadedInstanceID,
     ) {
-        let _ = zone_serial; // TODO
         let mut state = zone.state.lock().unwrap();
         ZoneHandle {
             zone,
@@ -538,7 +542,7 @@ impl ZoneServer {
             center,
         }
         .storage()
-        .approve_loaded();
+        .approve_loaded(id);
     }
 
     fn on_signed_zone_approved(&self, center: &Arc<Center>, zone: &Arc<Zone>, zone_serial: Serial) {
@@ -599,6 +603,8 @@ impl ZoneServer {
         // Look up the version of the zone being reviewed.
         match self.source {
             Source::Unsigned => {
+                // TODO: Make the reviewer pass the ID.
+                let id;
                 {
                     let mut zone_state = zone.state.lock().unwrap();
                     let Some(version) = zone_state.unsigned.get_mut(&zone_serial) else {
@@ -622,6 +628,13 @@ impl ZoneServer {
                     }
 
                     version.review = new_review_state;
+                    id = match zone_state.instances.upcoming {
+                        Some(
+                            crate::zone::instance::UpcomingInstance::Loading { id }
+                            | crate::zone::instance::UpcomingInstance::ReviewingLoaded { id },
+                        ) => id,
+                        _ => unreachable!(),
+                    }
                 }
                 if matches!(decision, ZoneReviewDecision::Approve) {
                     info!(
@@ -629,7 +642,7 @@ impl ZoneServer {
                     );
                     match Self::promote_zone_to_signable(center.clone(), zone_name) {
                         Ok(()) => {
-                            self.on_unsigned_zone_approved(center, zone, zone_serial);
+                            self.on_unsigned_zone_approved(center, zone, id);
                         }
                         Err(err) => {
                             error!(

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -59,6 +59,7 @@ use crate::util::{
     AbortOnDrop, serialize_duration_as_secs, serialize_instant_as_duration_secs,
     serialize_opt_duration_as_secs,
 };
+use crate::zone::instance::SignedInstanceID;
 use crate::zone::{HistoricalEvent, HistoricalEventType, PipelineMode, Zone, ZoneHandle};
 
 // Re-signing zones before signatures expire works as follows:
@@ -314,6 +315,7 @@ impl ZoneSigner {
         center: &Arc<Center>,
         zone: &Arc<Zone>,
         builder: &mut SignedZoneBuilder,
+        id: SignedInstanceID,
         trigger: SigningTrigger,
         status: Arc<RwLock<SigningStatusPerZone>>,
     ) -> Result<(), SignerError> {
@@ -907,6 +909,8 @@ impl ZoneSigner {
             center,
             zone,
             domain::base::Serial(serial.into()),
+            None,
+            Some(id),
         );
 
         Ok(())

--- a/src/zone/instance.rs
+++ b/src/zone/instance.rs
@@ -26,6 +26,177 @@ pub struct Instances {
     pub old: OldInstances,
 }
 
+/// # Loader Operations
+impl Instances {
+    /// Start loading a new instance of the zone.
+    ///
+    /// A new upcoming instance of the zone is prepared, and it is assigned an
+    /// ID (which is returned).
+    ///
+    /// ## Panics
+    ///
+    /// Panics if an upcoming instance of the zone already exists.
+    #[tracing::instrument(level = "trace", skip_all)]
+    pub fn start_load(&mut self) -> LoadedInstanceID {
+        assert!(
+            self.upcoming.is_none(),
+            "Cannot start a load while an upcoming instance exists"
+        );
+
+        let id = LoadedInstanceID(self.next_loaded_id);
+        // TODO(MSRV 1.91): Use 'strict_add()'.
+        self.next_loaded_id = self.next_loaded_id.checked_add(1).unwrap();
+        self.upcoming = Some(UpcomingInstance::Loading { id });
+        id
+    }
+
+    /// Abandon an ongoing load.
+    ///
+    /// The upcoming instance of the zone, initialized by
+    /// [`Self::start_load()`], will be abandoned.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the specified `id` does not match the upcoming (loaded)
+    /// instance of the zone. Panics if an upcoming signed instance of the zone
+    /// exists.
+    #[tracing::instrument(level = "trace", skip_all, fields(?expected_id))]
+    pub fn abandon_load(&mut self, expected_id: LoadedInstanceID) {
+        match self.upcoming.take() {
+            Some(UpcomingInstance::Loading { id } | UpcomingInstance::ReviewingLoaded { id }) => {
+                assert_eq!(id, expected_id, "The loaded instance has a different ID");
+                self.abandoned
+                    .push(AbandonedInstance::Loaded(AbandonedLoadedInstance { id }));
+            }
+            other => panic!("A loaded instance is not being built or reviewed: {other:?}"),
+        }
+    }
+}
+
+/// # Signer Operations
+impl Instances {
+    /// Start signing a newly loaded instance of the zone.
+    ///
+    /// A new upcoming signed instance of the zone is prepared, and it is
+    /// assigned an ID (which is returned).
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the upcoming loaded instance of the zone does not exist, or
+    /// has a different ID. Panics if the upcoming signed instance of the zone
+    /// already exists.
+    #[tracing::instrument(level = "trace", skip_all, fields(?loaded_id))]
+    pub fn start_new_sign(&mut self, loaded_id: LoadedInstanceID) -> SignedInstanceID {
+        let (upcoming, id) = self
+            .upcoming
+            .take()
+            .unwrap_or_else(|| panic!("There is no upcoming instance"))
+            .into_signing_new();
+        self.upcoming = Some(upcoming);
+        id
+    }
+
+    /// Start re-signing the zone.
+    ///
+    /// A new upcoming signed instance of the zone is prepared, relative to the
+    /// current loaded instance. The upcoming instance is assigned an ID (which
+    /// is returned).
+    ///
+    /// Note that a current signed instance does not have to exist (e.g. if
+    /// signing was previously disabled).
+    ///
+    /// ## Panics
+    ///
+    /// Panics if a current *loaded* instance of the zone does not exist. Panics
+    /// if an upcoming instance of the zone already exists.
+    #[tracing::instrument(level = "trace", skip_all)]
+    pub fn start_resign(&mut self) -> SignedInstanceID {
+        let current = self
+            .current
+            .as_ref()
+            .unwrap_or_else(|| panic!("There is no current instance to re-sign"));
+        assert!(
+            self.upcoming.is_none(),
+            "An upcoming instance already exists"
+        );
+
+        let id = SignedInstanceID(current.loaded.id, self.next_signed_id);
+        // TODO(MSRV 1.91): Use 'strict_add()'.
+        self.next_signed_id = self.next_signed_id.checked_add(1).unwrap();
+        self.upcoming = Some(UpcomingInstance::Resigning { id });
+        id
+    }
+
+    // TODO: `retry_sign()`
+
+    /// Abandon an ongoing signing operation.
+    ///
+    /// The upcoming signed and (if any) loaded instance of the zone will be
+    /// abandoned.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if there is no upcoming instance of the zone. Panics if the
+    /// specified `id` does not match the upcoming instance of the zone.
+    #[tracing::instrument(level = "trace", skip_all, fields(?expected_id))]
+    pub fn abandon_sign(&mut self, expected_id: SignedInstanceID) {
+        match self.upcoming.take() {
+            Some(
+                UpcomingInstance::SigningNew { id } | UpcomingInstance::ReviewingNewSigned { id },
+            ) => {
+                assert_eq!(id, expected_id, "The signed instance has a different ID");
+                self.abandoned
+                    .push(AbandonedInstance::Signed(AbandonedSignedInstance { id }));
+                self.abandoned
+                    .push(AbandonedInstance::Loaded(AbandonedLoadedInstance {
+                        id: id.0,
+                    }));
+            }
+            Some(
+                UpcomingInstance::Resigning { id } | UpcomingInstance::ReviewingResigned { id },
+            ) => {
+                assert_eq!(id, expected_id, "The signed instance has a different ID");
+                self.abandoned
+                    .push(AbandonedInstance::Signed(AbandonedSignedInstance { id }));
+            }
+            other => panic!("A signed instance is not being built or reviewed: {other:?}"),
+        }
+    }
+
+    /// Accept the upcoming signed instance.
+    ///
+    /// The upcoming signed instance will replace the current instance.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if there is no upcoming instance of the zone. Panics if the
+    /// upcoming instance has a different ID.
+    #[tracing::instrument(level = "trace", skip_all, fields(?expected_id))]
+    pub fn accept_signed(&mut self, expected_id: SignedInstanceID) {
+        match self.upcoming.take() {
+            Some(
+                UpcomingInstance::SigningNew { id } | UpcomingInstance::ReviewingNewSigned { id },
+            ) => {
+                assert_eq!(id, expected_id, "The signed instance has a different ID");
+                self.current = Some(CurrentInstance {
+                    loaded: CurrentLoadedInstance { id: id.0 },
+                    signed: Some(CurrentSignedInstance { id }),
+                });
+            }
+            Some(
+                UpcomingInstance::Resigning { id } | UpcomingInstance::ReviewingResigned { id },
+            ) => {
+                assert_eq!(id, expected_id, "The signed instance has a different ID");
+                self.current
+                    .as_mut()
+                    .expect("Re-signing only occurs if a current instance exists")
+                    .signed = Some(CurrentSignedInstance { id });
+            }
+            other => panic!("A signed instance is not being built or reviewed: {other:?}"),
+        }
+    }
+}
+
 //----------- CurrentInstance --------------------------------------------------
 
 /// The current instance of the zone.

--- a/src/zone/instance.rs
+++ b/src/zone/instance.rs
@@ -1,0 +1,245 @@
+//! Tracking instances of zones.
+
+use std::collections::VecDeque;
+
+//----------- Instances --------------------------------------------------------
+
+/// Current and old instances of a zone.
+#[derive(Debug, Default)]
+pub struct Instances {
+    /// The ID of the next loaded instance.
+    pub next_loaded_id: u64,
+
+    /// The ID of the next signed instance.
+    pub next_signed_id: u64,
+
+    /// The current instance of the zone.
+    pub current: Option<CurrentInstance>,
+
+    /// An upcoming instance of the zone, if any.
+    pub upcoming: Option<UpcomingInstance>,
+
+    /// Abandoned instances of the zone.
+    pub abandoned: Vec<AbandonedInstance>,
+
+    /// Old instances of the zone.
+    pub old: OldInstances,
+}
+
+//----------- CurrentInstance --------------------------------------------------
+
+/// The current instance of the zone.
+#[derive(Debug)]
+pub struct CurrentInstance {
+    /// The current loaded instance of the zone, if any.
+    pub loaded: CurrentLoadedInstance,
+
+    /// The current signed instance of the zone, if any.
+    ///
+    /// If this exists, there is also a current loaded instance, and it has a
+    /// corresponding ID.
+    pub signed: Option<CurrentSignedInstance>,
+}
+
+/// The current loaded instance of a zone.
+#[derive(Debug)]
+pub struct CurrentLoadedInstance {
+    /// The ID of this instance.
+    pub id: LoadedInstanceID,
+}
+
+/// The current signed instance of a zone.
+#[derive(Debug)]
+pub struct CurrentSignedInstance {
+    /// The ID of this instance.
+    pub id: SignedInstanceID,
+}
+
+//----------- UpcomingInstance -------------------------------------------------
+
+/// An upcoming instance of a zone.
+#[derive(Debug)]
+pub enum UpcomingInstance {
+    /// A new instance is being loaded.
+    Loading {
+        /// The ID of the instance.
+        id: LoadedInstanceID,
+    },
+
+    /// A newly loaded instance is being reviewed.
+    ReviewingLoaded {
+        /// The ID of the instance.
+        id: LoadedInstanceID,
+    },
+
+    /// A newly loaded instance is being signed.
+    SigningNew {
+        /// The ID of the instance.
+        id: SignedInstanceID,
+    },
+
+    /// A newly loaded and signed instance is being reviewed.
+    ReviewingNewSigned {
+        /// The ID of the instance.
+        id: SignedInstanceID,
+    },
+
+    /// The current instance is being re-signed.
+    Resigning {
+        /// The ID of the instance.
+        id: SignedInstanceID,
+    },
+
+    /// A re-signed instance is being reviewed.
+    ReviewingResigned {
+        /// The ID of the instance.
+        id: SignedInstanceID,
+    },
+}
+
+impl UpcomingInstance {
+    /// Begin reviewing the newly loaded instance.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if `self` is not [`Self::Loading`].
+    #[tracing::instrument(level = "trace")]
+    pub fn into_reviewing_loaded(self) -> Self {
+        match self {
+            Self::Loading { id } => Self::ReviewingLoaded { id },
+            other => panic!("An instance is not being loaded: {other:?}"),
+        }
+    }
+
+    /// Accept the newly loaded instance and transition to [`Self::SigningNew`].
+    ///
+    /// Returns the ID of the new signed instance being built.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if `self` is not [`Self::Loading`] or [`Self::ReviewingLoaded`].
+    #[tracing::instrument(level = "trace")]
+    pub fn into_signing_new(self) -> (Self, SignedInstanceID) {
+        match self {
+            Self::Loading { id } | Self::ReviewingLoaded { id } => {
+                let id = SignedInstanceID(id, 0);
+                (Self::SigningNew { id }, id)
+            }
+            other => panic!("An instance is not being loaded: {other:?}"),
+        }
+    }
+
+    /// Begin reviewing the signed instance.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if `self` is not [`Self::SigningNew`] or [`Self::Resigning`].
+    #[tracing::instrument(level = "trace")]
+    pub fn into_reviewing_signed(self) -> Self {
+        match self {
+            Self::SigningNew { id } => Self::ReviewingNewSigned { id },
+            Self::Resigning { id } => Self::ReviewingResigned { id },
+            other => panic!("An instance is not being signed: {other:?}"),
+        }
+    }
+}
+
+//----------- OldInstances -----------------------------------------------------
+
+/// Old instances of a zone.
+#[derive(Debug, Default)]
+pub struct OldInstances {
+    /// The instances, in order of replacement.
+    ///
+    /// When a new pair of loaded and signed instances replace the current ones,
+    /// the signed instance and the loaded instance (in that order) are pushed
+    /// to the back of this queue.
+    ///
+    /// Signed instances are based on the closest succeeding loaded instance.
+    pub instances: VecDeque<OldInstance>,
+}
+
+/// An old instance of a zone.
+#[derive(Debug)]
+pub enum OldInstance {
+    /// An old loaded instance.
+    Loaded(OldLoadedInstance),
+
+    /// An old signed instance.
+    Signed(OldSignedInstance),
+}
+
+/// An old loaded instance of a zone.
+#[derive(Debug)]
+pub struct OldLoadedInstance {
+    /// The ID of this instance.
+    pub id: LoadedInstanceID,
+}
+
+/// An old signed instance of a zone.
+#[derive(Debug)]
+pub struct OldSignedInstance {
+    /// The ID of this instance.
+    pub id: SignedInstanceID,
+}
+
+//----------- AbandonedInstance ------------------------------------------------
+
+/// An abandoned instance of a zone.
+#[derive(Debug)]
+pub enum AbandonedInstance {
+    /// An abandoned loaded instance.
+    Loaded(AbandonedLoadedInstance),
+
+    /// An abandoned signed instance.
+    Signed(AbandonedSignedInstance),
+}
+
+/// An abandoned loaded instance of a zone.
+#[derive(Debug)]
+pub struct AbandonedLoadedInstance {
+    /// The ID of this instance.
+    pub id: LoadedInstanceID,
+}
+
+/// An abandoned signed instance of a zone.
+#[derive(Debug)]
+pub struct AbandonedSignedInstance {
+    /// The ID of this instance.
+    pub id: SignedInstanceID,
+}
+
+//----------- LoadedInstanceID -------------------------------------------------
+
+/// A unique identifier for a loaded instance of a zone.
+///
+/// Every loaded instance is assigned an ID; it uniquely identifies them, even
+/// if two instances have the same SOA serial number.
+///
+/// The very first loaded instance of the zone is assigned ID 0. Every following
+/// instance is assigned the succeeding integer. These IDs disambiguate
+/// instances even if they have the same SOA serial number.
+///
+/// Integer overflow is considered impossible due to the sheer number of
+/// instances necessary for it. If the ID does overflow, Cascade will crash.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LoadedInstanceID(pub u64);
+
+//----------- SignedInstanceID -------------------------------------------------
+
+/// A unique identifier for a signed instance of a zone.
+///
+/// Every instance is assigned an ID (including the ID of the loaded instance
+/// it is based on); it uniquely identifies them, even if two instances have the
+/// same SOA serial number.
+///
+/// When a loaded instance is signed for the first time, the signed instance is
+/// assigned ID 0. Every following instance based on the same loaded instance is
+/// assigned the succeeding integer. When a new loaded instance is signed, the
+/// ID resets to 0 (this is unambiguous because the loaded instance ID is also
+/// included).
+///
+/// Integer overflow is considered impossible due to the sheer number of
+/// instances necessary for it. If the ID does overflow, Cascade will crash.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SignedInstanceID(pub LoadedInstanceID, pub u64);

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -24,7 +24,10 @@ use crate::{
     policy::{Policy, PolicyVersion},
     signer::zone::{SignerState, SignerZoneHandle},
     util::{deserialize_duration_from_secs, serialize_duration_as_secs},
+    zone::instance::Instances,
 };
+
+pub mod instance;
 
 mod storage;
 pub use storage::{StorageState, StorageZoneHandle};
@@ -104,6 +107,9 @@ pub struct ZoneState {
     /// duration of time.  If the field is `None`, and the state is changed, a
     /// new save operation should be enqueued.
     pub enqueued_save: Option<tokio::task::JoinHandle<()>>,
+
+    /// Instances of the zone.
+    pub instances: Instances,
 
     /// The minimum expiration time in the signed zone we are serving from
     /// the publication server.

--- a/src/zone/storage.rs
+++ b/src/zone/storage.rs
@@ -39,7 +39,10 @@ use crate::{
     common::light_weight_zone::LightWeightZone,
     signer::SigningTrigger,
     util::{BackgroundTasks, force_future},
-    zone::{HistoricalEvent, PipelineMode, Zone, ZoneHandle, ZoneState},
+    zone::{
+        HistoricalEvent, PipelineMode, Zone, ZoneHandle, ZoneState,
+        instance::{LoadedInstanceID, SignedInstanceID},
+    },
 };
 
 //----------- StorageZoneHandle ------------------------------------------------
@@ -119,7 +122,7 @@ impl StorageZoneHandle<'_> {
         skip_all,
         fields(zone = %self.zone.name),
     )]
-    pub fn finish_load(&mut self, built: LoadedZoneBuilt) {
+    pub fn finish_load(&mut self, built: LoadedZoneBuilt, id: LoadedInstanceID) {
         // Examine the current state.
         let (transition, state) = transition(&mut self.state.storage.machine);
         match state {
@@ -137,7 +140,7 @@ impl StorageZoneHandle<'_> {
                     Some(domain::base::Serial(serial.into())),
                 );
 
-                self.start_loaded_review(loaded_reviewer);
+                self.start_loaded_review(loaded_reviewer, id);
             }
 
             _ => unreachable!(
@@ -185,7 +188,7 @@ impl StorageZoneHandle<'_> {
         skip_all,
         fields(zone = %self.zone.name),
     )]
-    fn start_loaded_review(&mut self, loaded_reviewer: LoadedZoneReviewer) {
+    fn start_loaded_review(&mut self, loaded_reviewer: LoadedZoneReviewer, id: LoadedInstanceID) {
         // NOTE: This function provides compatibility with 'zonetree's.
 
         let zone = self.zone.clone();
@@ -256,6 +259,8 @@ impl StorageZoneHandle<'_> {
                     &center,
                     &zone,
                     domain::base::Serial(serial.into()),
+                    Some(id),
+                    None,
                 );
 
                 state = zone.state.lock().unwrap();
@@ -292,9 +297,9 @@ impl StorageZoneHandle<'_> {
     #[tracing::instrument(
         level = "trace",
         skip_all,
-        fields(zone = %self.zone.name),
+        fields(zone = %self.zone.name, ?id),
     )]
-    pub fn approve_loaded(&mut self) {
+    pub fn approve_loaded(&mut self, id: LoadedInstanceID) {
         self.state.record_event(
             HistoricalEvent::UnsignedZoneReview {
                 status: ZoneReviewStatus::Approved,
@@ -311,7 +316,7 @@ impl StorageZoneHandle<'_> {
 
                 let (s, persister) = s.mark_approved();
                 transition.move_to(ZoneDataStorage::PersistingLoaded(s));
-                self.start_loaded_persistence(persister);
+                self.start_loaded_persistence(persister, id);
             }
 
             _ => panic!("The zone is not undergoing loader review"),
@@ -370,9 +375,9 @@ impl StorageZoneHandle<'_> {
     #[tracing::instrument(
         level = "trace",
         skip_all,
-        fields(zone = %self.zone.name),
+        fields(zone = %self.zone.name, ?id),
     )]
-    pub fn finish_sign(&mut self, built: SignedZoneBuilt) {
+    pub fn finish_sign(&mut self, built: SignedZoneBuilt, id: SignedInstanceID) {
         // Examine the current state.
         let (transition, state) = transition(&mut self.state.storage.machine);
         match state {
@@ -393,7 +398,7 @@ impl StorageZoneHandle<'_> {
                     Some(domain::base::Serial(serial.into())),
                 );
 
-                self.start_signed_review(signed_reviewer);
+                self.start_signed_review(signed_reviewer, id);
             }
 
             _ => unreachable!(
@@ -445,9 +450,9 @@ impl StorageZoneHandle<'_> {
     #[tracing::instrument(
         level = "trace",
         skip_all,
-        fields(zone = %self.zone.name),
+        fields(zone = %self.zone.name, ?id),
     )]
-    fn start_signed_review(&mut self, signed_reviewer: SignedZoneReviewer) {
+    fn start_signed_review(&mut self, signed_reviewer: SignedZoneReviewer, id: SignedInstanceID) {
         // NOTE: This function provides compatibility with 'zonetree's.
 
         let zone = self.zone.clone();
@@ -496,6 +501,7 @@ impl StorageZoneHandle<'_> {
                     let (s, persister) = s.mark_approved();
                     let persisted = persister.persist();
                     let (s, viewer) = s.mark_complete(persisted);
+                    handle.state.instances.accept_signed(id);
                     let old_viewer = std::mem::replace(&mut handle.state.storage.viewer, viewer);
                     let (s, cleaner) = s.switch(old_viewer);
                     transition.move_to(ZoneDataStorage::Cleaning(s));
@@ -519,6 +525,8 @@ impl StorageZoneHandle<'_> {
                 &center,
                 &zone,
                 domain::base::Serial(serial.into()),
+                None,
+                Some(id),
             );
 
             state = zone.state.lock().unwrap();
@@ -624,9 +632,9 @@ impl StorageZoneHandle<'_> {
     #[tracing::instrument(
         level = "trace",
         skip_all,
-        fields(zone = %self.zone.name),
+        fields(zone = %self.zone.name, ?id),
     )]
-    fn start_loaded_persistence(&mut self, persister: LoadedZonePersister) {
+    fn start_loaded_persistence(&mut self, persister: LoadedZonePersister, id: LoadedInstanceID) {
         let zone = self.zone.clone();
         let center = self.center.clone();
         let span = trace_span!("persist_loaded");
@@ -658,7 +666,7 @@ impl StorageZoneHandle<'_> {
                     "'ZoneDataStorage::PersistingLoaded' is the only state where a 'LoadedZonePersister' is available"
                 ),
             };
-            handle.signer().enqueue_new_sign(builder);
+            handle.signer().enqueue_new_sign(builder, id);
 
             handle.state.storage.background_tasks.finish();
         });


### PR DESCRIPTION
This PR introduces `zone/instance.rs` for tracking zone instances. It introduces `{Loaded,Signed}InstanceID` as a way to uniquely identify loaded and signed instances of zones, respectively; unlike SOA serial numbers, instance IDs are guaranteed to be unique (even if two instances have the same SOA serial, or if an instance is rejected). The rest of the codebase has been integrated with this system, so IDs are correctly available at every step (except review to some extent; I will work on it next).

The new state for instances will eventually replace the `.{unsigned,signed}` fields of `ZoneState`. They will accumulate more instance-specific data, e.g. loader/signer statistics, diffs (for persistence, rollback, and IXFR out), maybe even logs/history.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
