### PR TITLE
Correct reviewer assertion when abandoning re-signing

### DIFF
--- a/crates/zonedata/src/storage/transitions.rs
+++ b/crates/zonedata/src/storage/transitions.rs
@@ -443,11 +443,16 @@ impl CleanLoadedPendingStorage {
             Arc::ptr_eq(old_reviewer.data(), &self.data),
             "'old_reviewer' is for a different zone"
         );
+        // If a diff existed, then '!curr_loaded_index' must be used.
         assert!(
-            old_reviewer.loaded_index != self.curr_loaded_index,
-            "'old_reviewer' does not point to the new instance",
+            old_reviewer.loaded_diff().is_some()
+                == (old_reviewer.loaded_index != self.curr_loaded_index),
+            "'old_reviewer' does not point to the instance being cleaned",
         );
 
+        // NOTE: We clean '!curr_loaded_index', *even if that was not the one
+        // being reviewed*. 'curr_loaded_index' is in use and thus must not be
+        // cleaned.
         let cleaner = unsafe {
             ZoneCleaner::new(
                 self.data.clone(),

--- a/crates/zonedata/src/storage/transitions.rs
+++ b/crates/zonedata/src/storage/transitions.rs
@@ -443,12 +443,7 @@ impl CleanLoadedPendingStorage {
             Arc::ptr_eq(old_reviewer.data(), &self.data),
             "'old_reviewer' is for a different zone"
         );
-        // If a diff existed, then '!curr_loaded_index' must be used.
-        assert!(
-            old_reviewer.loaded_diff().is_some()
-                == (old_reviewer.loaded_index != self.curr_loaded_index),
-            "'old_reviewer' does not point to the instance being cleaned",
-        );
+        // TODO: Verify that 'old_reviewer' is the right reviewer.
 
         // NOTE: We clean '!curr_loaded_index', *even if that was not the one
         // being reviewed*. 'curr_loaded_index' is in use and thus must not be


### PR DESCRIPTION
The assertion did not account for re-signing, where the loaded instance of the zone under review is the same as the current instance.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?