### PR TITLE
Show TSIG key of source in output of CLI command zone status.

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -378,7 +378,13 @@ impl Display for ZoneSource {
         match self {
             ZoneSource::None => f.write_str("<none>"),
             ZoneSource::Zonefile { path } => path.fmt(f),
-            ZoneSource::Server { addr, .. } => addr.fmt(f),
+            ZoneSource::Server { addr, tsig_key } => {
+                write!(f, "{addr}")?;
+                if let Some(tsig_key) = &tsig_key {
+                    write!(f, " with TSIG key '{tsig_key}'")?;
+                }
+                Ok(())
+            }
         }
     }
 }

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -318,7 +318,7 @@ impl std::fmt::Display for Source {
             Source::Server { addr, tsig_key } => {
                 write!(f, "{addr}")?;
                 if let Some(tsig_key) = &tsig_key {
-                    write!(f, " with  TSIG key '{}'", tsig_key.name())?;
+                    write!(f, " with TSIG key '{}'", tsig_key.name())?;
                 }
                 Ok(())
             }

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -384,10 +384,10 @@ impl HttpServer {
             source = match zone_state.loader.source.clone() {
                 loader::Source::None => api::ZoneSource::None,
                 loader::Source::Zonefile { path } => api::ZoneSource::Zonefile { path },
-                loader::Source::Server { addr, tsig_key: _ } => api::ZoneSource::Server {
-                    addr,
-                    tsig_key: None,
-                },
+                loader::Source::Server { addr, tsig_key } => {
+                    let tsig_key = tsig_key.map(|k| k.name().clone());
+                    api::ZoneSource::Server { addr, tsig_key }
+                }
             };
             unsigned_review_addr = state
                 .center


### PR DESCRIPTION
- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
