### PR TITLE
Introduce better `ZoneState` locks

### DIFF
--- a/src/center.rs
+++ b/src/center.rs
@@ -141,7 +141,7 @@ pub async fn add_zone(
         };
 
         {
-            let mut zone_state = zone.state.lock().unwrap();
+            let mut zone_state = zone.state.write_cleanly();
             let restorer = zone_state.storage.restorer.take().unwrap();
             let policy = state
                 .policies
@@ -213,7 +213,7 @@ pub async fn add_zone(
     }
 
     {
-        let mut state = zone.state.lock().unwrap();
+        let mut state = zone.write(center);
 
         state.record_event(HistoricalEvent::Added, None);
 
@@ -258,7 +258,7 @@ pub fn remove_zone(center: &Arc<Center>, name: Name<Bytes>) -> Result<(), ZoneRe
     SignedReviewServer::remove_zone(center, &zone);
     PublicationServer::remove_zone(center, &zone);
 
-    let mut zone_state = zone.state.lock().unwrap();
+    let mut zone_state = zone.state.write_cleanly();
 
     ZoneHandle {
         zone: &zone,
@@ -294,9 +294,14 @@ pub fn remove_zone(center: &Arc<Center>, name: Name<Bytes>) -> Result<(), ZoneRe
         state.tsig_store.mark_dirty(center);
     }
 
-    info!("Removed zone '{name}'");
+    // Persist the state file one last time.
     zone_state.record_event(HistoricalEvent::Removed, None);
-    zone.mark_dirty(&mut zone_state, center);
+    std::mem::drop(zone_state);
+    crate::zone::save_state_now(center, &zone);
+
+    // TODO: Remove the zone state file?
+
+    info!("Removed zone '{name}'");
     Ok(())
 }
 

--- a/src/center.rs
+++ b/src/center.rs
@@ -106,7 +106,7 @@ pub async fn add_zone(
         // Create the zone and initialize its state.
         zone = Arc::new(Zone::new(name));
         {
-            let mut zone_state = zone.state.lock().unwrap();
+            let mut zone_state = zone.state.write_cleanly();
             let restorer = zone_state.storage.restorer.take().unwrap();
             zone_state.policy = Some(policy.latest.clone());
             policy.zones.insert(zone.name.clone());
@@ -150,7 +150,7 @@ pub async fn add_zone(
     }
 
     {
-        let mut state = zone.state.lock().unwrap();
+        let mut state = zone.write(center);
 
         state.record_event(HistoricalEvent::Added, None);
 
@@ -212,7 +212,7 @@ pub fn remove_zone(center: &Arc<Center>, name: Name<Bytes>) -> Result<(), ZoneRe
     SignedReviewServer::remove_zone(center, &zone);
     PublicationServer::remove_zone(center, &zone);
 
-    let mut zone_state = zone.state.lock().unwrap();
+    let mut zone_state = zone.state.write_cleanly();
 
     ZoneHandle {
         zone: &zone,
@@ -233,9 +233,14 @@ pub fn remove_zone(center: &Arc<Center>, name: Name<Bytes>) -> Result<(), ZoneRe
         state.mark_dirty(center);
     }
 
-    info!("Removed zone '{name}'");
+    // Persist the state file one last time.
     zone_state.record_event(HistoricalEvent::Removed, None);
-    zone.mark_dirty(&mut zone_state, center);
+    std::mem::drop(zone_state);
+    crate::zone::save_state_now(center, &zone);
+
+    // TODO: Remove the zone state file?
+
+    info!("Removed zone '{name}'");
     Ok(())
 }
 

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     common::scheduler::Scheduler,
     loader::zone::EnqueuedRefresh,
     util::AbortOnDrop,
-    zone::{HistoricalEvent, Zone, ZoneByPtr, ZoneHandle},
+    zone::{HistoricalEvent, Zone, ZoneByName, ZoneByPtr},
 };
 
 mod server;
@@ -52,9 +52,9 @@ impl Loader {
     /// Initialize the loader, synchronously.
     pub fn init(center: &Arc<Center>, state: &mut State) {
         // Enqueue refreshes for all known upstream zones.
-        for zone in &state.zones {
-            let mut state = zone.0.state.lock().unwrap();
-            match state.loader.source {
+        for ZoneByName(zone) in &state.zones {
+            let mut handle = zone.write_handle(center);
+            match handle.state.loader.source {
                 Source::None => { /* Nothing to do */ }
                 Source::Zonefile { .. } => {
                     // Don't enqueue a refresh for zones sourced from disk
@@ -63,13 +63,7 @@ impl Loader {
                     // explicitly via `cascade zone reload`.
                 }
                 Source::Server { .. } => {
-                    ZoneHandle {
-                        zone: &zone.0,
-                        state: &mut state,
-                        center,
-                    }
-                    .loader()
-                    .enqueue_refresh(false);
+                    handle.loader().enqueue_refresh(false);
                 }
             }
         }
@@ -81,30 +75,16 @@ impl Loader {
             center
                 .loader
                 .refresh_scheduler
-                .run(|_time, zone| {
+                .run(|_time, ZoneByPtr(zone)| {
                     // Enqueue a (soft) refresh for the zone.
-                    let mut state = zone.0.state.lock().unwrap();
-                    ZoneHandle {
-                        zone: &zone.0,
-                        state: &mut state,
-                        center: &center,
-                    }
-                    .loader()
-                    .enqueue_refresh(false);
+                    zone.write_handle(&center).loader().enqueue_refresh(false);
                 })
                 .await
         }))
     }
 
     pub fn on_refresh_zone(&self, center: &Arc<Center>, zone: &Arc<Zone>) {
-        let mut state = zone.state.lock().expect("lock is not poisoned");
-        ZoneHandle {
-            zone,
-            state: &mut state,
-            center,
-        }
-        .loader()
-        .enqueue_refresh(false);
+        zone.write_handle(center).loader().enqueue_refresh(false);
     }
 
     pub fn on_reload_zone(
@@ -112,20 +92,14 @@ impl Loader {
         center: &Arc<Center>,
         zone: &Arc<Zone>,
     ) -> Result<(), ZoneReloadError> {
-        let mut zone_state = zone.state.lock().expect("lock is not poisoned");
-        if let Some(reason) = zone_state.halted_reason() {
+        let mut handle = zone.write_handle(center);
+        if let Some(reason) = handle.state.halted_reason() {
             return Err(ZoneReloadError::ZoneHalted(reason));
         }
-        if let Source::None = zone_state.loader.source {
+        if let Source::None = handle.state.loader.source {
             return Err(ZoneReloadError::ZoneWithoutSource);
         }
-        ZoneHandle {
-            zone,
-            state: &mut zone_state,
-            center,
-        }
-        .loader()
-        .enqueue_refresh(true);
+        handle.loader().enqueue_refresh(true);
         Ok(())
     }
 }
@@ -186,12 +160,7 @@ async fn refresh(
         }
     };
 
-    let mut state = zone.state.lock().unwrap();
-    let mut handle = ZoneHandle {
-        zone: &zone,
-        state: &mut state,
-        center: &center,
-    };
+    let mut handle = zone.write_handle(&center);
 
     // Finalize the load metrics.
     let start_time = metrics.start.0;
@@ -242,7 +211,7 @@ async fn refresh(
             );
 
             // Cancel the load
-            handle.abandon_load(builder);
+            handle.get().abandon_load(builder);
         }
 
         Ok(true) => {
@@ -260,7 +229,7 @@ async fn refresh(
                 unreachable!("source-specific loading succeeded and must have filled 'builder'")
             });
 
-            handle.finish_load(built);
+            handle.get().finish_load(built);
         }
 
         Err(err) => {
@@ -270,9 +239,9 @@ async fn refresh(
             );
 
             // Cancel the load
-            handle.abandon_load(builder);
+            handle.get().abandon_load(builder);
 
-            state.record_event(
+            handle.state.record_event(
                 HistoricalEvent::LoadingFailed {
                     reason: err.to_string(),
                 },

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     common::scheduler::Scheduler,
     loader::zone::EnqueuedRefresh,
     util::AbortOnDrop,
-    zone::{Zone, ZoneByPtr, ZoneHandle},
+    zone::{Zone, ZoneByName, ZoneByPtr},
 };
 
 mod server;
@@ -52,15 +52,8 @@ impl Loader {
     /// Initialize the loader, synchronously.
     pub fn init(center: &Arc<Center>, state: &mut State) {
         // Enqueue refreshes for all known zones.
-        for zone in &state.zones {
-            let mut state = zone.0.state.lock().unwrap();
-            ZoneHandle {
-                zone: &zone.0,
-                state: &mut state,
-                center,
-            }
-            .loader()
-            .enqueue_refresh(false);
+        for ZoneByName(zone) in &state.zones {
+            zone.write_handle(center).loader().enqueue_refresh(false);
         }
     }
 
@@ -70,30 +63,16 @@ impl Loader {
             center
                 .loader
                 .refresh_scheduler
-                .run(|_time, zone| {
+                .run(|_time, ZoneByPtr(zone)| {
                     // Enqueue a (soft) refresh for the zone.
-                    let mut state = zone.0.state.lock().unwrap();
-                    ZoneHandle {
-                        zone: &zone.0,
-                        state: &mut state,
-                        center: &center,
-                    }
-                    .loader()
-                    .enqueue_refresh(false);
+                    zone.write_handle(&center).loader().enqueue_refresh(false);
                 })
                 .await
         }))
     }
 
     pub fn on_refresh_zone(&self, center: &Arc<Center>, zone: &Arc<Zone>) {
-        let mut state = zone.state.lock().expect("lock is not poisoned");
-        ZoneHandle {
-            zone,
-            state: &mut state,
-            center,
-        }
-        .loader()
-        .enqueue_refresh(false);
+        zone.write_handle(center).loader().enqueue_refresh(false);
     }
 
     pub fn on_reload_zone(
@@ -101,20 +80,14 @@ impl Loader {
         center: &Arc<Center>,
         zone: &Arc<Zone>,
     ) -> Result<(), ZoneReloadError> {
-        let mut zone_state = zone.state.lock().expect("lock is not poisoned");
-        if let Some(reason) = zone_state.halted_reason() {
+        let mut handle = zone.write_handle(center);
+        if let Some(reason) = handle.state.halted_reason() {
             return Err(ZoneReloadError::ZoneHalted(reason));
         }
-        if let Source::None = zone_state.loader.source {
+        if let Source::None = handle.state.loader.source {
             return Err(ZoneReloadError::ZoneWithoutSource);
         }
-        ZoneHandle {
-            zone,
-            state: &mut zone_state,
-            center,
-        }
-        .loader()
-        .enqueue_refresh(true);
+        handle.loader().enqueue_refresh(true);
         Ok(())
     }
 }
@@ -175,12 +148,7 @@ async fn refresh(
         }
     };
 
-    let mut state = zone.state.lock().unwrap();
-    let mut handle = ZoneHandle {
-        zone: &zone,
-        state: &mut state,
-        center: &center,
-    };
+    let mut handle = zone.write_handle(&center);
 
     // Finalize the load metrics.
     let start_time = metrics.start.0;
@@ -231,7 +199,7 @@ async fn refresh(
             );
 
             // Cancel the load
-            handle.abandon_load(builder);
+            handle.get().abandon_load(builder);
         }
 
         Ok(true) => {
@@ -249,7 +217,7 @@ async fn refresh(
                 unreachable!("source-specific loading succeeded and must have filled 'builder'")
             });
 
-            handle.finish_load(built);
+            handle.get().finish_load(built);
         }
 
         Err(err) => {
@@ -259,7 +227,7 @@ async fn refresh(
             );
 
             // Cancel the load
-            handle.abandon_load(builder);
+            handle.get().abandon_load(builder);
         }
     }
 }

--- a/src/loader/zone.rs
+++ b/src/loader/zone.rs
@@ -55,8 +55,6 @@ impl LoaderZoneHandle<'_> {
         self.state
             .record_event(HistoricalEvent::SourceChanged, None);
 
-        self.zone.mark_dirty(self.state, self.center);
-
         self.enqueue_refresh(false);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,14 +124,13 @@ fn main() -> ExitCode {
             }
 
             // Update policy.zones
-            for zone in &state.zones {
-                let zone_state = zone.0.state.lock().expect("zone state lock should work");
-                if let Some(ref policy) = zone_state.policy {
+            for ZoneByName(zone) in &state.zones {
+                if let Some(ref policy) = zone.read().policy {
                     let pol = state
                         .policies
                         .get_mut(&policy.name)
                         .expect("zone policy should exist");
-                    pol.zones.insert(zone.0.name.clone());
+                    pol.zones.insert(zone.name.clone());
                 }
             }
 
@@ -211,13 +210,13 @@ fn main() -> ExitCode {
                     .expect("we just reloaded these policies");
 
                 for zone_name in &pol.zones {
-                    let zone = state
+                    let ZoneByName(zone) = state
                         .zones
                         .get(zone_name)
                         .expect("zones and policies are consistent");
 
-                    let mut state = zone.0.state.lock().expect("lock isn't poisoned");
-                    state.policy = Some(pol.latest.clone());
+                    // TODO: Mark these zones dirty.
+                    zone.state.write_cleanly().policy = Some(pol.latest.clone());
                 }
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,13 +154,13 @@ fn main() -> ExitCode {
                     .expect("we just reloaded these policies");
 
                 for zone_name in &pol.zones {
-                    let zone = state
+                    let ZoneByName(zone) = state
                         .zones
                         .get(zone_name)
                         .expect("zones and policies are consistent");
 
-                    let mut state = zone.0.state.lock().expect("lock isn't poisoned");
-                    state.policy = Some(pol.latest.clone());
+                    // TODO: Mark these zones dirty.
+                    zone.state.write_cleanly().policy = Some(pol.latest.clone());
                 }
             }
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -118,9 +118,7 @@ pub fn record_zone_event(
     event: HistoricalEvent,
     serial: Option<Serial>,
 ) {
-    let mut zone_state = zone.state.lock().unwrap();
-    zone_state.record_event(event, serial);
-    zone.mark_dirty(&mut zone_state, center);
+    zone.write_handle(center).state.record_event(event, serial);
 }
 
 //----------- Error ------------------------------------------------------------

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -119,7 +119,7 @@ impl MetricsCollection {
             zones_configured = state.zones.len() as i64;
 
             for ZoneByName(zone) in &state.zones {
-                let zone_state = zone.state.lock().unwrap();
+                let zone_state = zone.state.read();
 
                 if !matches!(zone_state.loader.source, crate::loader::Source::None) {
                     zones_loaded += 1;

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -94,11 +94,7 @@
 
 use std::sync::Arc;
 
-use crate::{
-    center::Center,
-    util::AbortOnDrop,
-    zone::{ZoneByName, ZoneHandle},
-};
+use crate::{center::Center, util::AbortOnDrop, zone::ZoneByName};
 
 mod persist;
 use persist::{persist_loaded, persist_signed};
@@ -167,12 +163,7 @@ impl Restorer {
 
             // Attempt to restore data for every zone.
             for zone in zones {
-                let mut state = zone.state.lock().unwrap();
-                let mut handle = ZoneHandle {
-                    zone: &zone,
-                    state: &mut state,
-                    center: &center,
-                };
+                let mut handle = zone.write_handle(&center);
 
                 // Zones that are _not_ restored from disk will move out the
                 // 'restorer' field and use it to initialize the zone data to

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -6,11 +6,7 @@
 
 use std::sync::Arc;
 
-use crate::{
-    center::Center,
-    util::AbortOnDrop,
-    zone::{ZoneByName, ZoneHandle},
-};
+use crate::{center::Center, util::AbortOnDrop, zone::ZoneByName};
 
 mod persist;
 use persist::{persist_loaded, persist_signed};
@@ -79,12 +75,7 @@ impl Restorer {
 
             // Attempt to restore data for every zone.
             for zone in zones {
-                let mut state = zone.state.lock().unwrap();
-                let mut handle = ZoneHandle {
-                    zone: &zone,
-                    state: &mut state,
-                    center: &center,
-                };
+                let mut handle = zone.write_handle(&center);
 
                 // Zones that are _not_ restored from disk will move out the
                 // 'restorer' field and use it to initialize the zone data to

--- a/src/persistence/persist.rs
+++ b/src/persistence/persist.rs
@@ -16,7 +16,7 @@ use tracing::{trace, warn};
 
 use crate::{
     center::Center,
-    zone::{Zone, ZoneHandle, save_state_now},
+    zone::{Zone, save_state_now},
 };
 
 /// Persist the data for a loaded instance of a zone.
@@ -39,12 +39,7 @@ pub fn persist_loaded(
         // TODO: Don't keep an unlimited number of diffs.
         // TODO: Compact diffs when idle?
         let destination = {
-            let mut state = zone.state.lock().unwrap();
-            let handle = ZoneHandle {
-                zone,
-                state: &mut state,
-                center,
-            };
+            let mut handle = zone.write_handle(center);
             let next_idx = handle.state.persisted_loaded_diff_paths.len();
             let destination = center
                 .config
@@ -103,7 +98,7 @@ pub fn persist_loaded(
         // unsigned zone content changes. Note that the SOA SERIAL is not
         // required to change unless using 'keep' policy and so we should not
         // require the SOA to have been removed and a new one added.
-        let mut state = zone.state.lock().unwrap();
+        let mut handle = zone.write_handle(center);
 
         let loaded_only_diff = (persister.loaded_diff().clone(), DiffData::new().into());
         trace!(
@@ -119,7 +114,7 @@ pub fn persist_loaded(
                 .as_ref()
                 .map(|soa_rr| soa_rr.rdata.serial),
         );
-        state.storage.diffs.push(loaded_only_diff);
+        handle.state.storage.diffs.push(loaded_only_diff);
     }
 
     persister.mark_complete()
@@ -148,12 +143,7 @@ pub fn persist_signed(
         // TODO: Don't keep an unlimited number of diffs.
         // TODO: Compact diffs when idle?
         let destination = {
-            let mut state = zone.state.lock().unwrap();
-            let handle = ZoneHandle {
-                zone,
-                state: &mut state,
-                center,
-            };
+            let mut handle = zone.write_handle(center);
             let next_idx = handle.state.persisted_signed_diff_paths.len();
             let destination = center
                 .config
@@ -216,7 +206,7 @@ pub fn persist_signed(
             // expiring. Signed zones MUST always have a new SOA SERIAL
             // compared to the previous version of the signed zone.
 
-            let mut state = zone.state.lock().unwrap();
+            let mut handle = zone.write_handle(center);
 
             // If we have a new signed diff to store because records in the
             // loaded part of the zone changed, e.g. due to changes in the
@@ -237,12 +227,12 @@ pub fn persist_signed(
             // diff first.
 
             let mut action = "Storing new";
-            if let Some(potentially_partial_diff) = state.storage.diffs.last()
+            if let Some(potentially_partial_diff) = handle.state.storage.diffs.last()
                 && potentially_partial_diff.1.is_empty()
             {
                 // Remove the partial diff, it will be replaced by a
                 // complete diff.
-                let _partial_diff = state.storage.diffs.pop();
+                let _partial_diff = handle.state.storage.diffs.pop();
                 action = "Updating existing";
             }
 
@@ -266,7 +256,11 @@ pub fn persist_signed(
                     .as_ref()
                     .map(|soa_rr| soa_rr.rdata.serial),
             );
-            state.storage.diffs.push((loaded_diff, signed_diff.clone()));
+            handle
+                .state
+                .storage
+                .diffs
+                .push((loaded_diff, signed_diff.clone()));
         }
     }
 

--- a/src/persistence/restore.rs
+++ b/src/persistence/restore.rs
@@ -40,7 +40,7 @@ pub fn restore_loaded(
     center: &Arc<Center>,
     restorer: &mut LoadedZoneRestorer,
 ) -> io::Result<bool> {
-    let mut state = zone.state.lock().unwrap();
+    let mut state = zone.write(center);
     if state.persisted_loaded_diff_paths.is_empty() {
         return io::Result::Ok(false);
     }
@@ -106,7 +106,7 @@ pub fn restore_loaded(
 
         if let Some(diff) = restorer.take_diff() {
             // Store the loaded diff to be used as part of serving an IXFR.
-            let mut state = zone.state.lock().unwrap();
+            let mut state = zone.write(center);
             state
                 .storage
                 .diffs
@@ -145,7 +145,7 @@ pub fn restore_signed(
     center: &Arc<Center>,
     restorer: &mut SignedZoneRestorer,
 ) -> io::Result<bool> {
-    let state = zone.state.lock().unwrap();
+    let state = zone.read();
     if state.persisted_signed_diff_paths.is_empty() {
         return io::Result::Ok(false);
     }
@@ -216,7 +216,7 @@ pub fn restore_signed(
             .map_err(|err| io::Error::other(format!("Internal error: Apply failed: {err}")))?;
 
         if let Some(signed_diff) = restorer.take_diff() {
-            let mut state = zone.state.lock().unwrap();
+            let mut state = zone.write(center);
             // Get the diff pair (loaded diff and missing signed diff) that
             // this signed diff needs to be inserted into. If the signed diff
             // was caused by incremental signing then a loaded diff won't have

--- a/src/persistence/zone.rs
+++ b/src/persistence/zone.rs
@@ -79,13 +79,9 @@ impl ZonePersistenceHandle<'_> {
 
                 // Obtain the signed zone restorer.
                 let mut restorer = {
-                    let mut state = zone.state.lock().unwrap();
-                    let mut handle = ZoneHandle {
-                        zone: &zone,
-                        state: &mut state,
-                        center: &center,
-                    };
-                    handle.storage().finish_loaded_restoration(restored)
+                    zone.write_handle(&center)
+                        .storage()
+                        .finish_loaded_restoration(restored)
                 };
 
                 // Try to restore the signed instance.
@@ -108,13 +104,11 @@ impl ZonePersistenceHandle<'_> {
                     }
                 };
 
-                let mut state = zone.state.lock().unwrap();
-                trace!("Restored diffs: {:?}", state.persisted_loaded_diff_paths);
-                let mut handle = ZoneHandle {
-                    zone: &zone,
-                    state: &mut state,
-                    center: &center,
-                };
+                let mut handle = zone.write_handle(&center);
+                trace!(
+                    "Restored diffs: {:?}",
+                    handle.state.persisted_loaded_diff_paths
+                );
                 handle.storage().finish_signed_restoration(restored);
                 handle.state.persistence.ongoing.finish();
             });
@@ -144,15 +138,8 @@ impl ZonePersistenceHandle<'_> {
                 // NOTE: The outer function, which is spawning the background
                 // task, has a lock of the zone state. Thus, the following lock
                 // cannot be taken until the outer function terminates.
-                let mut state = zone.state.lock().unwrap();
-                let mut handle = ZoneHandle {
-                    zone: &zone,
-                    state: &mut state,
-                    center: &center,
-                };
-
-                handle.start_new_sign(persisted);
-
+                let mut handle = zone.write_handle(&center);
+                handle.get().start_new_sign(persisted);
                 handle.state.persistence.ongoing.finish();
             });
     }
@@ -181,14 +168,9 @@ impl ZonePersistenceHandle<'_> {
                 // NOTE: The outer function, which is spawning the background
                 // task, has a lock of the zone state. Thus, the following lock
                 // cannot be taken until the outer function terminates.
-                let mut state = zone.state.lock().unwrap();
-                let mut handle = ZoneHandle {
-                    zone: &zone,
-                    state: &mut state,
-                    center: &center,
-                };
+                let mut handle = zone.write_handle(&center);
 
-                handle.start_switch(persisted);
+                handle.get().start_switch(persisted);
 
                 handle.state.persistence.ongoing.finish();
             });
@@ -201,12 +183,7 @@ fn abandon_loaded_restoration(
     restorer: LoadedZoneRestorer,
 ) {
     reset_state_due_to_abandoned_restore(center, zone);
-    let mut state = zone.state.lock().unwrap();
-    let mut handle = ZoneHandle {
-        zone,
-        state: &mut state,
-        center,
-    };
+    let mut handle = zone.write_handle(center);
     handle.storage().abandon_loaded_restoration(restorer);
     handle.state.persistence.ongoing.finish();
 }
@@ -217,19 +194,14 @@ fn abandon_signed_restoration(
     restorer: SignedZoneRestorer,
 ) {
     reset_state_due_to_abandoned_restore(center, zone);
-    let mut state = zone.state.lock().unwrap();
-    let mut handle = ZoneHandle {
-        zone,
-        state: &mut state,
-        center,
-    };
+    let mut handle = zone.write_handle(center);
     handle.storage().abandon_signed_restoration(restorer);
     handle.state.persistence.ongoing.finish();
 }
 
 fn reset_state_due_to_abandoned_restore(center: &Arc<Center>, zone: &Arc<Zone>) {
     {
-        let mut state = zone.state.lock().unwrap();
+        let mut state = zone.write(center);
         clear_persisted_zone_data(center, &mut state);
 
         // In case this zone was signed in the past we have to make sure that

--- a/src/persistence/zone.rs
+++ b/src/persistence/zone.rs
@@ -64,12 +64,7 @@ impl ZonePersistenceHandle<'_> {
                     }),
                     Err(_) => {
                         trace!("Abandoning loaded restoration");
-                        let mut state = zone.state.lock().unwrap();
-                        let mut handle = ZoneHandle {
-                            zone: &zone,
-                            state: &mut state,
-                            center: &center,
-                        };
+                        let mut handle = zone.write_handle(&center);
                         handle.storage().abandon_loaded_restoration(restorer);
                         handle.state.persistence.ongoing.finish();
                         return;
@@ -78,13 +73,9 @@ impl ZonePersistenceHandle<'_> {
 
                 // Obtain the signed zone restorer.
                 let mut restorer = {
-                    let mut state = zone.state.lock().unwrap();
-                    let mut handle = ZoneHandle {
-                        zone: &zone,
-                        state: &mut state,
-                        center: &center,
-                    };
-                    handle.storage().finish_loaded_restoration(restored)
+                    zone.write_handle(&center)
+                        .storage()
+                        .finish_loaded_restoration(restored)
                 };
 
                 // Try to restore the signed instance.
@@ -96,12 +87,7 @@ impl ZonePersistenceHandle<'_> {
                     }),
                     Err(_) => {
                         trace!("Abandoning signed restoration");
-                        let mut state = zone.state.lock().unwrap();
-                        let mut handle = ZoneHandle {
-                            zone: &zone,
-                            state: &mut state,
-                            center: &center,
-                        };
+                        let mut handle = zone.write_handle(&center);
                         handle.storage().abandon_signed_restoration(restorer);
                         handle.state.persistence.ongoing.finish();
                         return;
@@ -109,12 +95,7 @@ impl ZonePersistenceHandle<'_> {
                 };
 
                 info!("Restored the zone's persisted data");
-                let mut state = zone.state.lock().unwrap();
-                let mut handle = ZoneHandle {
-                    zone: &zone,
-                    state: &mut state,
-                    center: &center,
-                };
+                let mut handle = zone.write_handle(&center);
                 handle.storage().finish_signed_restoration(restored);
                 handle.state.persistence.ongoing.finish();
             });
@@ -144,15 +125,8 @@ impl ZonePersistenceHandle<'_> {
                 // NOTE: The outer function, which is spawning the background
                 // task, has a lock of the zone state. Thus, the following lock
                 // cannot be taken until the outer function terminates.
-                let mut state = zone.state.lock().unwrap();
-                let mut handle = ZoneHandle {
-                    zone: &zone,
-                    state: &mut state,
-                    center: &center,
-                };
-
-                handle.start_new_sign(persisted);
-
+                let mut handle = zone.write_handle(&center);
+                handle.get().start_new_sign(persisted);
                 handle.state.persistence.ongoing.finish();
             });
     }
@@ -181,14 +155,9 @@ impl ZonePersistenceHandle<'_> {
                 // NOTE: The outer function, which is spawning the background
                 // task, has a lock of the zone state. Thus, the following lock
                 // cannot be taken until the outer function terminates.
-                let mut state = zone.state.lock().unwrap();
-                let mut handle = ZoneHandle {
-                    zone: &zone,
-                    state: &mut state,
-                    center: &center,
-                };
+                let mut handle = zone.write_handle(&center);
 
-                handle.start_switch(persisted);
+                handle.get().start_switch(persisted);
 
                 handle.state.persistence.ongoing.finish();
             });

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -181,7 +181,7 @@ mod compat {
         zone: &ServedZone<V>,
         request: &Request<Vec<u8>, Option<Arc<tsig::Key>>>,
     ) -> bool {
-        let zone_state = zone.handle.state.lock().unwrap();
+        let zone_state = zone.handle.read();
 
         if tracing::enabled!(Level::TRACE) {
             let tsig_key = request.metadata().as_ref().map(|key| key.name());
@@ -426,7 +426,7 @@ mod compat {
         }
 
         let diffs = {
-            let zone_state = zone.handle.state.lock().unwrap();
+            let zone_state = zone.handle.read();
 
             match mode {
                 ServiceMode::LoadedReview => {

--- a/src/signer/incremental.rs
+++ b/src/signer/incremental.rs
@@ -80,14 +80,7 @@ pub fn sign_incrementally(
     let keyset_state: KeySetState = serde_json::from_str(&state)
         .map_err(|e| SignerError::SigningError(format!("loading keyset state failed: {e}")))?;
 
-    let policy;
-    {
-        let zone_state = zone
-            .state
-            .lock()
-            .map_err(|e| SignerError::SigningError(format!("zone.state.lock() failed: {e}")))?;
-        policy = zone_state.policy.clone().expect("should be there");
-    };
+    let policy = zone.read().policy.clone().unwrap();
 
     let use_nsec3 = matches!(policy.signer.denial, SignerDenialPolicy::NSec3 { .. });
 
@@ -231,7 +224,7 @@ pub fn sign_incrementally(
             .map(|s| domain::base::Serial(s.into())),
     );
 
-    ws.local_state.save(&ws.center, &ws.zone)?;
+    ws.local_state.save(&ws.center, &ws.zone);
 
     Ok(())
 }
@@ -2285,10 +2278,7 @@ pub struct LocalState {
 
 impl LocalState {
     pub fn new(zone: &Arc<Zone>) -> Result<Self, SignerError> {
-        let zone_state = zone
-            .state
-            .lock()
-            .map_err(|e| SignerError::SigningError(format!("zone.state.lock() failed: {e}")))?;
+        let zone_state = zone.read();
 
         Ok(Self {
             apex_remove: zone_state.apex_remove.clone(),
@@ -2301,47 +2291,19 @@ impl LocalState {
         })
     }
 
-    pub fn save(self, center: &Arc<Center>, zone: &Arc<Zone>) -> Result<(), SignerError> {
-        let mut modified = false;
+    pub fn save(self, center: &Arc<Center>, zone: &Arc<Zone>) {
+        // TODO: The state is always marked as dirty. We could avoid marking it
+        // as dirty in case we detect a modification has not happened. We should
+        // evaluate whether this is worthwhile.
+        let mut zone_state = zone.write(center);
 
-        let mut zone_state = zone
-            .state
-            .lock()
-            .map_err(|e| SignerError::SigningError(format!("zone.state.lock() failed: {e}")))?;
-
-        if self.apex_remove != zone_state.apex_remove {
-            zone_state.apex_remove = self.apex_remove;
-            modified = true;
-        }
-        if self.apex_extra != zone_state.apex_extra {
-            zone_state.apex_extra = self.apex_extra;
-            modified = true;
-        }
-        if self.last_signature_refresh != zone_state.last_signature_refresh {
-            zone_state.last_signature_refresh = self.last_signature_refresh;
-            modified = true;
-        }
-        if self.key_tags != zone_state.key_tags {
-            zone_state.key_tags = self.key_tags;
-            modified = true;
-        }
-        if self.key_roll != zone_state.key_roll {
-            zone_state.key_roll = self.key_roll;
-            modified = true;
-        }
-        if self.previous_serial != zone_state.previous_serial {
-            zone_state.previous_serial = self.previous_serial;
-            modified = true;
-        }
-        if self.next_min_expiration != zone_state.next_min_expiration {
-            zone_state.next_min_expiration = self.next_min_expiration;
-            modified = true;
-        }
-
-        if modified {
-            zone.mark_dirty(&mut zone_state, center);
-        }
-        Ok(())
+        zone_state.apex_remove = self.apex_remove;
+        zone_state.apex_extra = self.apex_extra;
+        zone_state.last_signature_refresh = self.last_signature_refresh;
+        zone_state.key_tags = self.key_tags;
+        zone_state.key_roll = self.key_roll;
+        zone_state.previous_serial = self.previous_serial;
+        zone_state.next_min_expiration = self.next_min_expiration;
     }
 }
 

--- a/src/signer/incremental.rs
+++ b/src/signer/incremental.rs
@@ -76,14 +76,7 @@ pub fn sign_incrementally(
     let keyset_state: KeySetState = serde_json::from_str(&state)
         .map_err(|e| SignerError::SigningError(format!("loading keyset state failed: {e}")))?;
 
-    let policy;
-    {
-        let zone_state = zone
-            .state
-            .lock()
-            .map_err(|e| SignerError::SigningError(format!("zone.state.lock() failed: {e}")))?;
-        policy = zone_state.policy.clone().expect("should be there");
-    };
+    let policy = { zone.read().policy.clone().unwrap() };
 
     let use_nsec3 = matches!(policy.signer.denial, SignerDenialPolicy::NSec3 { .. });
 
@@ -216,7 +209,7 @@ pub fn sign_incrementally(
         ws.local_state.next_min_expiration
     );
 
-    ws.local_state.save(&ws.center, &ws.zone)?;
+    ws.local_state.save(&ws.center, &ws.zone);
 
     Ok(())
 }
@@ -2228,10 +2221,7 @@ struct LocalState {
 
 impl LocalState {
     fn new(zone: &Arc<Zone>) -> Result<Self, SignerError> {
-        let zone_state = zone
-            .state
-            .lock()
-            .map_err(|e| SignerError::SigningError(format!("zone.state.lock() failed: {e}")))?;
+        let zone_state = zone.read();
 
         Ok(Self {
             apex_remove: zone_state.apex_remove.clone(),
@@ -2244,47 +2234,19 @@ impl LocalState {
         })
     }
 
-    fn save(self, center: &Arc<Center>, zone: &Arc<Zone>) -> Result<(), SignerError> {
-        let mut modified = false;
+    fn save(self, center: &Arc<Center>, zone: &Arc<Zone>) {
+        // TODO: The state is always marked as dirty. We could avoid marking it
+        // as dirty in case we detect a modification has not happened. We should
+        // evaluate whether this is worthwhile.
+        let mut zone_state = zone.write(center);
 
-        let mut zone_state = zone
-            .state
-            .lock()
-            .map_err(|e| SignerError::SigningError(format!("zone.state.lock() failed: {e}")))?;
-
-        if self.apex_remove != zone_state.apex_remove {
-            zone_state.apex_remove = self.apex_remove;
-            modified = true;
-        }
-        if self.apex_extra != zone_state.apex_extra {
-            zone_state.apex_extra = self.apex_extra;
-            modified = true;
-        }
-        if self.last_signature_refresh != zone_state.last_signature_refresh {
-            zone_state.last_signature_refresh = self.last_signature_refresh;
-            modified = true;
-        }
-        if self.key_tags != zone_state.key_tags {
-            zone_state.key_tags = self.key_tags;
-            modified = true;
-        }
-        if self.key_roll != zone_state.key_roll {
-            zone_state.key_roll = self.key_roll;
-            modified = true;
-        }
-        if self.previous_serial != zone_state.previous_serial {
-            zone_state.previous_serial = self.previous_serial;
-            modified = true;
-        }
-        if self.next_min_expiration != zone_state.next_min_expiration {
-            zone_state.next_min_expiration = self.next_min_expiration;
-            modified = true;
-        }
-
-        if modified {
-            zone.mark_dirty(&mut zone_state, center);
-        }
-        Ok(())
+        zone_state.apex_remove = self.apex_remove;
+        zone_state.apex_extra = self.apex_extra;
+        zone_state.last_signature_refresh = self.last_signature_refresh;
+        zone_state.key_tags = self.key_tags;
+        zone_state.key_roll = self.key_roll;
+        zone_state.previous_serial = self.previous_serial;
+        zone_state.next_min_expiration = self.next_min_expiration;
     }
 }
 

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -28,7 +28,7 @@ use tracing::{debug, error};
 use crate::units::zone_signer::SignerError;
 use crate::{
     center::Center,
-    zone::{HistoricalEvent, Zone, ZoneHandle},
+    zone::{HistoricalEvent, Zone},
 };
 
 pub mod incremental;
@@ -75,23 +75,18 @@ async fn sign(
     .unwrap();
 
     let mut status = status.write().unwrap();
-    let mut state = zone.state.lock().unwrap();
-    let mut handle = ZoneHandle {
-        zone: &zone,
-        state: &mut state,
-        center: &center,
-    };
+    let mut handle = zone.write_handle(&center);
     handle.state.signer.ongoing.finish();
 
     match result {
         Ok(()) => {
             let built = builder.finish().unwrap_or_else(|_| unreachable!());
-            handle.finish_signing(built);
+            handle.get().finish_signing(built);
             status.status.finish(true);
             status.current_action = "Finished".to_string();
         }
         Err(SignerError::NothingToDo) => {
-            handle.abandon_signing(builder);
+            handle.get().abandon_signing(builder);
             status.status.finish(true);
             status.current_action = "Nothing to do".to_string();
         }
@@ -100,7 +95,7 @@ async fn sign(
             // a while assuming the unsigned zone gets updated regularly.
             // TODO: But if nothing happens for too long we should warn.
             // Something in status would be good.
-            handle.abandon_signing(builder);
+            handle.get().abandon_signing(builder);
             status.status.finish(true);
 
             status.current_action = "Resign failed due to Keep policy".to_string();
@@ -125,7 +120,7 @@ async fn sign(
         }
         Err(error) => {
             error!("Signing failed: {error}");
-            handle.signing_failed(builder, error.clone());
+            handle.get().signing_failed(builder, error.clone());
             status.status.finish(false);
             status.current_action = "Aborted".to_string();
 

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -28,7 +28,7 @@ use tracing::error;
 use crate::units::zone_signer::SignerError;
 use crate::{
     center::Center,
-    zone::{HistoricalEvent, Zone, ZoneHandle},
+    zone::{HistoricalEvent, Zone},
 };
 
 pub mod incremental;
@@ -75,23 +75,18 @@ async fn sign(
     .unwrap();
 
     let mut status = status.write().unwrap();
-    let mut state = zone.state.lock().unwrap();
-    let mut handle = ZoneHandle {
-        zone: &zone,
-        state: &mut state,
-        center: &center,
-    };
+    let mut handle = zone.write_handle(&center);
     handle.state.signer.ongoing.finish();
 
     match result {
         Ok(()) => {
             let built = builder.finish().unwrap_or_else(|_| unreachable!());
-            handle.finish_signing(built);
+            handle.get().finish_signing(built);
             status.status.finish(true);
             status.current_action = "Finished".to_string();
         }
         Err(SignerError::NothingToDo) => {
-            handle.abandon_signing(builder);
+            handle.get().abandon_signing(builder);
             status.status.finish(true);
             status.current_action = "Nothing to do".to_string();
         }
@@ -100,13 +95,13 @@ async fn sign(
             // a while assuming the unsigned zone gets updated regularly.
             // TODO: But if nothing happens for too long we should warn.
             // Something in status would be good.
-            handle.abandon_signing(builder);
+            handle.get().abandon_signing(builder);
             status.status.finish(true);
             status.current_action = "Resign failed due to Keep policy".to_string();
         }
         Err(error) => {
             error!("Signing failed: {error}");
-            handle.signing_failed(builder, error.clone());
+            handle.get().signing_failed(builder, error.clone());
             status.status.finish(false);
             status.current_action = "Aborted".to_string();
 

--- a/src/tsig/mod.rs
+++ b/src/tsig/mod.rs
@@ -5,7 +5,11 @@ use std::{collections::hash_map, fmt, io, sync::Arc, time::Duration};
 use domain::tsig;
 use tracing::{debug, error, trace};
 
-use crate::{center::Center, config::Config, zone::ZoneByPtr};
+use crate::{
+    center::Center,
+    config::Config,
+    zone::{ZoneByName, ZoneByPtr},
+};
 
 pub mod file;
 
@@ -288,9 +292,8 @@ pub fn remove_key(center: &Arc<Center>, name: &tsig::KeyName) -> Result<(), Remo
     }
 
     // Is the TSIG key in use with a zone source?
-    if state.zones.iter().any(|z| {
-        let zone_state = z.0.state.lock().unwrap();
-        matches!(zone_state.loader.source, crate::loader::Source::Server { tsig_key: Some(ref key), .. } if name == key.name())
+    if state.zones.iter().any(|ZoneByName(zone)| {
+        matches!(zone.read().loader.source, crate::loader::Source::Server { tsig_key: Some(ref key), .. } if name == key.name())
     }) {
         return Err(RemoveError::Used);
     }

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -50,10 +50,8 @@ use crate::units::key_manager::KmipServerCredentialsFileMode;
 use crate::units::key_manager::mk_dnst_keyset_cfg_file_path;
 use crate::units::key_manager::mk_dnst_keyset_state_file_path;
 use crate::units::zone_signer::KeySetState;
-use crate::zone::HistoricalEvent;
-use crate::zone::HistoricalEventType;
-use crate::zone::ZoneHandle;
 use crate::zone::machine::ZoneStateMachine;
+use crate::zone::{HistoricalEvent, HistoricalEventType, ZoneByName};
 
 pub const HTTP_UNIT_NAME: &str = "HS";
 
@@ -218,11 +216,9 @@ impl HttpServer {
         let center = &state.center;
 
         // Determine which pipelines are halted.
-        for zone in center.state.lock().unwrap().zones.iter() {
-            if let Ok(zone_state) = zone.0.state.lock()
-                && let Some(err) = zone_state.machine.display_halted_reason()
-            {
-                halted_zones.push((zone.0.name.clone(), err.clone()))
+        for ZoneByName(zone) in center.state.lock().unwrap().zones.iter() {
+            if let Some(err) = zone.read().machine.display_halted_reason() {
+                halted_zones.push((zone.name.clone(), err.clone()))
             }
         }
 
@@ -322,15 +318,7 @@ impl HttpServer {
         let do_zone_reset = || {
             let zone = center::get_zone(&state.center, &name).ok_or(ZoneResetError::NoSuchZone)?;
 
-            let mut zone_state = zone.state.lock().unwrap();
-
-            let mut handle = ZoneHandle {
-                zone: &zone,
-                state: &mut zone_state,
-                center: &state.center,
-            };
-
-            match handle.try_reset() {
+            match zone.write_handle(&state.center).get().try_reset() {
                 Ok(_) => Ok(ZoneResetOutput {
                     zone: zone.name.clone(),
                 }),
@@ -390,7 +378,7 @@ impl HttpServer {
                 .0
                 .clone();
 
-            let zone_state = zone.state.lock().unwrap();
+            let zone_state = zone.read();
             halted_reason = zone_state.halted_reason();
 
             policy = zone_state
@@ -625,7 +613,7 @@ impl HttpServer {
 
         // TODO: Report separate information for ongoing and completed loads.
         let receipt_report = {
-            let state = zone.state.lock().unwrap();
+            let state = zone.read();
             let active = state.loader.active_load_metrics.as_ref();
             let last = state.loader.last_load_metrics.as_ref();
             active
@@ -679,9 +667,9 @@ impl HttpServer {
             Some(zone) => zone,
             None => return Json(Err(ZoneHistoryError::ZoneDoesNotExist)),
         };
-        let zone_state = zone.state.lock().unwrap();
         Json(Ok(ZoneHistory {
-            history: zone_state
+            history: zone
+                .read()
                 .history
                 .iter()
                 .map(|i| i.clone().into())
@@ -760,15 +748,11 @@ impl HttpServer {
             let zone =
                 center::get_zone(&state.center, &name).ok_or(ZoneOverrideError::NoSuchZone)?;
 
-            let mut zone_state = zone.state.lock().unwrap();
-
-            let mut handle = ZoneHandle {
-                zone: &zone,
-                state: &mut zone_state,
-                center: &state.center,
-            };
-
-            match handle.try_override_loaded_reject() {
+            match zone
+                .write_handle(&state.center)
+                .get()
+                .try_override_loaded_reject()
+            {
                 Ok(_) => Ok(ZoneOverrideOutput {
                     review_stage: ZoneReviewStage::Unsigned,
                     zone: zone.name.clone(),
@@ -833,15 +817,11 @@ impl HttpServer {
             let zone =
                 center::get_zone(&state.center, &name).ok_or(ZoneOverrideError::NoSuchZone)?;
 
-            let mut zone_state = zone.state.lock().unwrap();
-
-            let mut handle = ZoneHandle {
-                zone: &zone,
-                state: &mut zone_state,
-                center: &state.center,
-            };
-
-            match handle.try_override_signed_reject() {
+            match zone
+                .write_handle(&state.center)
+                .get()
+                .try_override_signed_reject()
+            {
                 Ok(_) => Ok(ZoneOverrideOutput {
                     review_stage: ZoneReviewStage::Signed,
                     zone: zone.name.clone(),
@@ -875,7 +855,7 @@ impl HttpServer {
         let zone =
             center::get_zone(&state.center, &name).ok_or(ZoneMaintenanceModeError::NoSuchZone)?;
 
-        let mut zone_state = zone.state.lock().unwrap();
+        let mut zone_state = zone.write(&state.center);
 
         if zone_state.maintenance_mode == enable {
             return Err(ZoneMaintenanceModeError::AlreadyInThatState);
@@ -955,20 +935,16 @@ impl HttpServer {
                 .expect("we just reloaded these policies");
 
             for zone_name in &pol.zones {
-                let zone = state
+                let ZoneByName(zone) = state
                     .zones
                     .get(zone_name)
                     .expect("zones and policies are consistent");
 
-                let mut state = zone.0.state.lock().expect("lock isn't poisoned");
-                state.policy = Some(pol.latest.clone());
+                zone.write(center).policy = Some(pol.latest.clone());
 
-                center.key_manager.on_zone_policy_changed(
-                    center,
-                    &zone.0,
-                    old.clone(),
-                    new.clone(),
-                );
+                center
+                    .key_manager
+                    .on_zone_policy_changed(center, zone, old.clone(), new.clone());
             }
         }
 

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -45,10 +45,8 @@ use crate::units::key_manager::KmipServerCredentialsFileMode;
 use crate::units::key_manager::mk_dnst_keyset_cfg_file_path;
 use crate::units::key_manager::mk_dnst_keyset_state_file_path;
 use crate::units::zone_signer::KeySetState;
-use crate::zone::HistoricalEvent;
-use crate::zone::HistoricalEventType;
-use crate::zone::ZoneHandle;
 use crate::zone::machine::ZoneStateMachine;
+use crate::zone::{HistoricalEvent, HistoricalEventType, ZoneByName};
 
 pub const HTTP_UNIT_NAME: &str = "HS";
 
@@ -202,11 +200,9 @@ impl HttpServer {
         let center = &state.center;
 
         // Determine which pipelines are halted.
-        for zone in center.state.lock().unwrap().zones.iter() {
-            if let Ok(zone_state) = zone.0.state.lock()
-                && let Some(err) = zone_state.machine.display_halted_reason()
-            {
-                halted_zones.push((zone.0.name.clone(), err.clone()))
+        for ZoneByName(zone) in center.state.lock().unwrap().zones.iter() {
+            if let Some(err) = zone.read().machine.display_halted_reason() {
+                halted_zones.push((zone.name.clone(), err.clone()))
             }
         }
 
@@ -298,15 +294,7 @@ impl HttpServer {
         let do_zone_reset = || {
             let zone = center::get_zone(&state.center, &name).ok_or(ZoneResetError::NoSuchZone)?;
 
-            let mut zone_state = zone.state.lock().unwrap();
-
-            let mut handle = ZoneHandle {
-                zone: &zone,
-                state: &mut zone_state,
-                center: &state.center,
-            };
-
-            match handle.try_reset() {
+            match zone.write_handle(&state.center).get().try_reset() {
                 Ok(_) => Ok(ZoneResetOutput {
                     zone: zone.name.clone(),
                 }),
@@ -364,7 +352,7 @@ impl HttpServer {
                 .0
                 .clone();
 
-            let zone_state = zone.state.lock().unwrap();
+            let zone_state = zone.read();
             halted_reason = zone_state.halted_reason();
 
             policy = zone_state
@@ -547,7 +535,7 @@ impl HttpServer {
 
         // TODO: Report separate information for ongoing and completed loads.
         let receipt_report = {
-            let state = zone.state.lock().unwrap();
+            let state = zone.read();
             let active = state.loader.active_load_metrics.as_ref();
             let last = state.loader.last_load_metrics.as_ref();
             active
@@ -597,9 +585,9 @@ impl HttpServer {
             Some(zone) => zone,
             None => return Json(Err(ZoneHistoryError::ZoneDoesNotExist)),
         };
-        let zone_state = zone.state.lock().unwrap();
         Json(Ok(ZoneHistory {
-            history: zone_state
+            history: zone
+                .read()
                 .history
                 .iter()
                 .map(|i| i.clone().into())
@@ -678,15 +666,11 @@ impl HttpServer {
             let zone =
                 center::get_zone(&state.center, &name).ok_or(ZoneOverrideError::NoSuchZone)?;
 
-            let mut zone_state = zone.state.lock().unwrap();
-
-            let mut handle = ZoneHandle {
-                zone: &zone,
-                state: &mut zone_state,
-                center: &state.center,
-            };
-
-            match handle.try_override_loaded_reject() {
+            match zone
+                .write_handle(&state.center)
+                .get()
+                .try_override_loaded_reject()
+            {
                 Ok(_) => Ok(ZoneOverrideOutput {
                     review_stage: ZoneReviewStage::Unsigned,
                     zone: zone.name.clone(),
@@ -751,15 +735,11 @@ impl HttpServer {
             let zone =
                 center::get_zone(&state.center, &name).ok_or(ZoneOverrideError::NoSuchZone)?;
 
-            let mut zone_state = zone.state.lock().unwrap();
-
-            let mut handle = ZoneHandle {
-                zone: &zone,
-                state: &mut zone_state,
-                center: &state.center,
-            };
-
-            match handle.try_override_signed_reject() {
+            match zone
+                .write_handle(&state.center)
+                .get()
+                .try_override_signed_reject()
+            {
                 Ok(_) => Ok(ZoneOverrideOutput {
                     review_stage: ZoneReviewStage::Signed,
                     zone: zone.name.clone(),
@@ -836,13 +816,12 @@ impl HttpServer {
                 .expect("we just reloaded these policies");
 
             for zone_name in &pol.zones {
-                let zone = state
+                let ZoneByName(zone) = state
                     .zones
                     .get(zone_name)
                     .expect("zones and policies are consistent");
 
-                let mut state = zone.0.state.lock().expect("lock isn't poisoned");
-                state.policy = Some(pol.latest.clone());
+                zone.write(center).policy = Some(pol.latest.clone());
 
                 center.key_manager.on_zone_policy_changed(
                     center,

--- a/src/units/key_manager.rs
+++ b/src/units/key_manager.rs
@@ -6,7 +6,7 @@ use crate::policy::{KeyParameters, PolicyVersion};
 use crate::signer::ResigningTrigger;
 use crate::units::http_server::KmipServerState;
 use crate::util::AbortOnDrop;
-use crate::zone::{HistoricalEvent, Zone, ZoneHandle};
+use crate::zone::{HistoricalEvent, Zone};
 use bytes::Bytes;
 use camino::{Utf8Path, Utf8PathBuf};
 use cascade_api::keyset::{KeyRollCommand, KeyRollVariant};
@@ -493,14 +493,9 @@ impl KeyManager {
                     }
                 };
                 let _ = ks_info.insert(zone.name.clone(), new_info);
-                let mut state = zone.state.lock().unwrap();
-                ZoneHandle {
-                    zone,
-                    state: &mut state,
-                    center,
-                }
-                .signer()
-                .enqueue_resign(ResigningTrigger::KEYS_CHANGED);
+                zone.write_handle(center)
+                    .signer()
+                    .enqueue_resign(ResigningTrigger::KEYS_CHANGED);
                 continue;
             }
 
@@ -538,14 +533,9 @@ impl KeyManager {
                         // signer.
                         // let new_info = get_keyset_info(&state_path);
                         let _ = ks_info.insert(zone.name.clone(), new_info);
-                        let mut state = zone.state.lock().unwrap();
-                        ZoneHandle {
-                            zone,
-                            state: &mut state,
-                            center,
-                        }
-                        .signer()
-                        .enqueue_resign(ResigningTrigger::KEYS_CHANGED);
+                        zone.write_handle(center)
+                            .signer()
+                            .enqueue_resign(ResigningTrigger::KEYS_CHANGED);
                         continue;
                     }
 

--- a/src/units/key_manager.rs
+++ b/src/units/key_manager.rs
@@ -6,7 +6,7 @@ use crate::policy::{KeyParameters, PolicyVersion};
 use crate::signer::ResigningTrigger;
 use crate::units::http_server::KmipServerState;
 use crate::util::AbortOnDrop;
-use crate::zone::{HistoricalEvent, ZoneHandle};
+use crate::zone::HistoricalEvent;
 use bytes::Bytes;
 use camino::{Utf8Path, Utf8PathBuf};
 use cascade_api::keyset::{KeyRollCommand, KeyRollVariant};
@@ -491,14 +491,9 @@ impl KeyManager {
                     }
                 };
                 let _ = ks_info.insert(zone.name.clone(), new_info);
-                let mut state = zone.state.lock().unwrap();
-                ZoneHandle {
-                    zone,
-                    state: &mut state,
-                    center,
-                }
-                .signer()
-                .enqueue_resign(ResigningTrigger::KEYS_CHANGED);
+                zone.write_handle(center)
+                    .signer()
+                    .enqueue_resign(ResigningTrigger::KEYS_CHANGED);
                 continue;
             }
 
@@ -536,14 +531,9 @@ impl KeyManager {
                         // signer.
                         // let new_info = get_keyset_info(&state_path);
                         let _ = ks_info.insert(zone.name.clone(), new_info);
-                        let mut state = zone.state.lock().unwrap();
-                        ZoneHandle {
-                            zone,
-                            state: &mut state,
-                            center,
-                        }
-                        .signer()
-                        .enqueue_resign(ResigningTrigger::KEYS_CHANGED);
+                        zone.write_handle(center)
+                            .signer()
+                            .enqueue_resign(ResigningTrigger::KEYS_CHANGED);
                         continue;
                     }
 

--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -39,8 +39,7 @@ use crate::policy::{NameserverCommsPolicy, OnReject, ReviewMode};
 use crate::server::{LoadedReviewServer, PublicationServer, SignedReviewServer};
 use crate::util::AbortOnDrop;
 use crate::zone::{
-    HistoricalEvent, SignedZoneVersionState, UnsignedZoneVersionState, Zone, ZoneHandle,
-    ZoneVersionReviewState,
+    HistoricalEvent, SignedZoneVersionState, UnsignedZoneVersionState, Zone, ZoneVersionReviewState,
 };
 
 /// The source of a zone server.
@@ -222,14 +221,13 @@ impl ZoneServer {
 
         // Move next_min_expiration to min_expiration, and determine policy.
         let (policy, soa) = {
-            // Use a block to make sure that the mutex is clearly dropped.
-            let mut zone_state = zone.state.lock().unwrap();
+            // Use a block to make sure that the lock is clearly dropped.
+            let mut zone_state = zone.write(center);
 
             // Save as next_min_expiration. After the signed zone is approved
             // this value should be move to min_expiration.
             zone_state.min_expiration = zone_state.next_min_expiration;
             zone_state.next_min_expiration = None;
-            zone.mark_dirty(&mut zone_state, center);
 
             (
                 zone_state.policy.clone(),
@@ -274,7 +272,7 @@ impl ZoneServer {
         };
 
         let review = {
-            let zone_state = zone.state.lock().unwrap();
+            let zone_state = zone.read();
             let policy = zone_state.policy.as_ref().unwrap();
             match self.source {
                 Source::Unsigned => policy.loader.review.clone(),
@@ -325,7 +323,7 @@ impl ZoneServer {
         // not all components use these fields yet.  For now, they need to be
         // created over here -- hence 'or_insert_with()'.
         {
-            let mut zone_state = zone.state.lock().unwrap();
+            let mut zone_state = zone.write(center);
             match self.source {
                 Source::Unsigned => {
                     zone_state
@@ -461,7 +459,7 @@ impl ZoneServer {
                 );
 
                 {
-                    let mut zone_state = zone.state.lock().unwrap();
+                    let mut zone_state = zone.write(center);
                     match self.source {
                         Source::Unsigned => {
                             zone_state.record_event(
@@ -498,24 +496,12 @@ impl ZoneServer {
         zone_serial: Serial,
     ) {
         let _ = zone_serial; // TODO
-        let mut state = zone.state.lock().unwrap();
-        ZoneHandle {
-            zone,
-            state: &mut state,
-            center,
-        }
-        .approve_loaded();
+        zone.write_handle(center).get().approve_loaded();
     }
 
     fn on_signed_zone_approved(&self, center: &Arc<Center>, zone: &Arc<Zone>, zone_serial: Serial) {
         {
-            let mut state = zone.state.lock().unwrap();
-            ZoneHandle {
-                zone,
-                state: &mut state,
-                center,
-            }
-            .approve_signed();
+            zone.write_handle(center).get().approve_signed();
         }
 
         // Send a message to the zone signer to trigger a re-scan of
@@ -565,7 +551,7 @@ impl ZoneServer {
         match self.source {
             Source::Unsigned => {
                 {
-                    let mut zone_state = zone.state.lock().unwrap();
+                    let mut zone_state = zone.write(center);
                     let Some(version) = zone_state.unsigned.get_mut(&zone_serial) else {
                         // 'on_seek_approval_for_zone_cmd()' should have created
                         // this.  Since it doesn't exist, the zone is not under
@@ -598,23 +584,14 @@ impl ZoneServer {
                         "Unsigned zone '{zone_name}' with serial {zone_serial} has been rejected."
                     );
 
-                    let mut state = zone.state.lock().unwrap();
-                    match state.policy.as_ref().unwrap().loader.review.on_reject {
+                    let mut handle = zone.write_handle(center);
+                    let policy = handle.state.policy.as_ref().unwrap();
+                    match policy.loader.review.on_reject {
                         OnReject::Discard => {
-                            ZoneHandle {
-                                zone,
-                                state: &mut state,
-                                center,
-                            }
-                            .soft_reject_loaded();
+                            handle.get().soft_reject_loaded();
                         }
                         OnReject::Halt => {
-                            ZoneHandle {
-                                zone,
-                                state: &mut state,
-                                center,
-                            }
-                            .hard_reject_loaded();
+                            handle.get().hard_reject_loaded();
                         }
                     }
                 }
@@ -622,7 +599,7 @@ impl ZoneServer {
 
             Source::Signed => {
                 {
-                    let mut zone_state = zone.state.lock().unwrap();
+                    let mut zone_state = zone.write(center);
                     let Some(version) = zone_state.signed.get_mut(&zone_serial) else {
                         // 'on_seek_approval_for_zone_cmd()' should have created
                         // this.  Since it doesn't exist, the zone is not under
@@ -652,24 +629,14 @@ impl ZoneServer {
                     error!(
                         "Signed zone '{zone_name}' with serial {zone_serial} has been rejected."
                     );
-                    // TODO: Whether to soft or hard reject should be part of the policy
-                    let mut state = zone.state.lock().unwrap();
-                    match state.policy.as_ref().unwrap().signer.review.on_reject {
+                    let mut handle = zone.write_handle(center);
+                    let policy = handle.state.policy.as_ref().unwrap();
+                    match policy.signer.review.on_reject {
                         OnReject::Discard => {
-                            ZoneHandle {
-                                zone,
-                                state: &mut state,
-                                center,
-                            }
-                            .soft_reject_signed();
+                            handle.get().soft_reject_signed();
                         }
                         OnReject::Halt => {
-                            ZoneHandle {
-                                zone,
-                                state: &mut state,
-                                center,
-                            }
-                            .hard_reject_signed();
+                            handle.get().hard_reject_signed();
                         }
                     }
                 }
@@ -758,7 +725,7 @@ impl Notifiable for LoaderNotifier {
 
                 // Clone the source so that we don't hold the zone state lock
                 // when calling on_refresh_zone().
-                let zone_source = zone.state.lock().unwrap().loader.source.clone();
+                let zone_source = zone.read().loader.source.clone();
                 match zone_source {
                     crate::loader::Source::Server { .. } => {
                         info!("Instructing zone loader to refresh zone '{apex_name}");

--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -36,8 +36,7 @@ use crate::manager::record_zone_event;
 use crate::server::{LoadedReviewServer, PublicationServer, SignedReviewServer};
 use crate::util::AbortOnDrop;
 use crate::zone::{
-    HistoricalEvent, SignedZoneVersionState, UnsignedZoneVersionState, Zone, ZoneHandle,
-    ZoneVersionReviewState,
+    HistoricalEvent, SignedZoneVersionState, UnsignedZoneVersionState, Zone, ZoneVersionReviewState,
 };
 
 /// The source of a zone server.
@@ -219,14 +218,13 @@ impl ZoneServer {
 
         // Move next_min_expiration to min_expiration, and determine policy.
         let policy = {
-            // Use a block to make sure that the mutex is clearly dropped.
-            let mut zone_state = zone.state.lock().unwrap();
+            // Use a block to make sure that the lock is clearly dropped.
+            let mut zone_state = zone.write(center);
 
             // Save as next_min_expiration. After the signed zone is approved
             // this value should be move to min_expiration.
             zone_state.min_expiration = zone_state.next_min_expiration;
             zone_state.next_min_expiration = None;
-            zone.mark_dirty(&mut zone_state, center);
 
             zone_state.policy.clone()
         };
@@ -270,7 +268,7 @@ impl ZoneServer {
         };
 
         let review = {
-            let zone_state = zone.state.lock().unwrap();
+            let zone_state = zone.read();
             let policy = zone_state.policy.as_ref().unwrap();
             match self.source {
                 Source::Unsigned => policy.loader.review.clone(),
@@ -321,7 +319,7 @@ impl ZoneServer {
         // not all components use these fields yet.  For now, they need to be
         // created over here -- hence 'or_insert_with()'.
         {
-            let mut zone_state = zone.state.lock().unwrap();
+            let mut zone_state = zone.write(center);
             match self.source {
                 Source::Unsigned => {
                     zone_state
@@ -452,7 +450,7 @@ impl ZoneServer {
                 );
 
                 {
-                    let mut zone_state = zone.state.lock().unwrap();
+                    let mut zone_state = zone.write(center);
                     match self.source {
                         Source::Unsigned => {
                             zone_state.unsigned.get_mut(&zone_serial).unwrap().review =
@@ -477,24 +475,12 @@ impl ZoneServer {
         zone_serial: Serial,
     ) {
         let _ = zone_serial; // TODO
-        let mut state = zone.state.lock().unwrap();
-        ZoneHandle {
-            zone,
-            state: &mut state,
-            center,
-        }
-        .approve_loaded();
+        zone.write_handle(center).get().approve_loaded();
     }
 
     fn on_signed_zone_approved(&self, center: &Arc<Center>, zone: &Arc<Zone>, zone_serial: Serial) {
         {
-            let mut state = zone.state.lock().unwrap();
-            ZoneHandle {
-                zone,
-                state: &mut state,
-                center,
-            }
-            .approve_signed();
+            zone.write_handle(center).get().approve_signed();
         }
 
         // Send a message to the zone signer to trigger a re-scan of
@@ -544,7 +530,7 @@ impl ZoneServer {
         match self.source {
             Source::Unsigned => {
                 {
-                    let mut zone_state = zone.state.lock().unwrap();
+                    let mut zone_state = zone.write(center);
                     let Some(version) = zone_state.unsigned.get_mut(&zone_serial) else {
                         // 'on_seek_approval_for_zone_cmd()' should have created
                         // this.  Since it doesn't exist, the zone is not under
@@ -578,19 +564,13 @@ impl ZoneServer {
                     );
 
                     // TODO: Whether to soft or hard reject should be part of the policy
-                    let mut state = zone.state.lock().unwrap();
-                    ZoneHandle {
-                        zone,
-                        state: &mut state,
-                        center,
-                    }
-                    .hard_reject_loaded();
+                    zone.write_handle(center).get().hard_reject_loaded();
                 }
             }
 
             Source::Signed => {
                 {
-                    let mut zone_state = zone.state.lock().unwrap();
+                    let mut zone_state = zone.write(center);
                     let Some(version) = zone_state.signed.get_mut(&zone_serial) else {
                         // 'on_seek_approval_for_zone_cmd()' should have created
                         // this.  Since it doesn't exist, the zone is not under
@@ -621,13 +601,7 @@ impl ZoneServer {
                         "Signed zone '{zone_name}' with serial {zone_serial} has been rejected."
                     );
                     // TODO: Whether to soft or hard reject should be part of the policy
-                    let mut state = zone.state.lock().unwrap();
-                    ZoneHandle {
-                        zone,
-                        state: &mut state,
-                        center,
-                    }
-                    .hard_reject_signed();
+                    zone.write_handle(center).get().hard_reject_signed();
                 }
             }
 

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -62,7 +62,7 @@ use crate::util::{
     AbortOnDrop, serialize_duration_as_secs, serialize_instant_as_duration_secs,
     serialize_opt_duration_as_secs,
 };
-use crate::zone::{HistoricalEvent, Zone, ZoneHandle};
+use crate::zone::{HistoricalEvent, Zone, ZoneByName};
 
 // Re-signing zones before signatures expire works as follows:
 // - compute when the first zone needs to be re-signed. Loop over unsigned
@@ -341,8 +341,8 @@ impl ZoneSigner {
         let mut local_state = LocalState::new(zone)?;
 
         let policy = {
-            // Use a block to make sure that the mutex is clearly dropped.
-            let zone_state = zone.state.lock().unwrap();
+            // Use a block to make sure that the lock is clearly dropped.
+            let zone_state = zone.read();
 
             zone_state.policy.clone().unwrap()
         };
@@ -770,7 +770,7 @@ impl ZoneSigner {
         );
 
         local_state.last_signature_refresh = UnixTime::now();
-        local_state.save(center, zone)?;
+        local_state.save(center, zone);
 
         Ok(())
     }
@@ -814,27 +814,25 @@ impl ZoneSigner {
 
         // Compute when to incrementally sign a zone again to refresh
         // signatures.
-        for zone in zones {
-            let zone = &zone.0;
+        for ZoneByName(zone) in zones {
             let zone_name = &zone.name;
 
-            let last_signature_refresh = {
-                // Use a block to make sure that the mutex is clearly dropped.
-                let zone_state = zone.state.lock().unwrap();
-                zone_state.last_signature_refresh.clone()
-            };
+            let last_signature_refresh;
+            let signature_refresh_interval;
+            {
+                // Use a block to make sure that the lock is clearly dropped.
+                let zone_state = zone.read();
 
-            // Ensure that the Mutexes are locked only in this block;
-            let signature_refresh_interval = {
-                let zone_state = zone.state.lock().unwrap();
+                last_signature_refresh = zone_state.last_signature_refresh.clone();
+
                 // TODO: what if there is no policy?
-                zone_state
+                signature_refresh_interval = zone_state
                     .policy
                     .as_ref()
                     .unwrap()
                     .signer
-                    .signature_refresh_interval
-            };
+                    .signature_refresh_interval;
+            }
 
             let curr_refresh_time = last_signature_refresh.clone()
                 + Duration::from_secs(signature_refresh_interval as u64);
@@ -890,23 +888,22 @@ impl ZoneSigner {
             let zone = &zone.0;
             let zone_name = &zone.name;
 
-            let last_signature_refresh = {
-                // Use a block to make sure that the mutex is clearly dropped.
-                let zone_state = zone.state.lock().unwrap();
-                zone_state.last_signature_refresh.clone()
-            };
+            let last_signature_refresh;
+            let signature_refresh_interval;
+            {
+                // Use a block to make sure that the lock is clearly dropped.
+                let zone_state = zone.read();
 
-            // Ensure that the Mutexes are locked only in this block;
-            let signature_refresh_interval = {
-                let zone_state = zone.state.lock().unwrap();
-                // What if there is no policy?
-                zone_state
+                last_signature_refresh = zone_state.last_signature_refresh.clone();
+
+                // TODO: what if there is no policy?
+                signature_refresh_interval = zone_state
                     .policy
                     .as_ref()
                     .unwrap()
                     .signer
-                    .signature_refresh_interval
-            };
+                    .signature_refresh_interval;
+            }
 
             let curr_refresh_time = last_signature_refresh.clone()
                 + Duration::from_secs(signature_refresh_interval as u64);
@@ -933,14 +930,9 @@ impl ZoneSigner {
                     let mut resign_busy = center.resign_busy.lock().expect("should not fail");
                     resign_busy.insert(zone_name.clone(), curr_refresh_time);
                 }
-                let mut state = zone.state.lock().unwrap();
-                ZoneHandle {
-                    zone,
-                    state: &mut state,
-                    center,
-                }
-                .signer()
-                .enqueue_resign(ResigningTrigger::SIGS_NEED_REFRESH);
+                zone.write_handle(center)
+                    .signer()
+                    .enqueue_resign(ResigningTrigger::SIGS_NEED_REFRESH);
             }
         }
     }

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -60,7 +60,7 @@ use crate::util::{
     AbortOnDrop, serialize_duration_as_secs, serialize_instant_as_duration_secs,
     serialize_opt_duration_as_secs,
 };
-use crate::zone::{HistoricalEvent, HistoricalEventType, Zone, ZoneHandle};
+use crate::zone::{HistoricalEvent, HistoricalEventType, Zone, ZoneByName};
 
 // Re-signing zones before signatures expire works as follows:
 // - compute when the first zone needs to be re-signed. Loop over unsigned
@@ -330,8 +330,8 @@ impl ZoneSigner {
         let start = Instant::now();
 
         let (last_signed_serial, policy) = {
-            // Use a block to make sure that the mutex is clearly dropped.
-            let zone_state = zone.state.lock().unwrap();
+            // Use a block to make sure that the lock is clearly dropped.
+            let zone_state = zone.read();
 
             let last_signed_serial = zone_state
                 .find_last_event(HistoricalEventType::SigningSucceeded, None)
@@ -718,7 +718,7 @@ impl ZoneSigner {
         // Save the minimum of the expiration times.
         {
             // Use a block to make sure that the mutex is clearly dropped.
-            let mut zone_state = zone.state.lock().unwrap();
+            let mut zone_state = zone.write(center);
 
             // Save as next_min_expiration. After the signed zone is approved
             // this value should be move to min_expiration.
@@ -727,8 +727,6 @@ impl ZoneSigner {
                 "SIGNER: Determined min expiration time: {:?}",
                 zone_state.next_min_expiration
             );
-
-            zone.mark_dirty(&mut zone_state, center);
         }
 
         let total_time = start.elapsed();
@@ -810,27 +808,25 @@ impl ZoneSigner {
 
         // Compute when to incrementally sign a zone again to refresh
         // signatures.
-        for zone in zones {
-            let zone = &zone.0;
+        for ZoneByName(zone) in zones {
             let zone_name = &zone.name;
 
-            let last_signature_refresh = {
-                // Use a block to make sure that the mutex is clearly dropped.
-                let zone_state = zone.state.lock().unwrap();
-                zone_state.last_signature_refresh.clone()
-            };
+            let last_signature_refresh;
+            let signature_refresh_interval;
+            {
+                // Use a block to make sure that the lock is clearly dropped.
+                let zone_state = zone.read();
 
-            // Ensure that the Mutexes are locked only in this block;
-            let signature_refresh_interval = {
-                let zone_state = zone.state.lock().unwrap();
+                last_signature_refresh = zone_state.last_signature_refresh.clone();
+
                 // TODO: what if there is no policy?
-                zone_state
+                signature_refresh_interval = zone_state
                     .policy
                     .as_ref()
                     .unwrap()
                     .signer
-                    .signature_refresh_interval
-            };
+                    .signature_refresh_interval;
+            }
 
             let curr_refresh_time = last_signature_refresh.clone()
                 + Duration::from_secs(signature_refresh_interval as u64);
@@ -886,23 +882,22 @@ impl ZoneSigner {
             let zone = &zone.0;
             let zone_name = &zone.name;
 
-            let last_signature_refresh = {
-                // Use a block to make sure that the mutex is clearly dropped.
-                let zone_state = zone.state.lock().unwrap();
-                zone_state.last_signature_refresh.clone()
-            };
+            let last_signature_refresh;
+            let signature_refresh_interval;
+            {
+                // Use a block to make sure that the lock is clearly dropped.
+                let zone_state = zone.read();
 
-            // Ensure that the Mutexes are locked only in this block;
-            let signature_refresh_interval = {
-                let zone_state = zone.state.lock().unwrap();
-                // What if there is no policy?
-                zone_state
+                last_signature_refresh = zone_state.last_signature_refresh.clone();
+
+                // TODO: what if there is no policy?
+                signature_refresh_interval = zone_state
                     .policy
                     .as_ref()
                     .unwrap()
                     .signer
-                    .signature_refresh_interval
-            };
+                    .signature_refresh_interval;
+            }
 
             let curr_refresh_time = last_signature_refresh.clone()
                 + Duration::from_secs(signature_refresh_interval as u64);
@@ -929,14 +924,9 @@ impl ZoneSigner {
                     let mut resign_busy = center.resign_busy.lock().expect("should not fail");
                     resign_busy.insert(zone_name.clone(), curr_refresh_time);
                 }
-                let mut state = zone.state.lock().unwrap();
-                ZoneHandle {
-                    zone,
-                    state: &mut state,
-                    center,
-                }
-                .signer()
-                .enqueue_resign(ResigningTrigger::SIGS_NEED_REFRESH);
+                zone.write_handle(center)
+                    .signer()
+                    .enqueue_resign(ResigningTrigger::SIGS_NEED_REFRESH);
             }
         }
     }

--- a/src/zone/lock.rs
+++ b/src/zone/lock.rs
@@ -1,0 +1,85 @@
+//! Locking zone state.
+
+use std::sync::{PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+use super::ZoneState;
+
+#[cfg(doc)]
+use super::{Zone, ZoneHandle};
+
+/// A lock around [`ZoneState`].
+///
+/// [`ZoneState`] is locked so that it can be used and modified across threads,
+/// while keeping all parts of the zone state consistent with each other. This
+/// is important for preventing race conditions.
+///
+/// `ZoneLock` is a wrapper around `RwLock<ZoneState>` that provides some
+/// convenience functionality. It hides lock poisoning (Cascade does not try
+/// to recover in case of panics) and prevents callers from writing to the
+/// zone state without marking it dirty. It eliminates boilerplate and avoids
+/// inconsistent uses of the zone state across the codebase.
+#[derive(Debug)]
+pub struct ZoneStateLock {
+    /// The underlying lock.
+    inner: RwLock<ZoneState>,
+}
+
+impl ZoneStateLock {
+    /// Construct a new [`ZoneStateLock`].
+    #[must_use]
+    pub const fn new(state: ZoneState) -> Self {
+        Self {
+            inner: RwLock::new(state),
+        }
+    }
+
+    /// Destructure this into the underlying [`ZoneState`].
+    #[must_use]
+    pub fn into_inner(self) -> ZoneState {
+        self.inner.into_inner().unwrap_or_else(handle_poison)
+    }
+
+    /// Obtain a read lock over the [`ZoneState`].
+    ///
+    /// A read lock which [deref]s to [`ZoneState`] is returned.
+    ///
+    /// Prefer using [`Zone::read()`]; it is more convenient.
+    ///
+    /// The current thread is blocked until the read lock can be acquired.
+    ///
+    /// [deref]: std::ops::Deref
+    pub fn read(&self) -> ReadableZoneState<'_> {
+        self.inner.read().unwrap_or_else(handle_poison)
+    }
+
+    /// Obtain a write lock over the [`ZoneState`] **without marking it dirty**.
+    ///
+    /// A write lock which [deref]s to [`ZoneState`] is returned.
+    ///
+    /// Prefer using [`Zone::write()`], which will mark the state as dirty. If
+    /// a [`ZoneHandle`] is needed, use [`Zone::write_handle()`].
+    ///
+    /// The current thread is blocked until the write lock can be acquired.
+    ///
+    /// The state will **not** be marked dirty; it is the caller's
+    /// responsibility to mark the state as dirty if/when a change is made.
+    ///
+    /// [deref]: std::ops::DerefMut
+    pub fn write_cleanly(&self) -> WritableZoneState<'_> {
+        self.inner.write().unwrap_or_else(handle_poison)
+    }
+}
+
+/// A read guard to a zone's state.
+pub type ReadableZoneState<'a> = RwLockReadGuard<'a, ZoneState>;
+
+/// A write guard to a zone's state.
+pub type WritableZoneState<'a> = RwLockWriteGuard<'a, ZoneState>;
+
+/// Handle a lock poisoning failure.
+//
+// TODO: Return '!'.
+#[track_caller]
+fn handle_poison<T, R>(_: PoisonError<T>) -> R {
+    panic!("A zone state lock is poisoned; see its panic message")
+}

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -142,6 +142,7 @@ pub struct ZoneHandle<'a> {
 
 impl ZoneHandle<'_> {
     /// Consider loader-specific operations.
+    #[must_use]
     pub const fn loader(&mut self) -> LoaderZoneHandle<'_> {
         LoaderZoneHandle {
             zone: self.zone,
@@ -151,6 +152,7 @@ impl ZoneHandle<'_> {
     }
 
     /// Consider signer-specific operations.
+    #[must_use]
     pub const fn signer(&mut self) -> SignerZoneHandle<'_> {
         SignerZoneHandle {
             zone: self.zone,
@@ -160,6 +162,7 @@ impl ZoneHandle<'_> {
     }
 
     /// Consider storage-specific operations.
+    #[must_use]
     pub const fn storage(&mut self) -> StorageZoneHandle<'_> {
         StorageZoneHandle {
             zone: self.zone,
@@ -169,10 +172,80 @@ impl ZoneHandle<'_> {
     }
 
     /// Consider data persistence specific operations.
+    #[must_use]
     pub const fn persistence(&mut self) -> ZonePersistenceHandle<'_> {
         ZonePersistenceHandle {
             zone: self.zone,
             state: self.state,
+            center: self.center,
+        }
+    }
+}
+
+//----------- OwnedZoneHandle --------------------------------------------------
+
+/// A [`ZoneHandle`] that owns a zone state write lock.
+///
+/// This is a convenience type. By owning the write lock, it can simplify
+/// construction of `ZoneHandle`s for quick uses.
+pub struct OwnedZoneHandle<'a> {
+    /// The zone being operated on.
+    pub zone: &'a Arc<Zone>,
+
+    /// The locked zone state.
+    pub state: WritableZoneState<'a>,
+
+    /// Cascade's global state.
+    pub center: &'a Arc<Center>,
+}
+
+impl OwnedZoneHandle<'_> {
+    /// Get the corresponding [`ZoneHandle`].
+    #[must_use]
+    pub fn get(&mut self) -> ZoneHandle<'_> {
+        ZoneHandle {
+            zone: self.zone,
+            state: &mut self.state,
+            center: self.center,
+        }
+    }
+
+    /// Consider loader-specific operations.
+    #[must_use]
+    pub fn loader(&mut self) -> LoaderZoneHandle<'_> {
+        LoaderZoneHandle {
+            zone: self.zone,
+            state: &mut self.state,
+            center: self.center,
+        }
+    }
+
+    /// Consider signer-specific operations.
+    #[must_use]
+    pub fn signer(&mut self) -> SignerZoneHandle<'_> {
+        SignerZoneHandle {
+            zone: self.zone,
+            state: &mut self.state,
+            center: self.center,
+        }
+    }
+
+    /// Consider storage-specific operations.
+    #[must_use]
+    pub fn storage(&mut self) -> StorageZoneHandle<'_> {
+        StorageZoneHandle {
+            zone: self.zone,
+            state: &mut self.state,
+            center: self.center,
+        }
+    }
+
+    /// Consider data persistence specific operations.
+    #[must_use]
+    pub fn persistence(&mut self) -> ZonePersistenceHandle<'_> {
+        ZonePersistenceHandle {
+            zone: self.zone,
+            state: &mut self.state,
             center: self.center,
         }
     }

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -40,6 +40,9 @@ pub use storage::{StorageState, StorageZoneHandle};
 pub mod machine;
 pub mod state;
 
+mod lock;
+pub use lock::{ReadableZoneState, WritableZoneState, ZoneStateLock};
+
 //----------- Zone -------------------------------------------------------------
 
 /// A zone.

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -7,7 +7,7 @@ use std::{
     cmp::Ordering,
     fmt,
     hash::{Hash, Hasher},
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::{Duration, SystemTime},
 };
 
@@ -53,10 +53,9 @@ pub struct Zone {
 
     /// The state of this zone.
     ///
-    /// This uses a mutex to ensure that all parts of the zone state are
-    /// consistent with each other, and that changes to the zone happen in a
-    /// single (sequentially consistent) order.
-    pub state: Mutex<ZoneState>,
+    /// The state is locked for consistency. For the underlying data, see
+    /// [`ZoneState`].
+    pub state: ZoneStateLock,
 
     /// Whether the zone was restored from the state file.
     ///
@@ -74,7 +73,7 @@ impl Zone {
     pub fn new(name: Name<Bytes>) -> Self {
         Self {
             name,
-            state: Default::default(),
+            state: ZoneStateLock::new(ZoneState::default()),
             restored: false,
         }
     }
@@ -120,9 +119,55 @@ impl Zone {
 
         Ok(Self {
             name,
-            state: Mutex::new(state),
+            state: ZoneStateLock::new(state),
             restored: true,
         })
+    }
+
+    /// Obtain a read lock over the zone state.
+    ///
+    /// A read lock which [deref]s to [`ZoneState`] is returned.
+    ///
+    /// The current thread is blocked until the read lock can be acquired.
+    ///
+    /// Prefer this to `self.state.read()`.
+    ///
+    /// [deref]: std::ops::Deref
+    pub fn read(&self) -> ReadableZoneState<'_> {
+        self.state.read()
+    }
+
+    /// Obtain a write lock and build a handle to the zone.
+    ///
+    /// An [`OwnedZoneHandle`] is returned, through which high-level zone
+    /// operations are available.
+    ///
+    /// The current thread is blocked until the write lock can be acquired.
+    ///
+    /// The state will be marked dirty; some time after the lock is released,
+    /// the (likely modified) state will be persisted to disk. To guarantee that
+    /// the state is persisted at a particular point, use [`save_state_now()`].
+    pub fn write_handle<'a>(self: &'a Arc<Self>, center: &'a Arc<Center>) -> OwnedZoneHandle<'a> {
+        OwnedZoneHandle {
+            zone: self,
+            state: self.write(center),
+            center,
+        }
+    }
+
+    /// Obtain a write lock over the zone state.
+    ///
+    /// Prefer [`Self::write_handle()`], as it returns a convenient zone handle.
+    ///
+    /// The current thread is blocked until the write lock can be acquired.
+    ///
+    /// The state will be marked dirty; some time after the lock is released,
+    /// the (likely modified) state will be persisted to disk. To guarantee that
+    /// the state is persisted at a particular point, use [`save_state_now()`].
+    pub fn write<'z>(self: &'z Arc<Self>, center: &Arc<Center>) -> WritableZoneState<'z> {
+        let mut writer = self.state.write_cleanly();
+        self.mark_dirty(&mut writer, center);
+        writer
     }
 }
 
@@ -663,7 +708,7 @@ impl Zone {
 
             // Load the actual zone contents.
             let spec = {
-                let mut state = zone.state.lock().unwrap();
+                let mut state = zone.state.write_cleanly();
                 let Some(_) = state.enqueued_save.take_if(|s| s.id() == tokio::task::id()) else {
                     // 'enqueued_save' does not match what we set, so somebody
                     // else set it to 'None' first.  Don't do anything.
@@ -695,7 +740,7 @@ pub fn save_state_now(center: &Center, zone: &Zone) {
 
     // Load the actual zone contents.
     let spec = {
-        let mut state = zone.state.lock().unwrap();
+        let mut state = zone.state.write_cleanly();
 
         // If there was an enqueued save operation, stop it.
         if let Some(save) = state.enqueued_save.take() {

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -137,6 +137,7 @@ pub struct ZoneHandle<'a> {
 
 impl ZoneHandle<'_> {
     /// Consider loader-specific operations.
+    #[must_use]
     pub const fn loader(&mut self) -> LoaderZoneHandle<'_> {
         LoaderZoneHandle {
             zone: self.zone,
@@ -146,6 +147,7 @@ impl ZoneHandle<'_> {
     }
 
     /// Consider signer-specific operations.
+    #[must_use]
     pub const fn signer(&mut self) -> SignerZoneHandle<'_> {
         SignerZoneHandle {
             zone: self.zone,
@@ -155,6 +157,7 @@ impl ZoneHandle<'_> {
     }
 
     /// Consider storage-specific operations.
+    #[must_use]
     pub const fn storage(&mut self) -> StorageZoneHandle<'_> {
         StorageZoneHandle {
             zone: self.zone,
@@ -164,10 +167,80 @@ impl ZoneHandle<'_> {
     }
 
     /// Consider data persistence specific operations.
+    #[must_use]
     pub const fn persistence(&mut self) -> ZonePersistenceHandle<'_> {
         ZonePersistenceHandle {
             zone: self.zone,
             state: self.state,
+            center: self.center,
+        }
+    }
+}
+
+//----------- OwnedZoneHandle --------------------------------------------------
+
+/// A [`ZoneHandle`] that owns a zone state write lock.
+///
+/// This is a convenience type. By owning the write lock, it can simplify
+/// construction of `ZoneHandle`s for quick uses.
+pub struct OwnedZoneHandle<'a> {
+    /// The zone being operated on.
+    pub zone: &'a Arc<Zone>,
+
+    /// The locked zone state.
+    pub state: WritableZoneState<'a>,
+
+    /// Cascade's global state.
+    pub center: &'a Arc<Center>,
+}
+
+impl OwnedZoneHandle<'_> {
+    /// Get the corresponding [`ZoneHandle`].
+    #[must_use]
+    pub fn get(&mut self) -> ZoneHandle<'_> {
+        ZoneHandle {
+            zone: self.zone,
+            state: &mut self.state,
+            center: self.center,
+        }
+    }
+
+    /// Consider loader-specific operations.
+    #[must_use]
+    pub fn loader(&mut self) -> LoaderZoneHandle<'_> {
+        LoaderZoneHandle {
+            zone: self.zone,
+            state: &mut self.state,
+            center: self.center,
+        }
+    }
+
+    /// Consider signer-specific operations.
+    #[must_use]
+    pub fn signer(&mut self) -> SignerZoneHandle<'_> {
+        SignerZoneHandle {
+            zone: self.zone,
+            state: &mut self.state,
+            center: self.center,
+        }
+    }
+
+    /// Consider storage-specific operations.
+    #[must_use]
+    pub fn storage(&mut self) -> StorageZoneHandle<'_> {
+        StorageZoneHandle {
+            zone: self.zone,
+            state: &mut self.state,
+            center: self.center,
+        }
+    }
+
+    /// Consider data persistence specific operations.
+    #[must_use]
+    pub fn persistence(&mut self) -> ZonePersistenceHandle<'_> {
+        ZonePersistenceHandle {
+            zone: self.zone,
+            state: &mut self.state,
             center: self.center,
         }
     }

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -39,6 +39,9 @@ pub use storage::{StorageState, StorageZoneHandle};
 pub mod machine;
 pub mod state;
 
+mod lock;
+pub use lock::{ReadableZoneState, WritableZoneState, ZoneStateLock};
+
 //----------- Zone -------------------------------------------------------------
 
 /// A zone.

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -7,7 +7,7 @@ use std::{
     fmt,
     hash::{Hash, Hasher},
     io,
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::{Duration, SystemTime},
 };
 
@@ -52,10 +52,8 @@ pub struct Zone {
 
     /// The state of this zone.
     ///
-    /// This uses a mutex to ensure that all parts of the zone state are
-    /// consistent with each other, and that changes to the zone happen in a
-    /// single (sequentially consistent) order.
-    pub state: Mutex<ZoneState>,
+    /// The state is locked for consistency; see [`ZoneStateLock`].
+    pub state: ZoneStateLock,
 
     /// Whether the zone was restored from the state file.
     ///
@@ -73,7 +71,7 @@ impl Zone {
     pub fn new(name: Name<Bytes>) -> Self {
         Self {
             name,
-            state: Default::default(),
+            state: ZoneStateLock::new(ZoneState::default()),
             restored: false,
         }
     }
@@ -115,9 +113,55 @@ impl Zone {
 
         Ok(Self {
             name,
-            state: Mutex::new(state),
+            state: ZoneStateLock::new(state),
             restored: true,
         })
+    }
+
+    /// Obtain a read lock over the zone state.
+    ///
+    /// A read lock which [deref]s to [`ZoneState`] is returned.
+    ///
+    /// The current thread is blocked until the read lock can be acquired.
+    ///
+    /// Prefer this to `self.state.read()`.
+    ///
+    /// [deref]: std::ops::Deref
+    pub fn read(&self) -> ReadableZoneState<'_> {
+        self.state.read()
+    }
+
+    /// Obtain a write lock and build a handle to the zone.
+    ///
+    /// An [`OwnedZoneHandle`] is returned, through which high-level zone
+    /// operations are available.
+    ///
+    /// The current thread is blocked until the write lock can be acquired.
+    ///
+    /// The state will be marked dirty; some time after the lock is released,
+    /// the (likely modified) state will be persisted to disk. To guarantee that
+    /// the state is persisted at a particular point, use [`save_state_now()`].
+    pub fn write_handle<'a>(self: &'a Arc<Self>, center: &'a Arc<Center>) -> OwnedZoneHandle<'a> {
+        OwnedZoneHandle {
+            zone: self,
+            state: self.write(center),
+            center,
+        }
+    }
+
+    /// Obtain a write lock over the zone state.
+    ///
+    /// Prefer [`Self::write_handle()`], as it returns a convenient zone handle.
+    ///
+    /// The current thread is blocked until the write lock can be acquired.
+    ///
+    /// The state will be marked dirty; some time after the lock is released,
+    /// the (likely modified) state will be persisted to disk. To guarantee that
+    /// the state is persisted at a particular point, use [`save_state_now()`].
+    pub fn write<'z>(self: &'z Arc<Self>, center: &Arc<Center>) -> WritableZoneState<'z> {
+        let mut writer = self.state.write_cleanly();
+        self.mark_dirty(&mut writer, center);
+        writer
     }
 }
 
@@ -605,7 +649,7 @@ impl Zone {
 
             // Load the actual zone contents.
             let spec = {
-                let mut state = zone.state.lock().unwrap();
+                let mut state = zone.state.write_cleanly();
                 let Some(_) = state.enqueued_save.take_if(|s| s.id() == tokio::task::id()) else {
                     // 'enqueued_save' does not match what we set, so somebody
                     // else set it to 'None' first.  Don't do anything.
@@ -637,7 +681,7 @@ pub fn save_state_now(center: &Center, zone: &Zone) {
 
     // Load the actual zone contents.
     let spec = {
-        let mut state = zone.state.lock().unwrap();
+        let mut state = zone.state.write_cleanly();
 
         // If there was an enqueued save operation, stop it.
         if let Some(save) = state.enqueued_save.take() {

--- a/src/zone/storage.rs
+++ b/src/zone/storage.rs
@@ -200,7 +200,7 @@ impl StorageZoneHandle<'_> {
             trace!("Updating the viewer in 'LoadedReviewServer'");
             let old_loaded_reviewer = LoadedReviewServer::update_viewer(&center, &zone, loaded_reviewer).await;
 
-            let mut state = zone.state.lock().unwrap();
+            let mut state = zone.write(&center);
 
             // Transition into the reviewing state.
             match transition(&mut state.storage.machine) {
@@ -225,7 +225,7 @@ impl StorageZoneHandle<'_> {
                 domain::base::Serial(serial.into()),
             );
 
-            state = zone.state.lock().unwrap();
+            state = zone.write(&center);
 
             state.storage.background_tasks.finish();
         });
@@ -436,7 +436,7 @@ impl StorageZoneHandle<'_> {
             trace!("Updating the viewer in 'SignedReviewServer'");
             let old_signed_reviewer = SignedReviewServer::update_viewer(&center, &zone, signed_reviewer).await;
 
-            let mut state = zone.state.lock().unwrap();
+            let mut state = zone.write(&center);
 
             // Transition into the reviewing state.
             match transition(&mut state.storage.machine) {
@@ -461,7 +461,7 @@ impl StorageZoneHandle<'_> {
                 domain::base::Serial(serial.into()),
             );
 
-            state = zone.state.lock().unwrap();
+            state = zone.write(&center);
 
             state.storage.background_tasks.finish()
         });
@@ -526,12 +526,7 @@ impl StorageZoneHandle<'_> {
                 LoadedReviewServer::update_viewer(&center, &zone, loaded_reviewer).await;
 
             // Examine the current state.
-            let mut state = zone.state.lock().unwrap();
-            let mut handle = ZoneHandle {
-                zone: &zone,
-                state: &mut state,
-                center: &center,
-            };
+            let mut handle = zone.write_handle(&center);
             let cleaner = match transition(&mut handle.state.storage.machine) {
                 (transition, ZoneDataStorage::CleanWholePending(s)) => {
                     let (s, cleaner) = s
@@ -686,12 +681,7 @@ impl StorageZoneHandle<'_> {
             // NOTE: The outer function, which is spawning the background task,
             // has a lock of the zone state. Thus, the following lock cannot be
             // taken until the outer function terminates.
-            let mut state = zone.state.lock().unwrap();
-            let mut handle = ZoneHandle {
-                zone: &zone,
-                state: &mut state,
-                center: &center,
-            };
+            let mut handle = zone.write_handle(&center);
 
             match transition(&mut handle.state.storage.machine) {
                 (transition, ZoneDataStorage::Cleaning(s)) => {
@@ -754,12 +744,7 @@ impl StorageZoneHandle<'_> {
             // NOTE: The outer function, which is spawning the background task,
             // has a lock of the zone state. Thus, the following lock cannot be
             // taken until the outer function terminates.
-            let mut state = zone.state.lock().unwrap();
-            let mut handle = ZoneHandle {
-                zone: &zone,
-                state: &mut state,
-                center: &center,
-            };
+            let mut handle = zone.write_handle(&center);
 
             // Update the zone data storage state machine.
             let cleaner = match transition(&mut handle.state.storage.machine) {
@@ -802,7 +787,7 @@ impl StorageZoneHandle<'_> {
                 num_records,
             });
 
-            handle.finish_switch(cleaner);
+            handle.get().finish_switch(cleaner);
 
             handle.state.storage.background_tasks.finish();
         });
@@ -842,12 +827,7 @@ impl StorageZoneHandle<'_> {
                 LoadedReviewServer::update_viewer(&center, &zone, loaded_reviewer).await;
 
             // Examine the current state.
-            let mut state = zone.state.lock().unwrap();
-            let mut handle = ZoneHandle {
-                zone: &zone,
-                state: &mut state,
-                center: &center,
-            };
+            let mut handle = zone.write_handle(&center);
             let cleaner = match transition(&mut handle.state.storage.machine) {
                 (transition, ZoneDataStorage::CleanLoadedPending(s)) => {
                     let (s, cleaner) = s.stop_review(old_loaded_reviewer);

--- a/src/zone/storage.rs
+++ b/src/zone/storage.rs
@@ -200,7 +200,7 @@ impl StorageZoneHandle<'_> {
             trace!("Updating the viewer in 'LoadedReviewServer'");
             let old_loaded_reviewer = LoadedReviewServer::update_viewer(&center, &zone, loaded_reviewer).await;
 
-            let mut state = zone.state.lock().unwrap();
+            let mut state = zone.write(&center);
 
             // Transition into the reviewing state.
             match transition(&mut state.storage.machine) {
@@ -225,7 +225,7 @@ impl StorageZoneHandle<'_> {
                 domain::base::Serial(serial.into()),
             );
 
-            state = zone.state.lock().unwrap();
+            state = zone.write(&center);
 
             state.storage.background_tasks.finish();
         });
@@ -436,7 +436,7 @@ impl StorageZoneHandle<'_> {
             trace!("Updating the viewer in 'SignedReviewServer'");
             let old_signed_reviewer = SignedReviewServer::update_viewer(&center, &zone, signed_reviewer).await;
 
-            let mut state = zone.state.lock().unwrap();
+            let mut state = zone.write(&center);
 
             // Transition into the reviewing state.
             match transition(&mut state.storage.machine) {
@@ -461,7 +461,7 @@ impl StorageZoneHandle<'_> {
                 domain::base::Serial(serial.into()),
             );
 
-            state = zone.state.lock().unwrap();
+            state = zone.write(&center);
 
             state.storage.background_tasks.finish()
         });
@@ -526,12 +526,7 @@ impl StorageZoneHandle<'_> {
                 LoadedReviewServer::update_viewer(&center, &zone, loaded_reviewer).await;
 
             // Examine the current state.
-            let mut state = zone.state.lock().unwrap();
-            let mut handle = ZoneHandle {
-                zone: &zone,
-                state: &mut state,
-                center: &center,
-            };
+            let mut handle = zone.write_handle(&center);
             let cleaner = match transition(&mut handle.state.storage.machine) {
                 (transition, ZoneDataStorage::CleanWholePending(s)) => {
                     let (s, cleaner) = s
@@ -688,12 +683,7 @@ impl StorageZoneHandle<'_> {
             // NOTE: The outer function, which is spawning the background task,
             // has a lock of the zone state. Thus, the following lock cannot be
             // taken until the outer function terminates.
-            let mut state = zone.state.lock().unwrap();
-            let mut handle = ZoneHandle {
-                zone: &zone,
-                state: &mut state,
-                center: &center,
-            };
+            let mut handle = zone.write_handle(&center);
 
             match transition(&mut handle.state.storage.machine) {
                 (transition, ZoneDataStorage::Cleaning(s)) => {
@@ -750,12 +740,7 @@ impl StorageZoneHandle<'_> {
             // NOTE: The outer function, which is spawning the background task,
             // has a lock of the zone state. Thus, the following lock cannot be
             // taken until the outer function terminates.
-            let mut state = zone.state.lock().unwrap();
-            let mut handle = ZoneHandle {
-                zone: &zone,
-                state: &mut state,
-                center: &center,
-            };
+            let mut handle = zone.write_handle(&center);
 
             // Update the zone data storage state machine.
             let cleaner = match transition(&mut handle.state.storage.machine) {
@@ -793,7 +778,7 @@ impl StorageZoneHandle<'_> {
                 ),
             });
 
-            handle.finish_switch(cleaner);
+            handle.get().finish_switch(cleaner);
 
             handle.state.storage.background_tasks.finish();
         });
@@ -833,12 +818,7 @@ impl StorageZoneHandle<'_> {
                 LoadedReviewServer::update_viewer(&center, &zone, loaded_reviewer).await;
 
             // Examine the current state.
-            let mut state = zone.state.lock().unwrap();
-            let mut handle = ZoneHandle {
-                zone: &zone,
-                state: &mut state,
-                center: &center,
-            };
+            let mut handle = zone.write_handle(&center);
             let cleaner = match transition(&mut handle.state.storage.machine) {
                 (transition, ZoneDataStorage::CleanLoadedPending(s)) => {
                     let (s, cleaner) = s.stop_review(old_loaded_reviewer);


### PR DESCRIPTION
This PR introduces `ZoneStateLock`, a wrapper around the `ZoneState` lock with higher-level methods. `ZoneStateLock` alleviates boilerplate and inconsistencies around how we use the `ZoneState` lock.

Previously, access to zone state was obtained via `zone.state.lock().unwrap()`. Some call sites used `.expect()` or `?` instead of `.unwrap()`, introducing inconsistencies. Most importantly: _most_ call sites did not call `.mark_dirty()`, so changes to the zone were not being persisted with regularity.

`ZoneStateLock` wraps an `RwLock` instead of a `Mutex` because some call sites only read the zone state, and it seemed better to expose that functionality rather than use write locks everywhere. Rather than a simple `.lock()` method, a write lock must be obtained with the obtuse name `.write_cleanly()`, and that method tells users to prefer `Zone::write()`. `Zone::write()` marks the state as dirty automatically so that callers don't have to remember to.

In addition, a new `OwnedZoneHandle` type is introduced. This works around some borrowing limitations of `ZoneHandle`. The new `Zone::write_handle()` method obtains a write lock over the zone state, marks it as dirty, and returns an `OwnedZoneHandle` so that handle-related methods can be called conveniently.

All call sites of `zone.state.lock()` have been updated to use the new locking methods, and most of them (particularly those that needed `ZoneHandle`) are much simpler now.

Note: this PR is very prone to (causing and incurring) merge conflicts.

Resolves #599.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?