### PR TITLE
Reduce git conflicts and verbose test definitions.

### DIFF
--- a/act-wrapper
+++ b/act-wrapper
@@ -34,6 +34,7 @@ function usage {
 	echo "Inputs that can be provided via --input:"
 	echo "	--input build-profile=debug|release"
 	echo "	--input log-level=error|warn|info|debug|trace"
+	echo "  --input concurrent-tests=1"
 	echo ""
 	echo "Use --matrix test:<TEST NAME TO RUN> to limit which jobs the 'tests' job runs."
 }

--- a/act-wrapper
+++ b/act-wrapper
@@ -34,6 +34,8 @@ function usage {
 	echo "Inputs that can be provided via --input:"
 	echo "	--input build-profile=debug|release"
 	echo "	--input log-level=error|warn|info|debug|trace"
+	echo ""
+	echo "Use --matrix test:<TEST NAME TO RUN> to limit which jobs the 'tests' job runs."
 }
 
 if [[ "$1" =~ ^-h|--help$ ]]; then

--- a/act-wrapper
+++ b/act-wrapper
@@ -162,7 +162,7 @@ if [[ "$docker_stats" == true ]]; then
 fi
 
 echo "Running tests"
-act "${act_args[@]}" --log-prefix-job-id --pull=false -P "ubuntu-latest=nlnetlabs/cascade-tests-runner" -W integration-tests/system-tests.yml "$@" && ACT_EXIT_CODE=$? || ACT_EXIT_CODE=$? 
+act "${act_args[@]}" --pull=false -P "ubuntu-latest=nlnetlabs/cascade-tests-runner" -W integration-tests/system-tests.yml "$@" && ACT_EXIT_CODE=$? || ACT_EXIT_CODE=$? 
 
 # Stop the docker stats collection process, if needed.
 if [[ "$docker_stats" == true ]]; then

--- a/integration-tests/system-tests.yml
+++ b/integration-tests/system-tests.yml
@@ -60,9 +60,6 @@ jobs:
   test-release-version:
     name: Example test with prepare environment and cascade --version (release)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [stable]
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/prepare-systest-env
@@ -75,94 +72,28 @@ jobs:
   test-version:
     name: Example test with prepare environment and cascade --version (debug)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [stable]
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/prepare-systest-env
     - run: cascade --version
     - run: file $(which cascade)
 
-  add-zone-query:
-    name: Add a zone, query the published zone
+  tests:
+    name: Run the system tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable]
+        test: [add-zone-query, load-zonefile, review-unsigned-zone, review-unsigned-zone2, ixfr-in, notify-in-for-unknown-zone, remove-zone, all-rr-types]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/set-build-profile
         with:
           build-profile: ${{ inputs.build-profile }}
-      - uses: ./integration-tests/tests/add-zone-query
+      - uses: jenseng/dynamic-uses@v1
         with:
-          log-level: ${{ inputs.log-level }}
-
-  # Added for https://github.com/NLnetLabs/cascade/pull/402
-  load-zonefile:
-    name: Load a zone from a file, query the published zone
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [stable]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/set-build-profile
-        with:
-          build-profile: ${{ inputs.build-profile }}
-      - uses: ./integration-tests/tests/load-zonefile
-        with:
-          log-level: ${{ inputs.log-level }}
-
-  # Added for https://github.com/NLnetLabs/cascade/pull/398
-  review-unsigned-zone:
-    name: Add a zone, approve the unsigned zone, query the published zone
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [stable]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/set-build-profile
-        with:
-          build-profile: ${{ inputs.build-profile }}
-      - uses: ./integration-tests/tests/review-unsigned-zone
-        with:
-          log-level: ${{ inputs.log-level }}
-
-  review-unsigned-zone2:
-    name: Test that the review server has the original zone
-    runs-on: ubuntu-latest
-    strategy:
-      #max-parallel: 1
-      matrix:
-        rust: [stable]
-        test_idx: [1, 2]
-        key: ['Kexample.+015+02835.key']
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/set-build-profile
-        with:
-          build-profile: ${{ inputs.build-profile }}
-      - uses: ./integration-tests/tests/review-unsigned-zone2
-        with:
-          log-level: ${{ inputs.log-level }}
-          test_idx: ${{ matrix.test_idx }}
-          key: ${{ matrix.key }}
-
-  ixfr-in:
-    name: Receive a zone via IXFR from the NSD primary.
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [stable]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/set-build-profile
-        with:
-          build-profile: ${{ inputs.build-profile }}
-      - uses: ./integration-tests/tests/ixfr-in
+          uses: ./integration-tests/tests/${{ matrix.test }}
+          # with:
+          #   log-level: ${{ inputs.log-level }}
 
   incremental-signing:
     name: Test incremental signing.
@@ -213,48 +144,3 @@ jobs:
           policy: ${{ matrix.policy }}
           test_idx: ${{ matrix.test_idx }}
           key: ${{ matrix.key }}
-
-  notify-in-for-unknown-zone:
-    name: Receive a NOTIFY for a zone that is unknown to Cascade.
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [stable]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/set-build-profile
-        with:
-          build-profile: release
-      - uses: ./integration-tests/tests/notify-in-for-unknown-zone
-        with:
-          log-level: ${{ inputs.log-level }}
-
-  remove-zone:
-    name: Add, sign and remove a zone.
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [stable]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/set-build-profile
-        with:
-          build-profile: ${{ inputs.build-profile }}
-      - uses: ./integration-tests/tests/remove-zone
-        with:
-          log-level: ${{ inputs.log-level }}
-
-  all-rr-types:
-    name: Tests loading of all supported RR types.
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [stable]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/set-build-profile
-        with:
-          build-profile: ${{ inputs.build-profile }}
-      - uses: ./integration-tests/tests/all-rr-types
-        with:
-          log-level: ${{ inputs.log-level }}

--- a/integration-tests/system-tests.yml
+++ b/integration-tests/system-tests.yml
@@ -79,7 +79,7 @@ jobs:
     - run: file $(which cascade)
 
   tests:
-    name: Run the system tests
+    name: Run ${{ join(matrix.test, ' - ') }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/integration-tests/system-tests.yml
+++ b/integration-tests/system-tests.yml
@@ -44,6 +44,11 @@ on:
           - info
           - debug
           - trace
+      concurrent-tests:
+        description: The number of tests job system tests to run concurrently.
+        required: false
+        default: 8
+        type: number
 
 env:
   # Set this assignment to your choosing to set the cargo build verbosity
@@ -84,6 +89,7 @@ jobs:
     strategy:
       matrix:
         test: [add-zone-query, load-zonefile, review-unsigned-zone, review-unsigned-zone2, ixfr-in, notify-in-for-unknown-zone, remove-zone, all-rr-types]
+      max-parallel: ${{ inputs.concurrent-tests }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/set-build-profile


### PR DESCRIPTION
Combine the almost identical system test definitions into a single job that invokes them as a matrix requiring only that new test names be added to the 'tests' matrix key rather than duplicating the entire job block every time, and each PR that adds a system test then conflicting with the others due to each modifying the same part of system-tests.yml.

Notes added to `act-wrapper` help output:
- To limit which tests are run by the new tests job one must now supply --matrix tests:<TEST NAME TO RUN> instead of --job <JOB NAME TO RUN>..
- To limit the number of concurrent 'tests' sub-jobs one must now supply --input concurrent-tests:1

The tests fail when run, not sure if that also happens on `main` at present.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
