### PR TITLE
Add maintenance mode

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -120,6 +120,23 @@ impl std::fmt::Display for ZoneOverrideError {
     }
 }
 
+//----------- ZoneOverride -----------------------------------------------------
+
+/// The result of a `zone maintenance start/stop` command.
+pub type ZoneMaintenanceModeResult = Result<ZoneMaintenanceModeOutput, ZoneMaintenanceModeError>;
+
+/// The output of a `zone maintenance start/stop` command.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct ZoneMaintenanceModeOutput {
+    pub zone: ZoneName,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum ZoneMaintenanceModeError {
+    NoSuchZone,
+    AlreadyInThatState,
+}
+
 //----------- ChangeLogging ----------------------------------------------------
 
 /// Change how Cascade logs information.
@@ -428,6 +445,7 @@ pub struct ZoneStatus {
     pub policy: String,
     pub last_published: Option<LastPublishedZone>,
     pub progress: Progress,
+    pub maintenance_mode: bool,
     pub keys: Vec<KeyInfo>,
     pub key_status: String,
     pub error: Option<String>,

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -120,6 +120,23 @@ impl std::fmt::Display for ZoneOverrideError {
     }
 }
 
+//----------- ZoneOverride -----------------------------------------------------
+
+/// The result of a `zone manual-mode` command.
+pub type ZoneManualModeResult = Result<ZoneManualModeOutput, ZoneManualModeError>;
+
+/// The output of a `zone manual-mode` command.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct ZoneManualModeOutput {
+    pub zone: ZoneName,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum ZoneManualModeError {
+    NoSuchZone,
+    AlreadyInThatState,
+}
+
 //----------- ChangeLogging ----------------------------------------------------
 
 /// Change how Cascade logs information.
@@ -422,6 +439,7 @@ pub struct ZoneStatus {
     pub policy: String,
     pub last_published: Option<LastPublishedZone>,
     pub progress: Progress,
+    pub manual_mode: bool,
     pub keys: Vec<KeyInfo>,
     pub key_status: String,
     pub error: Option<String>,

--- a/crates/cli/src/ansi.rs
+++ b/crates/cli/src/ansi.rs
@@ -12,5 +12,6 @@ pub const CYAN: &str = "\x1b[0;36m";
 pub const WHITE: &str = "\x1b[0;37m";
 pub const GRAY: &str = "\x1b[38;5;248m";
 pub const RESET: &str = "\x1b[0m";
+pub const BOLD: &str = "\x1b[1m";
 pub const DIM: &str = "\x1b[2m";
 pub const ITALIC: &str = "\x1b[3m";

--- a/crates/cli/src/ansi.rs
+++ b/crates/cli/src/ansi.rs
@@ -12,4 +12,5 @@ pub const CYAN: &str = "\x1b[0;36m";
 pub const WHITE: &str = "\x1b[0;37m";
 pub const GRAY: &str = "\x1b[38;5;248m";
 pub const RESET: &str = "\x1b[0m";
+pub const BOLD: &str = "\x1b[1m";
 pub const ITALIC: &str = "\x1b[3m";

--- a/crates/cli/src/commands/zone.rs
+++ b/crates/cli/src/commands/zone.rs
@@ -559,7 +559,7 @@ impl Zone {
                                 "Cascade will no longer automatically start new loading and signing operations"
                             );
                             println!(
-                                "Run {}`cascade zone maintenance stop {name}`{} to continue automatic operation",
+                                "Run {}`cascade zone maintenance stop {name}`{} to resume automatic operation",
                                 ansi::BLUE,
                                 ansi::RESET,
                             );

--- a/crates/cli/src/commands/zone.rs
+++ b/crates/cli/src/commands/zone.rs
@@ -130,6 +130,22 @@ pub enum ZoneCommand {
         /// The zone to report the history of.
         zone: ZoneName,
     },
+
+    /// Resume a paused zone pipeline
+    #[command(name = "maintenance")]
+    Maintenance {
+        /// Enable or disable maintenance mode.
+        #[command(subcommand)]
+        maintenance: Maintenance,
+    },
+}
+
+#[derive(Clone, Debug, clap::Subcommand)]
+pub enum Maintenance {
+    /// Enable maintenance mode; preventing new loading and signing operations.
+    Enable { zone: ZoneName },
+    /// Disable maintenance mode and resume normal operation.
+    Disable { zone: ZoneName },
 }
 
 /// The stage to review a zone at.
@@ -522,6 +538,54 @@ impl Zone {
                     }
                 }
             }
+            ZoneCommand::Maintenance { maintenance } => {
+                let (name, state) = match &maintenance {
+                    Maintenance::Enable { zone } => (zone, "enable"),
+                    Maintenance::Disable { zone } => (zone, "disable"),
+                };
+                let url = format!("/zone/{name}/maintenance/{state}");
+                let result: ZoneMaintenanceModeResult = client.post_json(&url).await?;
+
+                match result {
+                    Ok(_) => {
+                        if let Maintenance::Enable { .. } = maintenance {
+                            println!(
+                                "Maintenance mode for zone `{name}` is now {}enabled{}",
+                                ansi::BOLD,
+                                ansi::RESET
+                            );
+                            println!("");
+                            println!(
+                                "Cascade will no longer automatically start new loading and signing operations"
+                            );
+                            println!(
+                                "Run {}`cascade zone maintenance stop {name}`{} to continue automatic operation",
+                                ansi::BLUE,
+                                ansi::RESET,
+                            );
+                        } else {
+                            println!(
+                                "Maintenance mode for zone `{name}` is now {}disabled{}",
+                                ansi::BOLD,
+                                ansi::RESET
+                            );
+                            println!("");
+                            println!(
+                                "Cascade will automatically start new loading and signing operations when appropriate."
+                            );
+                        }
+                        Ok(())
+                    }
+                    Err(err) => match err {
+                        ZoneMaintenanceModeError::NoSuchZone => {
+                            Err(format!("zone `{name}` does not exist"))
+                        }
+                        ZoneMaintenanceModeError::AlreadyInThatState => Err(format!(
+                            "maintenance mode for zone `{name}` was already {state}d"
+                        )),
+                    },
+                }
+            }
         }
     }
 
@@ -589,6 +653,22 @@ impl Zone {
             println!("  {}ERROR: {error}{}", ansi::RED, ansi::RESET);
             println!(
                 "  Run {}`cascade zone history {}`{} for more information.",
+                ansi::BLUE,
+                zone.name,
+                ansi::RESET
+            );
+        }
+
+        if zone.maintenance_mode {
+            println!("");
+            println!(
+                "{}WARNING: This zone is in maintenance mode{}",
+                ansi::YELLOW,
+                ansi::RESET
+            );
+            println!("  Cascade will not automatically start new loading and signing operations");
+            println!(
+                "  Run {}`cascade zone maintenance disable {}`{} to resume normal operation",
                 ansi::BLUE,
                 zone.name,
                 ansi::RESET

--- a/crates/cli/src/commands/zone.rs
+++ b/crates/cli/src/commands/zone.rs
@@ -130,6 +130,19 @@ pub enum ZoneCommand {
         /// The zone to report the history of.
         zone: ZoneName,
     },
+
+    /// Resume a paused zone pipeline
+    #[command(name = "manual-mode")]
+    ManualMode {
+        #[command(subcommand)]
+        manual_mode: ManualMode,
+    },
+}
+
+#[derive(Clone, Debug, clap::Subcommand)]
+pub enum ManualMode {
+    Enable { zone: ZoneName },
+    Disable { zone: ZoneName },
 }
 
 /// The stage to review a zone at.
@@ -522,6 +535,54 @@ impl Zone {
                     }
                 }
             }
+            ZoneCommand::ManualMode { manual_mode } => {
+                let (name, state) = match &manual_mode {
+                    ManualMode::Enable { zone } => (zone, "enable"),
+                    ManualMode::Disable { zone } => (zone, "disable"),
+                };
+                let url = format!("/zone/{name}/manual-mode/{state}");
+                let result: ZoneManualModeResult = client.post_json(&url).await?;
+
+                match result {
+                    Ok(_) => {
+                        if let ManualMode::Enable { .. } = manual_mode {
+                            println!(
+                                "Manual mode for zone `{name}` is now {}enabled{}",
+                                ansi::BOLD,
+                                ansi::RESET
+                            );
+                            println!("");
+                            println!(
+                                "Cascade will no longer automatically start new loading and signing operations"
+                            );
+                            println!(
+                                "Run {}`cascade zone manual-mode disable {name}`{} to continue automatic operation",
+                                ansi::BLUE,
+                                ansi::RESET,
+                            );
+                        } else {
+                            println!(
+                                "Manual mode for zone `{name}` is now {}disabled{}",
+                                ansi::BOLD,
+                                ansi::RESET
+                            );
+                            println!("");
+                            println!(
+                                "Cascade will automatically start new loading and signing operations when appropriate."
+                            );
+                        }
+                        Ok(())
+                    }
+                    Err(err) => match err {
+                        ZoneManualModeError::NoSuchZone => {
+                            Err(format!("zone `{name}` does not exist"))
+                        }
+                        ZoneManualModeError::AlreadyInThatState => Err(format!(
+                            "manual mode for zone `{name}` was already {state}d"
+                        )),
+                    },
+                }
+            }
         }
     }
 
@@ -593,6 +654,22 @@ impl Zone {
             println!("  {}ERROR: {error}{}", ansi::RED, ansi::RESET);
             println!(
                 "  Run {}`cascade zone history {}`{} for more information.",
+                ansi::BLUE,
+                zone.name,
+                ansi::RESET
+            );
+        }
+
+        if zone.manual_mode {
+            println!("");
+            println!(
+                "{}WARNING: This zone is in manual mode{}",
+                ansi::YELLOW,
+                ansi::RESET
+            );
+            println!("  Cascade will not automatically start new loading and signing operations");
+            println!(
+                "  Run {}`cascade zone manual-mode disable {}`{} to disable manual mode",
                 ansi::BLUE,
                 zone.name,
                 ansi::RESET

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -136,6 +136,14 @@ impl HttpServer {
                 post(Self::reject_signed),
             )
             .route("/zone/{name}/signed/override", post(Self::override_signed))
+            .route(
+                "/zone/{zone}/maintenance/enable",
+                post(Self::enable_maintenance_mode),
+            )
+            .route(
+                "/zone/{zone}/maintenance/disable",
+                post(Self::disable_maintenance_mode),
+            )
             .route("/policy/", get(Self::policy_list))
             .route("/policy/reload", post(Self::policy_reload))
             .route("/policy/{name}", get(Self::policy_show))
@@ -362,6 +370,7 @@ impl HttpServer {
         let published_serial;
         let last_published;
         let error;
+        let maintenance_mode;
         {
             let locked_state = state.center.state.lock().unwrap();
             let keys_dir = &state.center.config.keys_dir;
@@ -514,6 +523,8 @@ impl HttpServer {
                 }
             }
             error = found_error;
+
+            maintenance_mode = zone_state.maintenance_mode;
         }
 
         // Query key status
@@ -623,6 +634,7 @@ impl HttpServer {
             source,
             policy,
             progress,
+            maintenance_mode,
             last_published,
             keys,
             key_status,
@@ -821,6 +833,38 @@ impl HttpServer {
         };
 
         Json(do_override())
+    }
+
+    async fn enable_maintenance_mode(
+        State(state): State<Arc<HttpServer>>,
+        Path(name): Path<Name<Bytes>>,
+    ) -> Json<ZoneMaintenanceModeResult> {
+        Json(Self::set_maintenance_mode(state, name, true))
+    }
+
+    async fn disable_maintenance_mode(
+        State(state): State<Arc<HttpServer>>,
+        Path(name): Path<Name<Bytes>>,
+    ) -> Json<ZoneMaintenanceModeResult> {
+        Json(Self::set_maintenance_mode(state, name, false))
+    }
+
+    fn set_maintenance_mode(
+        state: Arc<HttpServer>,
+        name: Name<Bytes>,
+        enable: bool,
+    ) -> ZoneMaintenanceModeResult {
+        let zone =
+            center::get_zone(&state.center, &name).ok_or(ZoneMaintenanceModeError::NoSuchZone)?;
+
+        let mut zone_state = zone.state.lock().unwrap();
+
+        if zone_state.maintenance_mode == enable {
+            return Err(ZoneMaintenanceModeError::AlreadyInThatState);
+        }
+
+        zone_state.maintenance_mode = enable;
+        Ok(ZoneMaintenanceModeOutput { zone: name.clone() })
     }
 
     async fn policy_list(State(state): State<Arc<HttpServer>>) -> Json<PolicyListResult> {

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -136,6 +136,14 @@ impl HttpServer {
                 post(Self::reject_signed),
             )
             .route("/zone/{name}/signed/override", post(Self::override_signed))
+            .route(
+                "/zone/{zone}/manual-mode/enable",
+                post(Self::enable_manual_mode),
+            )
+            .route(
+                "/zone/{zone}/manual-mode/disable",
+                post(Self::disable_manual_mode),
+            )
             .route("/policy/", get(Self::policy_list))
             .route("/policy/reload", post(Self::policy_reload))
             .route("/policy/{name}", get(Self::policy_show))
@@ -362,6 +370,7 @@ impl HttpServer {
         let published_serial;
         let last_published;
         let error;
+        let manual_mode;
         {
             let locked_state = state.center.state.lock().unwrap();
             let keys_dir = &state.center.config.keys_dir;
@@ -514,6 +523,8 @@ impl HttpServer {
                 }
             }
             error = found_error;
+
+            manual_mode = zone_state.manual_mode;
         }
 
         // Query key status
@@ -623,6 +634,7 @@ impl HttpServer {
             source,
             policy,
             progress,
+            manual_mode,
             last_published,
             keys,
             key_status,
@@ -821,6 +833,37 @@ impl HttpServer {
         };
 
         Json(do_override())
+    }
+
+    async fn enable_manual_mode(
+        State(state): State<Arc<HttpServer>>,
+        Path(name): Path<Name<Bytes>>,
+    ) -> Json<ZoneManualModeResult> {
+        Json(Self::set_manual_mode(state, name, true))
+    }
+
+    async fn disable_manual_mode(
+        State(state): State<Arc<HttpServer>>,
+        Path(name): Path<Name<Bytes>>,
+    ) -> Json<ZoneManualModeResult> {
+        Json(Self::set_manual_mode(state, name, false))
+    }
+
+    fn set_manual_mode(
+        state: Arc<HttpServer>,
+        name: Name<Bytes>,
+        enable: bool,
+    ) -> ZoneManualModeResult {
+        let zone = center::get_zone(&state.center, &name).ok_or(ZoneManualModeError::NoSuchZone)?;
+
+        let mut zone_state = zone.state.lock().unwrap();
+
+        if zone_state.manual_mode == enable {
+            return Err(ZoneManualModeError::AlreadyInThatState);
+        }
+
+        zone_state.manual_mode = enable;
+        Ok(ZoneManualModeOutput { zone: name.clone() })
     }
 
     async fn policy_list(State(state): State<Arc<HttpServer>>) -> Json<PolicyListResult> {

--- a/src/zone/machine.rs
+++ b/src/zone/machine.rs
@@ -101,6 +101,12 @@ impl ZoneStateMachine {
 /// # Initiating operations
 impl<'a> ZoneHandle<'a> {
     pub(crate) fn try_start_load(&mut self) -> Option<LoadedZoneBuilder> {
+        // If we're in maintenance mode, then we don't start this operation.
+        // TODO: distinguish between a manual load and an automatic one.
+        if self.state.maintenance_mode {
+            return None;
+        }
+
         // It's important that we first check the storage here instead of the
         // zone state machine. The reason is that while the zone state machine
         // is in the waiting state, the storage might still be persisting or
@@ -126,6 +132,12 @@ impl<'a> ZoneHandle<'a> {
     }
 
     pub(crate) fn try_start_resign(&mut self) -> Option<SignedZoneBuilder> {
+        // If we're in maintenance mode, then we don't start this operation.
+        // TODO: distinguish between a manual resign and an automatic one.
+        if self.state.maintenance_mode {
+            return None;
+        }
+
         // It's important that we first check the storage here instead of the
         // zone state machine. The reason is that while the zone state machine
         // is in the waiting state, the storage might still be persisting or

--- a/src/zone/machine.rs
+++ b/src/zone/machine.rs
@@ -101,6 +101,12 @@ impl ZoneStateMachine {
 /// # Initiating operations
 impl<'a> ZoneHandle<'a> {
     pub(crate) fn try_start_load(&mut self) -> Option<LoadedZoneBuilder> {
+        // If we're in manual mode, then we don't start this operation.
+        // TODO: distinguish between a manual load and an automatic one.
+        if self.state.manual_mode {
+            return None;
+        }
+
         // It's important that we first check the storage here instead of the
         // zone state machine. The reason is that while the zone state machine
         // is in the waiting state, the storage might still be persisting or
@@ -126,6 +132,12 @@ impl<'a> ZoneHandle<'a> {
     }
 
     pub(crate) fn try_start_resign(&mut self) -> Option<SignedZoneBuilder> {
+        // If we're in manual mode, then we don't start this operation.
+        // TODO: distinguish between a manual resign and an automatic one.
+        if self.state.manual_mode {
+            return None;
+        }
+
         // It's important that we first check the storage here instead of the
         // zone state machine. The reason is that while the zone state machine
         // is in the waiting state, the storage might still be persisting or

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -185,6 +185,12 @@ pub struct ZoneState {
     /// The policy (version) used by the zone.
     pub policy: Option<Arc<PolicyVersion>>,
 
+    /// Whether the zone is in maintenance mode
+    ///
+    /// Maintenance mode means that Cascade won't start loading and signing
+    /// operations automatically.
+    pub maintenance_mode: bool,
+
     /// Metadata related to the last published zone version.
     pub last_published: Option<LastPublished>,
 
@@ -297,6 +303,7 @@ impl Default for ZoneState {
         Self {
             machine: Default::default(),
             policy: Default::default(),
+            maintenance_mode: Default::default(),
             last_published: Default::default(),
             enqueued_save: Default::default(),
             min_expiration: Default::default(),

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -181,6 +181,12 @@ pub struct ZoneState {
     /// The policy (version) used by the zone.
     pub policy: Option<Arc<PolicyVersion>>,
 
+    /// Whether the zone is in manual mode
+    ///
+    /// Manual mode means that Cascade won't start loading and signing
+    /// operations automatically.
+    pub manual_mode: bool,
+
     /// Metadata related to the last published zone version.
     pub last_published: Option<LastPublished>,
 
@@ -293,6 +299,7 @@ impl Default for ZoneState {
         Self {
             machine: Default::default(),
             policy: Default::default(),
+            manual_mode: Default::default(),
             last_published: Default::default(),
             enqueued_save: Default::default(),
             min_expiration: Default::default(),


### PR DESCRIPTION
Maintenance mode disables automatic loading and signing. It is the new name of the "start/stop" functionality that we talked about.

```
cascade zone maintenance enable <name>
cascade zone maintenance disable <name>
```

Ultimately, this should allow the user to still trigger reloads and resigns manually.

We thought about many different names for this:
- start/stop
- resume/pause
- etc.

The "maintenance mode" name seemed to encapsulate the "do not start new operations" meaning best, because the others imply stopping/pausing an ongoing operation immediately. Additionally, we can expand maintenance mode to allow some useful operations.

When the pipeline is in maintenance mode, a big warning will be printed about that in the zone status.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
