### PR TITLE
Make key manager fns take zones rather than zone names.

### DIFF
--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -519,7 +519,7 @@ impl HttpServer {
         // Query key status
         let key_status = {
             let center = &state.center;
-            let res = center.key_manager.on_status(center, name.clone()).await;
+            let res = center.key_manager.on_status(center, &zone).await;
 
             let (Ok(output) | Err(output)) = res;
 
@@ -903,7 +903,7 @@ impl HttpServer {
 
                 center.key_manager.on_zone_policy_changed(
                     center,
-                    zone_name.clone(),
+                    &zone.0,
                     old.clone(),
                     new.clone(),
                 );
@@ -989,9 +989,12 @@ impl HttpServer {
         Json(KeyRoll { variant, cmd }): Json<KeyRoll>,
     ) -> Json<Result<(), String>> {
         let center = &state.center;
+        let Some(zone) = center::get_zone(center, &zone) else {
+            return Json(Err(format!("Zone '{zone}' does not exist")));
+        };
         let res = center
             .key_manager
-            .on_roll_key(center, zone, variant, cmd)
+            .on_roll_key(center, &zone, variant, cmd)
             .await;
 
         Json(res)
@@ -1007,9 +1010,12 @@ impl HttpServer {
         }): Json<KeyRemove>,
     ) -> Json<Result<(), String>> {
         let center = &state.center;
+        let Some(zone) = center::get_zone(center, &zone) else {
+            return Json(Err(format!("Zone '{zone}' does not exist")));
+        };
         let res = center
             .key_manager
-            .on_remove_key(center, zone, key, force, continue_flag)
+            .on_remove_key(center, &zone, key, force, continue_flag)
             .await;
 
         Json(res)
@@ -1021,9 +1027,12 @@ impl HttpServer {
         Json(KeyGet { key_type }): Json<KeyGet>,
     ) -> Json<Result<String, String>> {
         let center = &state.center;
+        let Some(zone) = center::get_zone(center, &zone) else {
+            return Json(Err(format!("Zone '{zone}' does not exist")));
+        };
         let res = center
             .key_manager
-            .on_get_key(center, zone, key_type.to_string())
+            .on_get_key(center, &zone, key_type.to_string())
             .await;
 
         Json(res)

--- a/src/units/key_manager.rs
+++ b/src/units/key_manager.rs
@@ -6,7 +6,7 @@ use crate::policy::{KeyParameters, PolicyVersion};
 use crate::signer::ResigningTrigger;
 use crate::units::http_server::KmipServerState;
 use crate::util::AbortOnDrop;
-use crate::zone::{HistoricalEvent, ZoneHandle};
+use crate::zone::{HistoricalEvent, Zone, ZoneHandle};
 use bytes::Bytes;
 use camino::{Utf8Path, Utf8PathBuf};
 use cascade_api::keyset::{KeyRollCommand, KeyRollVariant};
@@ -91,12 +91,12 @@ impl KeyManager {
     pub async fn on_roll_key(
         &self,
         center: &Arc<Center>,
-        zone: Name<Bytes>,
+        zone: &Zone,
         roll_variant: KeyRollVariant,
         roll_cmd: KeyRollCommand,
     ) -> Result<(), String> {
         let center = center.clone();
-        let mut cmd = Self::keyset_cmd(&center, zone, RecordingMode::Record);
+        let mut cmd = Self::keyset_cmd(&center, zone.name.clone(), RecordingMode::Record);
 
         cmd.arg(match roll_variant {
             api::keyset::KeyRollVariant::Ksk => "ksk",
@@ -137,13 +137,13 @@ impl KeyManager {
     pub async fn on_remove_key(
         &self,
         center: &Arc<Center>,
-        zone: Name<Bytes>,
+        zone: &Zone,
         key: String,
         force: bool,
         continue_flag: bool,
     ) -> Result<(), String> {
         let center = center.clone();
-        let mut cmd = Self::keyset_cmd(&center, zone, RecordingMode::Record);
+        let mut cmd = Self::keyset_cmd(&center, zone.name.clone(), RecordingMode::Record);
 
         cmd.arg("remove-key").arg(key);
 
@@ -166,11 +166,11 @@ impl KeyManager {
     pub async fn on_get_key(
         &self,
         center: &Arc<Center>,
-        zone: Name<Bytes>,
+        zone: &Zone,
         key_type: String,
     ) -> Result<String, String> {
         let center = center.clone();
-        let mut cmd = Self::keyset_cmd(&center, zone, RecordingMode::Record);
+        let mut cmd = Self::keyset_cmd(&center, zone.name.clone(), RecordingMode::Record);
 
         cmd.arg("get").arg(key_type);
 
@@ -196,17 +196,17 @@ impl KeyManager {
         }
     }
 
-    pub async fn on_status(
-        &self,
-        center: &Arc<Center>,
-        zone: Name<Bytes>,
-    ) -> Result<String, String> {
+    pub async fn on_status(&self, center: &Arc<Center>, zone: &Zone) -> Result<String, String> {
         let center = center.clone();
-        let res = Self::keyset_cmd(&center, zone, RecordingMode::RecordOnlyOnWarningOrError)
-            .arg("status")
-            .arg("-v")
-            .output()
-            .await;
+        let res = Self::keyset_cmd(
+            &center,
+            zone.name.clone(),
+            RecordingMode::RecordOnlyOnWarningOrError,
+        )
+        .arg("status")
+        .arg("-v")
+        .output()
+        .await;
         match res {
             Err(KeySetCommandError { err, output, .. }) => {
                 // The dnst keyset status command failed.
@@ -232,7 +232,7 @@ impl KeyManager {
     pub fn on_zone_policy_changed(
         &self,
         center: &Arc<Center>,
-        name: Name<Bytes>,
+        zone: &Zone,
         old: Option<Arc<PolicyVersion>>,
         new: Arc<PolicyVersion>,
     ) {
@@ -245,12 +245,14 @@ impl KeyManager {
             return;
         }
 
+        let zone_name = zone.name.clone();
+
         tokio::spawn(async move {
             // Keep it simple, just send all config items to keyset even
             // if they didn't change.
             let config_commands = policy_to_commands(&center, &new);
             for c in config_commands {
-                let mut cmd = Self::keyset_cmd(&center, name.clone(), RecordingMode::Record);
+                let mut cmd = Self::keyset_cmd(&center, zone_name.clone(), RecordingMode::Record);
                 cmd.arg("set");
 
                 for a in c {
@@ -428,11 +430,11 @@ impl KeyManager {
     /// Create a keyset command with the config file for the given zone.
     fn keyset_cmd(
         center: &Arc<Center>,
-        name: Name<Bytes>,
+        zone_name: Name<Bytes>,
         recording_mode: RecordingMode,
     ) -> KeySetCommand {
         KeySetCommand::new(
-            name,
+            zone_name,
             center.clone(),
             center.config.keys_dir.clone(),
             center.config.dnst_binary_path.clone(),


### PR DESCRIPTION
This ensures that zones it is asked to work with actually exist, preventing invocations of `dnst keyset` for non-existent zones and also preventing attempts to update history when that fails for a non-exist zone.

This change was made after hitting this panic with a typo of passing the wrong zone name to a CLI command:

```
026-04-30T12:41:27.247833Z DEBUG cascaded::units::key_manager: Executing keyset command /home/ximon/dnst keyset -c /home/ximon/cascade_dir/keys/nl.cfg algorithm propagation2-complete 100
2026-04-30T12:41:27.253249Z ERROR cascaded::units::key_manager: Keyset command '/home/ximon/dnst keyset -c /home/ximon/cascade_dir/keys/nl.cfg algorithm propagation2-complete 100' returned non-zero exit code: exit status: 1 [stdout=, stderr=[/home/ximon/dnst] ERROR: Error reporting propagation complete: wrong roll state for operation


]
2026-04-30T12:41:27.253266Z ERROR cascaded::daemon: thread 'cascade-worker' (ProcessId(19412), ThreadId(63)) panicked at src/units/key_manager.rs:1218:59: called `Option::unwrap()` on a `None` value
```

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
