### PR TITLE
Add last error to zone status

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -544,6 +544,8 @@ pub enum HistoricalEventType {
     SigningFailed,
     UnsignedZoneReview,
     SignedZoneReview,
+    UnsignedHookFailed,
+    SignedHookFailed,
     KeySetCommand,
     KeySetError,
 }
@@ -570,6 +572,12 @@ pub enum HistoricalEvent {
     SignedZoneReview {
         status: ZoneReviewStatus,
     },
+    UnsignedHookFailed {
+        err: String,
+    },
+    SignedHookFailed {
+        err: String,
+    },
     KeySetCommand {
         cmd: String,
         warning: Option<String>,
@@ -580,7 +588,9 @@ pub enum HistoricalEvent {
         err: String,
         elapsed: Duration,
     },
-    Error(String),
+    LoadingFailed {
+        reason: String,
+    },
 }
 
 /// The trigger for a (re-)signing operation.

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -353,6 +353,7 @@ pub struct ZoneStatus {
     pub progress: Progress,
     pub keys: Vec<KeyInfo>,
     pub key_status: String,
+    pub error: Option<String>,
     pub receipt_report: Option<ZoneLoaderReport>,
     pub unsigned_serial: Option<Serial>,
     pub unsigned_review_status: Option<TimestampedZoneReviewStatus>,
@@ -532,6 +533,8 @@ pub struct HistoryItem {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum HistoricalEventType {
+    StartedLoad,
+    StartedResign,
     Added,
     Removed,
     PolicyChanged,
@@ -547,6 +550,8 @@ pub enum HistoricalEventType {
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub enum HistoricalEvent {
+    StartedLoad,
+    StartedResign,
     Added,
     Removed,
     PolicyChanged,
@@ -575,6 +580,7 @@ pub enum HistoricalEvent {
         err: String,
         elapsed: Duration,
     },
+    Error(String),
 }
 
 /// The trigger for a (re-)signing operation.

--- a/crates/cli/src/commands/zone.rs
+++ b/crates/cli/src/commands/zone.rs
@@ -402,6 +402,8 @@ impl Zone {
                                 None => "-".to_string(),
                             };
                             let what = match &history_item.event {
+                                HistoricalEvent::StartedLoad => "Started load".to_string(),
+                                HistoricalEvent::StartedResign => "Started resign".to_string(),
                                 HistoricalEvent::Added => "Zone added".to_string(),
                                 HistoricalEvent::Removed => "Zone removed".to_string(),
                                 HistoricalEvent::PolicyChanged => "Policy changed".to_string(),
@@ -501,6 +503,7 @@ impl Zone {
                                         elapsed.as_secs()
                                     )
                                 }
+                                HistoricalEvent::Error(s) => s.clone(),
                             };
                             println!("{when} {serial:10} {what}");
                         }
@@ -574,6 +577,18 @@ impl Zone {
         if zone.last_published.is_some() {
             println!("");
             println!("Published zone available at {}", zone.publish_addr);
+        }
+
+        if let Some(error) = zone.error {
+            println!("");
+            println!("An error occurred during the last operation:");
+            println!("  {}ERROR: {error}{}", ansi::RED, ansi::RESET);
+            println!(
+                "  Run {}`cascade zone history {}`{} for more information.",
+                ansi::BLUE,
+                zone.name,
+                ansi::RESET
+            );
         }
 
         if detailed {

--- a/crates/cli/src/commands/zone.rs
+++ b/crates/cli/src/commands/zone.rs
@@ -477,6 +477,12 @@ impl Zone {
                                         ZoneReviewStatus::Rejected => "rejected",
                                     }
                                 ),
+                                HistoricalEvent::UnsignedHookFailed { err, .. } => {
+                                    format!("Could not execute loaded review hook: {err}",)
+                                }
+                                HistoricalEvent::SignedHookFailed { err, .. } => {
+                                    format!("Could not execute signed review hook: {err}",)
+                                }
                                 HistoricalEvent::KeySetCommand {
                                     cmd,
                                     elapsed,
@@ -503,7 +509,7 @@ impl Zone {
                                         elapsed.as_secs()
                                     )
                                 }
-                                HistoricalEvent::Error(s) => s.clone(),
+                                HistoricalEvent::LoadingFailed { reason } => reason.clone(),
                             };
                             println!("{when} {serial:10} {what}");
                         }

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -261,7 +261,12 @@ async fn refresh(
             // Cancel the load
             handle.abandon_load(builder);
 
-            state.record_event(HistoricalEvent::Error(err.to_string()), None);
+            state.record_event(
+                HistoricalEvent::LoadingFailed {
+                    reason: err.to_string(),
+                },
+                None,
+            );
         }
     }
 }

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     common::scheduler::Scheduler,
     loader::zone::EnqueuedRefresh,
     util::AbortOnDrop,
-    zone::{Zone, ZoneByPtr, ZoneHandle},
+    zone::{HistoricalEvent, Zone, ZoneByPtr, ZoneHandle},
 };
 
 mod server;
@@ -260,6 +260,8 @@ async fn refresh(
 
             // Cancel the load
             handle.abandon_load(builder);
+
+            state.record_event(HistoricalEvent::Error(err.to_string()), None);
         }
     }
 }

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -353,6 +353,7 @@ impl HttpServer {
         let signed_serial;
         let published_serial;
         let last_published;
+        let error;
         {
             let locked_state = state.center.state.lock().unwrap();
             let keys_dir = &state.center.config.keys_dir;
@@ -465,6 +466,23 @@ impl HttpServer {
                     loaded_serial: p.loaded_serial,
                     signed_serial: p.signed_serial,
                 });
+
+            let mut found_error = None;
+            for item in zone_state.history.iter().rev() {
+                // TODO: When we have instance IDs we should only look through
+                // history items related to that ID.
+                match &item.event {
+                    HistoricalEvent::StartedLoad | HistoricalEvent::StartedResign => {
+                        break;
+                    }
+                    HistoricalEvent::Error(s) => {
+                        found_error = Some(s);
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            error = found_error.cloned();
         }
 
         // Query key status
@@ -586,6 +604,7 @@ impl HttpServer {
             published_serial,
             publish_addr,
             halted_reason,
+            error,
         })
     }
 

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -475,14 +475,38 @@ impl HttpServer {
                     HistoricalEvent::StartedLoad | HistoricalEvent::StartedResign => {
                         break;
                     }
-                    HistoricalEvent::Error(s) => {
-                        found_error = Some(s);
+                    HistoricalEvent::LoadingFailed { reason } => {
+                        found_error = Some(reason.clone());
+                        break;
+                    }
+                    HistoricalEvent::SigningFailed { trigger: _, reason } => {
+                        found_error = Some(format!("signing failed: {reason}"));
+                        break;
+                    }
+                    HistoricalEvent::UnsignedZoneReview {
+                        status: ZoneReviewStatus::Rejected,
+                    } => {
+                        found_error = Some("loaded zone was rejected".into());
+                        break;
+                    }
+                    HistoricalEvent::SignedZoneReview {
+                        status: ZoneReviewStatus::Rejected,
+                    } => {
+                        found_error = Some("signed zone was rejected".into());
+                        break;
+                    }
+                    HistoricalEvent::UnsignedHookFailed { err } => {
+                        found_error = Some(format!("could not execute loaded review hook: {err}"));
+                        break;
+                    }
+                    HistoricalEvent::SignedHookFailed { err } => {
+                        found_error = Some(format!("could not execute signed review hook: {err}"));
                         break;
                     }
                     _ => {}
                 }
             }
-            error = found_error.cloned();
+            error = found_error;
         }
 
         // Query key status

--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -455,10 +455,22 @@ impl ZoneServer {
                     let mut zone_state = zone.state.lock().unwrap();
                     match self.source {
                         Source::Unsigned => {
+                            zone_state.record_event(
+                                HistoricalEvent::UnsignedHookFailed {
+                                    err: err.to_string(),
+                                },
+                                Some(zone_serial),
+                            );
                             zone_state.unsigned.get_mut(&zone_serial).unwrap().review =
                                 ZoneVersionReviewState::Rejected;
                         }
                         Source::Signed => {
+                            zone_state.record_event(
+                                HistoricalEvent::SignedHookFailed {
+                                    err: err.to_string(),
+                                },
+                                Some(zone_serial),
+                            );
                             zone_state.signed.get_mut(&zone_serial).unwrap().review =
                                 ZoneVersionReviewState::Rejected;
                         }

--- a/src/zone/machine.rs
+++ b/src/zone/machine.rs
@@ -120,6 +120,8 @@ impl<'a> ZoneHandle<'a> {
 
         transition.move_to(ZoneStateMachine::Loading(waiting.start_load()));
 
+        self.state.record_event(HistoricalEvent::StartedLoad, None);
+
         Some(builder)
     }
 
@@ -143,6 +145,8 @@ impl<'a> ZoneHandle<'a> {
         };
 
         transition.move_to(ZoneStateMachine::Signing(waiting.start_resign()));
+
+        self.state.record_event(HistoricalEvent::StartedLoad, None);
 
         Some(builder)
     }

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -318,6 +318,8 @@ impl HistoryItem {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum HistoricalEventType {
+    StartedLoad,
+    StartedResign,
     Added,
     Removed,
     PolicyChanged,
@@ -329,10 +331,13 @@ pub enum HistoricalEventType {
     SignedZoneReview,
     KeySetCommand,
     KeySetError,
+    Error,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub enum HistoricalEvent {
+    StartedLoad,
+    StartedResign,
     Added,
     Removed,
     PolicyChanged,
@@ -370,11 +375,14 @@ pub enum HistoricalEvent {
         )]
         elapsed: Duration,
     },
+    Error(String),
 }
 
 impl HistoricalEvent {
     fn get_type(&self) -> HistoricalEventType {
         match self {
+            HistoricalEvent::StartedLoad => HistoricalEventType::StartedLoad,
+            HistoricalEvent::StartedResign => HistoricalEventType::StartedResign,
             HistoricalEvent::Added => HistoricalEventType::Added,
             HistoricalEvent::Removed => HistoricalEventType::Removed,
             HistoricalEvent::PolicyChanged => HistoricalEventType::PolicyChanged,
@@ -386,6 +394,7 @@ impl HistoricalEvent {
             HistoricalEvent::SignedZoneReview { .. } => HistoricalEventType::SignedZoneReview,
             HistoricalEvent::KeySetCommand { .. } => HistoricalEventType::KeySetCommand,
             HistoricalEvent::KeySetError { .. } => HistoricalEventType::KeySetError,
+            HistoricalEvent::Error { .. } => HistoricalEventType::Error,
         }
     }
 
@@ -397,6 +406,8 @@ impl HistoricalEvent {
 impl From<HistoricalEvent> for api::HistoricalEvent {
     fn from(value: HistoricalEvent) -> Self {
         match value {
+            HistoricalEvent::StartedLoad => Self::StartedLoad,
+            HistoricalEvent::StartedResign => Self::StartedResign,
             HistoricalEvent::Added => Self::Added,
             HistoricalEvent::Removed => Self::Removed,
             HistoricalEvent::PolicyChanged => Self::PolicyChanged,
@@ -420,6 +431,7 @@ impl From<HistoricalEvent> for api::HistoricalEvent {
             HistoricalEvent::KeySetError { cmd, err, elapsed } => {
                 Self::KeySetError { cmd, err, elapsed }
             }
+            HistoricalEvent::Error(s) => Self::Error(s),
         }
     }
 }

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -329,6 +329,8 @@ pub enum HistoricalEventType {
     SigningFailed,
     UnsignedZoneReview,
     SignedZoneReview,
+    UnsignedHookFailed,
+    SignedHookFailed,
     KeySetCommand,
     KeySetError,
     Error,
@@ -343,6 +345,9 @@ pub enum HistoricalEvent {
     PolicyChanged,
     SourceChanged,
     NewVersionReceived,
+    LoadingFailed {
+        reason: String,
+    },
     SigningSucceeded {
         trigger: cascade_api::SigningTrigger,
     },
@@ -355,6 +360,12 @@ pub enum HistoricalEvent {
     },
     SignedZoneReview {
         status: ZoneReviewStatus,
+    },
+    UnsignedHookFailed {
+        err: String,
+    },
+    SignedHookFailed {
+        err: String,
     },
     KeySetCommand {
         cmd: String,
@@ -375,7 +386,6 @@ pub enum HistoricalEvent {
         )]
         elapsed: Duration,
     },
-    Error(String),
 }
 
 impl HistoricalEvent {
@@ -392,9 +402,11 @@ impl HistoricalEvent {
             HistoricalEvent::SigningFailed { .. } => HistoricalEventType::SigningFailed,
             HistoricalEvent::UnsignedZoneReview { .. } => HistoricalEventType::UnsignedZoneReview,
             HistoricalEvent::SignedZoneReview { .. } => HistoricalEventType::SignedZoneReview,
+            HistoricalEvent::UnsignedHookFailed { .. } => HistoricalEventType::UnsignedHookFailed,
+            HistoricalEvent::SignedHookFailed { .. } => HistoricalEventType::SignedHookFailed,
             HistoricalEvent::KeySetCommand { .. } => HistoricalEventType::KeySetCommand,
             HistoricalEvent::KeySetError { .. } => HistoricalEventType::KeySetError,
-            HistoricalEvent::Error { .. } => HistoricalEventType::Error,
+            HistoricalEvent::LoadingFailed { .. } => HistoricalEventType::Error,
         }
     }
 
@@ -419,6 +431,8 @@ impl From<HistoricalEvent> for api::HistoricalEvent {
             }
             HistoricalEvent::UnsignedZoneReview { status } => Self::UnsignedZoneReview { status },
             HistoricalEvent::SignedZoneReview { status } => Self::SignedZoneReview { status },
+            HistoricalEvent::UnsignedHookFailed { err } => Self::UnsignedHookFailed { err },
+            HistoricalEvent::SignedHookFailed { err } => Self::SignedHookFailed { err },
             HistoricalEvent::KeySetCommand {
                 cmd,
                 warning,
@@ -431,7 +445,7 @@ impl From<HistoricalEvent> for api::HistoricalEvent {
             HistoricalEvent::KeySetError { cmd, err, elapsed } => {
                 Self::KeySetError { cmd, err, elapsed }
             }
-            HistoricalEvent::Error(s) => Self::Error(s),
+            HistoricalEvent::LoadingFailed { reason } => Self::LoadingFailed { reason },
         }
     }
 }


### PR DESCRIPTION
Show an error that happened during the last operation in zone status. I've included the most important errors based on when `error!` was called, but we might have to add more errors to the zone history. We might also want to collect all of those into a single enum variant in the history, but we can always do that later.

```
zone:   se
policy: foo
source: /home/terts/code/cascade/se.zone.txt

review hooks
  loaded: none
  signed: none

last published
  <no versions published yet>

status: idle

An error occurred during the last operation:
  ERROR: the zonefile could not be loaded: the zonefile contains multiple SOA records
  Run `cascade zone history se` for more information.
```

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?