### PR TITLE
Fix typo in error message in cascade-zonedata

### DIFF
--- a/src/loader/zonefile.rs
+++ b/src/loader/zonefile.rs
@@ -186,7 +186,7 @@ impl fmt::Display for Error {
                 write!(f, "the zonefile does not contain a SOA record")
             }
             Error::Write(ReplaceError::MultipleSoas) => {
-                write!(f, "the zonefile contain multiple SOA records")
+                write!(f, "the zonefile contains multiple SOA records")
             }
         }
     }


### PR DESCRIPTION
Small typo fix.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
