### PR TITLE
Instructions for building dnst

### DIFF
--- a/doc/manual/source/building.rst
+++ b/doc/manual/source/building.rst
@@ -100,7 +100,7 @@ as simple as running:
 .. code-block:: bash
 
   cargo install --locked --git https://github.com/nlnetlabs/cascade cascade cascaded
-  cargo install --locked --bin dnst --git https://github.com/nlnetlabs/dnst
+  cargo install --locked --bin dnst --git https://github.com/nlnetlabs/dnst dnst
 
 The command will build Cascade and install it in the same directory that
 Cargo itself lives in, likely ``$HOME/.cargo/bin``. Ensure this directory is


### PR DESCRIPTION
If I can believe the command output, there's a `dnst` missing in the description of building `dnst`:

```
$ cargo install --locked --bin dnst --git https://github.com/nlnetlabs/dnst
    Updating git repository `https://github.com/nlnetlabs/dnst`
error: multiple packages with binaries found: dnst, dnst-ldnsutils. When installing a git repository, cargo will always search the entire repo for any Cargo.toml.
Please specify a package, e.g. `cargo install --git https://github.com/nlnetlabs/dnst dnst`.
```

Hence this tiny PR.

