### PR TITLE
Show loaded serial of published instance in `zone status`

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -368,9 +368,9 @@ pub struct ZoneStatus {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct LastPublishedZone {
+    pub loaded_serial: Serial,
     pub signed_serial: Serial,
     // TODO:
-    //  - loaded serial
     //  - time of publish
     //  - number of records
     //  - size in bytes

--- a/crates/cli/src/commands/zone.rs
+++ b/crates/cli/src/commands/zone.rs
@@ -558,7 +558,7 @@ impl Zone {
 
         println!("last published");
         if let Some(last) = &zone.last_published {
-            println!("  loaded serial: <TODO>");
+            println!("  loaded serial: {}", last.loaded_serial);
             println!("  signed serial: {}", last.signed_serial);
             println!("  timestamp:     <TODO>");
             println!("  size:          <TODO> records (<TODO>B)");

--- a/crates/zonedata/src/reader.rs
+++ b/crates/zonedata/src/reader.rs
@@ -172,6 +172,11 @@ impl<'d> SignedZoneReader<'d> {
         self.signed_instance.records.as_slice()
     }
 
+    /// The underlying loaded instance.
+    pub const fn loaded(&self) -> LoadedZoneReader<'d> {
+        LoadedZoneReader::new(self.loaded_instance)
+    }
+
     /// Records from the loaded instance of the zone.
     ///
     /// Records are sorted in DNSSEC canonical order. Only records also present

--- a/integration-tests/tests/ixfr-in/action.yml
+++ b/integration-tests/tests/ixfr-in/action.yml
@@ -45,8 +45,9 @@ runs:
       run: |
         timeout=10 # seconds
         start=$(date +%s)
-        until cascade zone status example.test | grep -q "load (serial: 1)"; do
+        until cascade zone status example.test | grep -q "loaded serial: 1"; do
           if (($(date +%s) > (start + timeout))); then
+            cascade zone status example.test
             echo "::error:: timeout: zone status did not report that the zone serial 1 was loaded"
             exit 1
           fi
@@ -100,7 +101,7 @@ runs:
       run: |
         timeout=10 # seconds
         start=$(date +%s)
-        until cascade zone status example.test | grep -q "load (serial: 2)"; do
+        until cascade zone status example.test | grep -q "loaded serial: 2"; do
           if (($(date +%s) > (start + timeout))); then
             cascade zone status example.test
             echo "::error:: timeout: zone status did not report that the zone serial 2 was loaded"
@@ -154,7 +155,7 @@ runs:
       run: |
         timeout=10 # seconds
         start=$(date +%s)
-        until cascade zone status example.test | grep -q "load (serial: 3)"; do
+        until cascade zone status example.test | grep -q "loaded serial: 3"; do
           if (($(date +%s) > (start + timeout))); then
             cascade zone status example.test
             echo "::error:: timeout: zone status did not report that the zone serial 3 was loaded"

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -462,6 +462,7 @@ impl HttpServer {
                 .last_published
                 .as_ref()
                 .map(|p| LastPublishedZone {
+                    loaded_serial: p.loaded_serial,
                     signed_serial: p.signed_serial,
                 });
         }

--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -36,8 +36,8 @@ use crate::manager::record_zone_event;
 use crate::server::{LoadedReviewServer, PublicationServer, SignedReviewServer};
 use crate::util::AbortOnDrop;
 use crate::zone::{
-    HistoricalEvent, LastPublished, SignedZoneVersionState, UnsignedZoneVersionState, Zone,
-    ZoneHandle, ZoneVersionReviewState,
+    HistoricalEvent, SignedZoneVersionState, UnsignedZoneVersionState, Zone, ZoneHandle,
+    ZoneVersionReviewState,
 };
 
 /// The source of a zone server.
@@ -495,10 +495,6 @@ impl ZoneServer {
                 center,
             }
             .approve_signed();
-
-            state.last_published = Some(LastPublished {
-                signed_serial: zone_serial,
-            })
         }
 
         // Send a message to the zone signer to trigger a re-scan of

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -168,9 +168,9 @@ impl ZoneState {
 
 #[derive(Debug)]
 pub struct LastPublished {
+    pub loaded_serial: Serial,
     pub signed_serial: Serial,
     // TODO:
-    //  - loaded serial
     //  - time of publish
     //  - number of records
     //  - size in bytes

--- a/src/zone/storage.rs
+++ b/src/zone/storage.rs
@@ -30,13 +30,14 @@ use cascade_zonedata::{
     SignedZoneBuilt, SignedZonePersister, SignedZoneReviewer, SoaRecord, ZoneCleaner,
     ZoneDataStorage, ZoneViewer,
 };
+use domain::base::Serial;
 use tracing::{info, trace, trace_span, warn};
 
 use crate::{
     center::Center,
     server::{LoadedReviewServer, PublicationServer, SignedReviewServer},
     util::BackgroundTasks,
-    zone::{HistoricalEvent, Zone, ZoneHandle, ZoneState},
+    zone::{HistoricalEvent, LastPublished, Zone, ZoneHandle, ZoneState},
 };
 
 //----------- StorageZoneHandle ------------------------------------------------
@@ -658,6 +659,7 @@ impl StorageZoneHandle<'_> {
                         let (s, viewer) = s.mark_complete(persisted);
                         transition.move_to(ZoneDataStorage::Switching(s));
                         state.storage.published_soa = viewer.read().map(|r| r.soa().clone());
+                        state.storage.published_loaded_soa = viewer.read().map(|r| r.loaded().soa().clone());
                         viewer
                     }
 
@@ -681,6 +683,11 @@ impl StorageZoneHandle<'_> {
 
                 _ => unreachable!("just transitioned to 'Switching'"),
             };
+
+            state.last_published = Some(LastPublished {
+                loaded_serial: Serial(state.storage.published_loaded_soa.as_ref().unwrap().rdata.serial.into()),
+                signed_serial: Serial(state.storage.published_soa.as_ref().unwrap().rdata.serial.into()),
+            });
 
             let mut handle = ZoneHandle { zone: &zone, state: &mut state, center: &center };
 
@@ -822,6 +829,13 @@ pub struct StorageState {
     // current i.e. published zone instance.
     pub published_soa: Option<SoaRecord>,
 
+    /// The SOA record of the loaded instance underlying the published instance
+    /// of the zone, if any.
+    //
+    // TODO: This should move into a component of 'ZoneState' tracking the
+    // current i.e. published zone instance.
+    pub published_loaded_soa: Option<SoaRecord>,
+
     /// Ongoing background tasks.
     ///
     /// When the zone data needs to be cleaned or persisted, a background task
@@ -842,6 +856,7 @@ impl StorageState {
             loaded_review_soa: None,
             signed_review_soa: None,
             published_soa: None,
+            published_loaded_soa: None,
             background_tasks: Default::default(),
         }
     }


### PR DESCRIPTION
Also, use the new information to fix the 'ixfr-in' integration test.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?