### PR TITLE
Soft halt

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -816,8 +816,21 @@ pub struct KeyManagerPolicyInfo {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct ReviewPolicyInfo {
-    pub required: bool,
-    pub cmd_hook: Option<String>,
+    pub mode: ReviewPolicyMode,
+    pub on_reject: ReviewPolicyOnReject,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum ReviewPolicyMode {
+    Off,
+    Manual,
+    Script { hook: String },
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum ReviewPolicyOnReject {
+    Discard,
+    Halt,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/crates/cli/src/ansi.rs
+++ b/crates/cli/src/ansi.rs
@@ -12,4 +12,5 @@ pub const CYAN: &str = "\x1b[0;36m";
 pub const WHITE: &str = "\x1b[0;37m";
 pub const GRAY: &str = "\x1b[38;5;248m";
 pub const RESET: &str = "\x1b[0m";
+pub const DIM: &str = "\x1b[2m";
 pub const ITALIC: &str = "\x1b[3m";

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -1,3 +1,5 @@
+use cascade_api::ReviewPolicyMode;
+
 use crate::{
     ansi,
     api::{
@@ -131,11 +133,14 @@ fn print_policy(p: &PolicyInfo) {
 
     fn print_review(r: &ReviewPolicyInfo) {
         println!("    review:");
-        println!("      required: {}", r.required);
-        println!(
-            "      cmd_hook: {}",
-            r.cmd_hook.as_ref().cloned().unwrap_or("<none>".into())
-        );
+        match &r.mode {
+            ReviewPolicyMode::Off => println!("      mode: off"),
+            ReviewPolicyMode::Manual => println!("      mode: manual"),
+            ReviewPolicyMode::Script { hook } => {
+                println!("      mode: script");
+                println!("      hook: {hook}")
+            }
+        }
     }
 
     fn print_nameserver_comms_policy(n: &[NameserverCommsPolicyInfo]) {

--- a/crates/cli/src/commands/zone.rs
+++ b/crates/cli/src/commands/zone.rs
@@ -545,24 +545,20 @@ impl Zone {
         println!("policy: {}", zone.policy);
         println!("source: {}", zone.source);
 
-        let loader_review = if !policy.loader.review.required {
-            "none"
-        } else if let Some(hook) = &policy.loader.review.cmd_hook {
-            hook
-        } else {
-            "manual"
+        let loader_review = match &policy.loader.review.mode {
+            ReviewPolicyMode::Off => "off",
+            ReviewPolicyMode::Script { hook } => &format!("script `{hook}`"),
+            ReviewPolicyMode::Manual => "manual",
         };
 
-        let signer_review = if !policy.signer.review.required {
-            "none"
-        } else if let Some(hook) = &policy.signer.review.cmd_hook {
-            hook
-        } else {
-            "manual"
+        let signer_review = match &policy.signer.review.mode {
+            ReviewPolicyMode::Off => "off",
+            ReviewPolicyMode::Script { hook } => &format!("script `{hook}`"),
+            ReviewPolicyMode::Manual => "manual",
         };
 
         println!("");
-        println!("review hooks");
+        println!("review");
         println!("  loaded: {loader_review}");
         println!("  signed: {signer_review}");
         println!("");
@@ -712,11 +708,17 @@ fn print_loaded_review_phase(
     policy: &PolicyInfo,
     current: Progress,
 ) {
-    use ansi::{BLUE, RED, RESET, YELLOW};
+    use ansi::{BLUE, DIM, RED, RESET, YELLOW};
+
+    if let ReviewPolicyMode::Off = policy.loader.review.mode {
+        println!("  {Pending} {DIM}review loaded zone (disabled){RESET}");
+        return;
+    }
+
     if current < Progress::LoadedReview {
         println!("  {Pending} review loaded zone");
     } else if current == Progress::LoadedReview {
-        if let Some(hook) = &policy.loader.review.cmd_hook {
+        if let ReviewPolicyMode::Script { hook } = &policy.loader.review.mode {
             println!("  {Ongoing} review loaded zone");
             println!("  |   {BLUE}automatic zone review in progress{RESET}");
             println!("  |   review hook: \"{hook}\"",);
@@ -785,11 +787,17 @@ fn print_signed_review_phase(
     policy: &PolicyInfo,
     current: Progress,
 ) {
-    use ansi::{BLUE, RED, RESET, YELLOW};
+    use ansi::{BLUE, DIM, RED, RESET, YELLOW};
+
+    if let ReviewPolicyMode::Off = policy.signer.review.mode {
+        println!("  {Pending} {DIM}review signed zone (disabled){RESET}");
+        return;
+    }
+
     if current < Progress::SignedReview {
         println!("  {Pending} review signed zone");
     } else if current == Progress::SignedReview {
-        if let Some(hook) = &policy.signer.review.cmd_hook {
+        if let ReviewPolicyMode::Script { hook } = &policy.signer.review.mode {
             println!("  {Ongoing} review signed zone");
             println!("  |   {YELLOW}automatic zone review in progress{RESET}");
             println!("  |   review hook: \"{hook}\"",);
@@ -835,12 +843,12 @@ use Icon::{Done, Error, Ongoing, Pending, Stopped};
 
 impl std::fmt::Display for Icon {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        use ansi::{BLUE, GRAY, GREEN, RED, RESET, YELLOW};
+        use ansi::{BLUE, DIM, GREEN, RED, RESET, YELLOW};
         let (color, character) = match self {
             Self::Done => (GREEN, '\u{2714}'),     // tick ✔
             Self::Ongoing => (BLUE, '\u{25CF}'),   // black circle ●
             Self::Stopped => (YELLOW, '\u{25A0}'), // black square ■
-            Self::Pending => (GRAY, '\u{25CB}'),   // white circle ○
+            Self::Pending => (DIM, '\u{25CB}'),    // white circle ○
             Self::Error => (RED, '\u{2A2F}'),      // cross ⨯
         };
         let s = format!("{color}{character}{RESET}");

--- a/doc/manual/source/man/cascaded-policy.toml.rst
+++ b/doc/manual/source/man/cascaded-policy.toml.rst
@@ -32,13 +32,13 @@ policy files, then update Cascade with ``cascade policy reload``.  Note that:
 Example
 -------
 
-.. code-block:: text
+.. code-block:: toml
 
     version = "v1"
 
     [loader]
     [loader.review]
-    required = false
+    mode = "off"
 
     [key-manager]
     ksk.validity = "365d"
@@ -87,7 +87,7 @@ Example
     type = "nsec"
 
     [signer.review]
-    required = false
+    mode = "off"
 
     [server.outbound]
     send-notify-to = []
@@ -126,18 +126,22 @@ The ``[loader.review]`` section.
 Review offers an opportunity to perform external checks on the zone contents
 loaded by Cascade.
 
-.. option:: required = false
+.. option:: mode = "off"
 
-   Whether review is required.
+   The mode for loader review.
 
-   If this is ``true``, a loaded version of a zone will not be signed or
-   published until it is approved.  If it is ``false``, loaded zones will be
-   signed immediately.  At the moment, the review hook will only be run if this
-   is set to true.
+   This can be one of the following values:
+   
+    - ``"off"`` will disable review
+    - ``"manual"`` will enable manual review via the CLI.
+    - ``"script"`` will enable automatic review via a hook. The ``hook`` field
+      must be specified in this case.
+
+   The default value is ``"off"``.
 
 .. _policy-loaded-review-cmd:
 
-.. option:: cmd-hook = ""
+.. option:: hook = ""
 
    A hook for reviewing a loaded zone. This is a path to an executable.
 
@@ -161,6 +165,18 @@ loaded by Cascade.
    accessible to Cascade (i.e. after it has dropped privileges). Its exit code
    will determine whether the zone is approved or not.
 
+.. option:: on-reject = "discard"
+
+   What to do when a zone is rejected by review.
+  
+   This field can only be specified if ``mode``` is either ``"manual"`` or
+   ``"script"`` and can have one of the following values:
+  
+    - ``"discard"`` will discard the rejected zone and go back to an idle state
+    - ``"halt"`` will halt the pipeline until an operator either resets the pipeline
+      or overrides the rejection.
+  
+   The default value is ``"discard"``.
 
 DNSSEC key management.
 ++++++++++++++++++++++

--- a/etc/policy.template.toml
+++ b/etc/policy.template.toml
@@ -39,13 +39,17 @@ version = "v1"
 # loaded by Cascade.
 [loader.review]
 
-# Whether review is required.
+# The mode for loader review.
 #
-# If this is 'true', a loaded version of a zone will not be signed or published
-# until it is approved.  If it is 'false', loaded zones will be signed
-# immediately.  At the moment, the review hook will only be run if this is set
-# to true.
-required = false
+# This can be one of the following values:
+# 
+#  - "off" will disable review
+#  - "manual" will enable manual review via the CLI.
+#  - "script" will enable automatic review via a hook. The `hook` field must be
+#    specified in this case. 
+#
+# The default value is "off"
+mode = "off"
 
 # A hook for reviewing a loaded zone.
 #
@@ -64,8 +68,19 @@ required = false
 # The command will be called from an unspecified directory, and it must be
 # accessible to Cascade (i.e. after it has dropped privileges).  Its exit code
 # will determine whether the zone is approved or not.
-#cmd-hook = "review-unsigned-zone.sh"
+#hook = "review-unsigned-zone.sh"
 
+# What to do when a zone is rejected by review.
+#
+# This field can only be specified if 'mode' is either "manual" or "script" and
+# can have one of the following values:
+#
+#  - "discard" will discard the rejected zone and go back to an idle state
+#  - "halt" will halt the pipeline until an operator either resets the pipeline
+#    or overrides the rejection.
+#
+# The default value is "discard".
+#on-reject = "discard"
 
 # DNSSEC key management.
 [key-manager]
@@ -349,12 +364,17 @@ type = "nsec"
 # How signed zones are reviewed.
 [signer.review]
 
-# Whether review is required.
+# The mode for loader review.
 #
-# If this is 'true', a signed version of a zone will not be published until it
-# is approved.  If it is 'false', signed zones will be published immediately.
-# At the moment, the review hook will only be run if this is set to true.
-required = false
+# This can be one of the following values:
+# 
+#  - "off" will disable review
+#  - "manual" will enable manual review via the CLI.
+#  - "script" will enable automatic review via a hook. The `hook` field must be
+#    specified in this case. 
+#
+# The default value is "off"
+mode = "off"
 
 # A hook for reviewing a signed zone.
 #
@@ -373,8 +393,19 @@ required = false
 # The command will be called from an unspecified directory, and it must be
 # accessible to Cascade (i.e. after it has dropped privileges).  Its exit code
 # will determine whether the zone is approved or not.
-#cmd-hook = "review-signed-zone.sh"
+#hook = "review-signed-zone.sh"
 
+# What to do when a zone is rejected by review.
+#
+# This field can only be specified if 'mode' is either "manual" or "script" and
+# can have one of the following values:
+#
+#  - "discard" will discard the rejected zone and go back to an idle state
+#  - "halt" will halt the pipeline until an operator either resets the pipeline
+#    or overrides the rejection.
+#
+# The default value is "discard".
+#on-reject = "discard"
 
 # How published zones are served.
 [server.outbound]

--- a/etc/policy.template.toml
+++ b/etc/policy.template.toml
@@ -373,7 +373,7 @@ type = "nsec"
 #  - "script" will enable automatic review via a hook. The `hook` field must be
 #    specified in this case. 
 #
-# The default value is "off"
+# The default value is "off".
 mode = "off"
 
 # A hook for reviewing a signed zone.

--- a/integration-tests/review-unsigned-zone/policies/test.toml
+++ b/integration-tests/review-unsigned-zone/policies/test.toml
@@ -3,5 +3,5 @@ version = "v1"
 # Define only the settings that we change compared to the defaults. Let all
 # other settings have their default values.
 [loader.review]
-required = true
-cmd-hook = "<INTEGRATION_TEST_DIR>/hooks/approve.sh"
+mode = "script"
+hook = "<INTEGRATION_TEST_DIR>/hooks/approve.sh"

--- a/integration-tests/review-unsigned-zone2/policies/review-test.toml
+++ b/integration-tests/review-unsigned-zone2/policies/review-test.toml
@@ -8,12 +8,12 @@
 version = "v1"
 
 [loader.review]
-required = true
-cmd-hook = "<INTEGRATION_TEST_DIR>/hooks/unsigned-review-compare-to-original"
+mode = "script"
+hook = "<INTEGRATION_TEST_DIR>/hooks/unsigned-review-compare-to-original"
 
 [signer.review]
-required = true
-cmd-hook = "<INTEGRATION_TEST_DIR>/hooks/signed-review-compare-to-original"
+mode = "script"
+hook = "<INTEGRATION_TEST_DIR>/hooks/signed-review-compare-to-original"
 
 # How zones are signed.
 #

--- a/src/policy/file/v1.rs
+++ b/src/policy/file/v1.rs
@@ -16,7 +16,7 @@ use serde_with::{DeserializeFromStr, SerializeDisplay};
 use crate::{
     common::datetime::TimeSpan,
     policy::{
-        KeyManagerPolicy, LoaderPolicy, NameserverCommsPolicy, OutboundPolicy, PolicyVersion,
+        self, KeyManagerPolicy, LoaderPolicy, NameserverCommsPolicy, OutboundPolicy, PolicyVersion,
         ReviewPolicy, ServerPolicy, SignerDenialPolicy, SignerPolicy, SignerSerialPolicy,
     },
 };
@@ -107,7 +107,7 @@ impl Spec {
 #[serde(rename_all = "kebab-case", deny_unknown_fields, default)]
 pub struct LoaderSpec {
     /// Reviewing loaded zones.
-    pub review: ReviewSpec,
+    pub review: Option<ReviewSpec>,
 }
 
 //--- Conversion
@@ -116,14 +116,14 @@ impl LoaderSpec {
     /// Parse from this specification.
     pub fn parse(self) -> LoaderPolicy {
         LoaderPolicy {
-            review: self.review.parse(),
+            review: self.review.map_or(Default::default(), |r| r.parse()),
         }
     }
 
     /// Build into this specification.
     pub fn build(policy: &LoaderPolicy) -> Self {
         Self {
-            review: ReviewSpec::build(&policy.review),
+            review: Some(ReviewSpec::build(&policy.review)),
         }
     }
 }
@@ -817,13 +817,37 @@ impl SignerDenialSpec {
 
 /// Policy for reviewing loaded/signed zones.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields, default)]
-pub struct ReviewSpec {
-    /// Whether review is required.
-    pub required: bool,
+#[serde(tag = "mode", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum ReviewSpec {
+    /// Do not review
+    #[default]
+    Off,
 
-    /// A command hook for reviewing a new version of the zone.
-    pub cmd_hook: Option<String>,
+    /// Reset the pipeline on reject
+    #[serde(rename_all = "kebab-case")]
+    Manual {
+        #[serde(default)]
+        on_reject: OnReject,
+    },
+
+    /// Halt the pipeline on reject
+    #[serde(rename_all = "kebab-case")]
+    Script {
+        hook: String,
+        #[serde(default)]
+        on_reject: OnReject,
+    },
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OnReject {
+    /// Reset the pipeline on reject
+    #[default]
+    Discard,
+
+    /// Halt the pipeline on reject
+    Halt,
 }
 
 //--- Conversion
@@ -831,17 +855,37 @@ pub struct ReviewSpec {
 impl ReviewSpec {
     /// Parse from this specification.
     pub fn parse(self) -> ReviewPolicy {
+        let (mode, on_reject) = match self {
+            ReviewSpec::Off => (policy::ReviewMode::Off, OnReject::Discard),
+            ReviewSpec::Manual { on_reject } => (policy::ReviewMode::Manual, on_reject),
+            ReviewSpec::Script { hook, on_reject } => {
+                (policy::ReviewMode::Script { hook }, on_reject)
+            }
+        };
         ReviewPolicy {
-            required: self.required,
-            cmd_hook: self.cmd_hook,
+            mode,
+            on_reject: match on_reject {
+                OnReject::Discard => policy::OnReject::Discard,
+                OnReject::Halt => policy::OnReject::Halt,
+            },
         }
     }
 
     /// Build into this specification.
     pub fn build(policy: &ReviewPolicy) -> Self {
-        Self {
-            required: policy.required,
-            cmd_hook: policy.cmd_hook.clone(),
+        let map_on_reject = |r: &policy::OnReject| match r {
+            policy::OnReject::Discard => OnReject::Discard,
+            policy::OnReject::Halt => OnReject::Halt,
+        };
+        match policy.mode.clone() {
+            policy::ReviewMode::Off => ReviewSpec::Off,
+            policy::ReviewMode::Manual => ReviewSpec::Manual {
+                on_reject: map_on_reject(&policy.on_reject),
+            },
+            policy::ReviewMode::Script { hook } => ReviewSpec::Script {
+                hook,
+                on_reject: map_on_reject(&policy.on_reject),
+            },
         }
     }
 }

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -422,20 +422,28 @@ pub enum SignerDenialPolicy {
 //----------- ReviewPolicy -----------------------------------------------------
 
 /// Policy for reviewing loaded/signed zones.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ReviewPolicy {
-    /// Whether review is required.
-    ///
-    /// If this is `false`, zones under this policy will not wait for external
-    /// approval of new versions when they are loaded / signed.
-    pub required: bool,
+    pub mode: ReviewMode,
 
-    /// A command hook for reviewing a new version of the zone.
-    ///
-    /// When a new loaded / signed version of the zone is prepared, this hook
-    /// (if [`Some`]) will be spawned to verify the zone.  If review is required
-    /// and the hook fails, the zone will not be propagated.
-    pub cmd_hook: Option<String>,
+    pub on_reject: OnReject,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum ReviewMode {
+    #[default]
+    Off,
+    Manual,
+    Script {
+        hook: String,
+    },
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum OnReject {
+    #[default]
+    Discard,
+    Halt,
 }
 
 //----------- ServerPolicy -----------------------------------------------------

--- a/src/state/v1.rs
+++ b/src/state/v1.rs
@@ -8,6 +8,7 @@ use domain::base::Name;
 use domain::base::Ttl;
 use serde::{Deserialize, Serialize};
 
+use crate::policy;
 use crate::policy::file::v1::NameserverCommsSpec;
 use crate::policy::file::v1::OutboundSpec;
 use crate::policy::{AutoConfig, DsAlgorithm, KeyParameters};
@@ -464,11 +465,22 @@ impl SignerDenialPolicySpec {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct ReviewPolicySpec {
-    /// Whether review is required.
-    pub required: bool,
+    pub mode: ReviewMode,
 
-    /// A command hook for reviewing a new version of the zone.
-    pub cmd_hook: Option<String>,
+    pub on_reject: OnReject,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum ReviewMode {
+    Off,
+    Manual,
+    Script { hook: String },
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum OnReject {
+    Discard,
+    Halt,
 }
 
 //--- Conversion
@@ -477,16 +489,30 @@ impl ReviewPolicySpec {
     /// Parse from this specification.
     pub fn parse(self) -> ReviewPolicy {
         ReviewPolicy {
-            required: self.required,
-            cmd_hook: self.cmd_hook,
+            mode: match self.mode {
+                ReviewMode::Off => policy::ReviewMode::Off,
+                ReviewMode::Manual => policy::ReviewMode::Manual,
+                ReviewMode::Script { hook } => policy::ReviewMode::Script { hook },
+            },
+            on_reject: match self.on_reject {
+                OnReject::Discard => policy::OnReject::Discard,
+                OnReject::Halt => policy::OnReject::Halt,
+            },
         }
     }
 
     /// Build into this specification.
     pub fn build(policy: &ReviewPolicy) -> Self {
         Self {
-            required: policy.required,
-            cmd_hook: policy.cmd_hook.clone(),
+            mode: match policy.mode.clone() {
+                policy::ReviewMode::Off => ReviewMode::Off,
+                policy::ReviewMode::Manual => ReviewMode::Manual,
+                policy::ReviewMode::Script { hook } => ReviewMode::Script { hook },
+            },
+            on_reject: match policy.on_reject {
+                policy::OnReject::Discard => OnReject::Discard,
+                policy::OnReject::Halt => OnReject::Halt,
+            },
         }
     }
 }

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -929,8 +929,15 @@ impl HttpServer {
         let zones = p.zones.iter().cloned().collect();
         let loader = LoaderPolicyInfo {
             review: ReviewPolicyInfo {
-                required: p.latest.loader.review.required,
-                cmd_hook: p.latest.loader.review.cmd_hook.clone(),
+                mode: match p.latest.loader.review.mode.clone() {
+                    crate::policy::ReviewMode::Off => ReviewPolicyMode::Off,
+                    crate::policy::ReviewMode::Manual => ReviewPolicyMode::Manual,
+                    crate::policy::ReviewMode::Script { hook } => ReviewPolicyMode::Script { hook },
+                },
+                on_reject: match p.latest.loader.review.on_reject {
+                    crate::policy::OnReject::Discard => ReviewPolicyOnReject::Discard,
+                    crate::policy::OnReject::Halt => ReviewPolicyOnReject::Halt,
+                },
             },
         };
 
@@ -948,8 +955,15 @@ impl HttpServer {
                 SignerDenialPolicy::NSec3 { opt_out } => SignerDenialPolicyInfo::NSec3 { opt_out },
             },
             review: ReviewPolicyInfo {
-                required: p.latest.signer.review.required,
-                cmd_hook: p.latest.signer.review.cmd_hook.clone(),
+                mode: match p.latest.signer.review.mode.clone() {
+                    crate::policy::ReviewMode::Off => ReviewPolicyMode::Off,
+                    crate::policy::ReviewMode::Manual => ReviewPolicyMode::Manual,
+                    crate::policy::ReviewMode::Script { hook } => ReviewPolicyMode::Script { hook },
+                },
+                on_reject: match p.latest.signer.review.on_reject {
+                    crate::policy::OnReject::Discard => ReviewPolicyOnReject::Discard,
+                    crate::policy::OnReject::Halt => ReviewPolicyOnReject::Halt,
+                },
             },
         };
 

--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -34,7 +34,7 @@ use crate::config::SocketConfig;
 use crate::daemon::SocketProvider;
 use crate::manager::Terminated;
 use crate::manager::record_zone_event;
-use crate::policy::NameserverCommsPolicy;
+use crate::policy::{NameserverCommsPolicy, OnReject, ReviewMode};
 use crate::server::{LoadedReviewServer, PublicationServer, SignedReviewServer};
 use crate::util::AbortOnDrop;
 use crate::zone::{
@@ -295,7 +295,7 @@ impl ZoneServer {
         };
 
         let zone_name = &zone.name;
-        if !review.required {
+        if let ReviewMode::Off = review.mode {
             // Approve immediately.
             match self.source {
                 Source::Unsigned => {
@@ -348,18 +348,21 @@ impl ZoneServer {
 
         record_zone_event(center, zone, pending_event, Some(zone_serial));
 
-        if review.cmd_hook.is_none() || review_server.is_none() {
-            match (review_server, review.cmd_hook) {
-                (None, None) => warn!(
-                    "[{unit_name}] Review required, but neither a review server nor a review hook is set; use the CLI to approve or reject the zone"
-                ),
-                (None, Some(_)) => warn!(
+        if ReviewMode::Off == review.mode
+            || ReviewMode::Manual == review.mode
+            || review_server.is_none()
+        {
+            match (review_server, review.mode) {
+                (None, ReviewMode::Script { .. }) => warn!(
                     "[{unit_name}] Review required, but no review server configured; use the CLI to approve or reject the zone"
                 ),
-                (Some(_), None) => {
+                (None, _) => warn!(
+                    "[{unit_name}] Review required, but neither a review server nor a review hook is set; use the CLI to approve or reject the zone"
+                ),
+                (Some(_), ReviewMode::Off | ReviewMode::Manual) => {
                     info!("[{unit_name}] No review hook set; waiting for manual review")
                 }
-                (Some(_), Some(_)) => unreachable!(),
+                (Some(_), ReviewMode::Script { .. }) => unreachable!(),
             }
             info!(
                 "[{unit_name}]: Approve with command: cascade zone approve --{zone_type} {zone_name} {zone_serial}"
@@ -370,7 +373,9 @@ impl ZoneServer {
             return None;
         }
 
-        let hook = review.cmd_hook.unwrap();
+        let ReviewMode::Script { hook } = review.mode else {
+            panic!()
+        };
         let review_server = review_server.unwrap();
 
         // TODO: Windows support?
@@ -589,14 +594,25 @@ impl ZoneServer {
                         "Unsigned zone '{zone_name}' with serial {zone_serial} has been rejected."
                     );
 
-                    // TODO: Whether to soft or hard reject should be part of the policy
                     let mut state = zone.state.lock().unwrap();
-                    ZoneHandle {
-                        zone,
-                        state: &mut state,
-                        center,
+                    match state.policy.as_ref().unwrap().loader.review.on_reject {
+                        OnReject::Discard => {
+                            ZoneHandle {
+                                zone,
+                                state: &mut state,
+                                center,
+                            }
+                            .soft_reject_loaded();
+                        }
+                        OnReject::Halt => {
+                            ZoneHandle {
+                                zone,
+                                state: &mut state,
+                                center,
+                            }
+                            .hard_reject_loaded();
+                        }
                     }
-                    .hard_reject_loaded();
                 }
             }
 
@@ -634,12 +650,24 @@ impl ZoneServer {
                     );
                     // TODO: Whether to soft or hard reject should be part of the policy
                     let mut state = zone.state.lock().unwrap();
-                    ZoneHandle {
-                        zone,
-                        state: &mut state,
-                        center,
+                    match state.policy.as_ref().unwrap().signer.review.on_reject {
+                        OnReject::Discard => {
+                            ZoneHandle {
+                                zone,
+                                state: &mut state,
+                                center,
+                            }
+                            .soft_reject_signed();
+                        }
+                        OnReject::Halt => {
+                            ZoneHandle {
+                                zone,
+                                state: &mut state,
+                                center,
+                            }
+                            .hard_reject_signed();
+                        }
                     }
-                    .hard_reject_signed();
                 }
             }
 

--- a/src/zone/machine.rs
+++ b/src/zone/machine.rs
@@ -199,7 +199,6 @@ impl<'a> ZoneHandle<'a> {
         self.persistence().start_loaded_persistence(persister);
     }
 
-    #[expect(dead_code)]
     pub(crate) fn soft_reject_loaded(&mut self) {
         self.state.record_event(
             HistoricalEvent::UnsignedZoneReview {
@@ -215,6 +214,7 @@ impl<'a> ZoneHandle<'a> {
         };
 
         transition.move_to(ZoneStateMachine::Waiting(loaded.soft_reject()));
+        self.storage().abandon_loaded_review();
     }
 
     pub(crate) fn hard_reject_loaded(&mut self) {
@@ -343,7 +343,6 @@ impl<'a> ZoneHandle<'a> {
         self.persistence().start_signed_persistence(persister);
     }
 
-    #[expect(dead_code)]
     pub(crate) fn soft_reject_signed(&mut self) {
         self.state.record_event(
             HistoricalEvent::SignedZoneReview {
@@ -359,6 +358,7 @@ impl<'a> ZoneHandle<'a> {
         };
 
         transition.move_to(ZoneStateMachine::Waiting(signed.soft_reject()));
+        self.storage().abandon_signed_review();
     }
 
     pub(crate) fn hard_reject_signed(&mut self) {

--- a/src/zone/state/v1.rs
+++ b/src/zone/state/v1.rs
@@ -473,10 +473,23 @@ impl Default for SignerDenialPolicySpec {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct ReviewPolicySpec {
     /// Whether review is required.
-    pub required: bool,
+    pub mode: ReviewPolicyMode,
 
     /// A command hook for reviewing a new version of the zone.
-    pub cmd_hook: Option<String>,
+    pub on_reject: ReviewPolicyOnReject,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum ReviewPolicyMode {
+    Off,
+    Manual,
+    Script { hook: String },
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum ReviewPolicyOnReject {
+    Discard,
+    Halt,
 }
 
 //--- Conversion
@@ -485,16 +498,30 @@ impl ReviewPolicySpec {
     /// Parse from this specification.
     pub fn parse(self) -> ReviewPolicy {
         ReviewPolicy {
-            required: self.required,
-            cmd_hook: self.cmd_hook,
+            mode: match self.mode {
+                ReviewPolicyMode::Off => crate::policy::ReviewMode::Off,
+                ReviewPolicyMode::Manual => crate::policy::ReviewMode::Manual,
+                ReviewPolicyMode::Script { hook } => crate::policy::ReviewMode::Script { hook },
+            },
+            on_reject: match self.on_reject {
+                ReviewPolicyOnReject::Discard => crate::policy::OnReject::Discard,
+                ReviewPolicyOnReject::Halt => crate::policy::OnReject::Halt,
+            },
         }
     }
 
     /// Build into this specification.
     pub fn build(policy: &ReviewPolicy) -> Self {
         Self {
-            required: policy.required,
-            cmd_hook: policy.cmd_hook.clone(),
+            mode: match policy.mode.clone() {
+                crate::policy::ReviewMode::Off => ReviewPolicyMode::Off,
+                crate::policy::ReviewMode::Manual => ReviewPolicyMode::Manual,
+                crate::policy::ReviewMode::Script { hook } => ReviewPolicyMode::Script { hook },
+            },
+            on_reject: match policy.on_reject {
+                crate::policy::OnReject::Discard => ReviewPolicyOnReject::Discard,
+                crate::policy::OnReject::Halt => ReviewPolicyOnReject::Halt,
+            },
         }
     }
 }


### PR DESCRIPTION
Re-introduces soft halting based on policy settings. To achieve this, I also reworked how the review is specified in the policy files.

> [!NOTE]
> I'm aware that the documentation is not up to date. I'd like to get consensus on this new mechanism before I update that.

It works as follows (examples are for loaded review but signed works the same way):

A missing `loader.review` in the policy file means that review is turned off. A more explicit way to say the same thing is:

```toml
[loader.review]
mode = "off"
```

Then we can switch the mode to `"manual"` for CLI review:

```toml
[loader.review]
mode = "manual"
```

or we can use a script like so:

```toml
[loader.review]
mode = "script"
hook = "my_hook"
```

Both the `"manual"` and `"script"` modes can additionally have a `on-reject` field that can be set to either `"discard"` or `"halt"` (i.e. soft and hard halt, respectively, but with more descriptive names).

`"discard"` will simply throw away the rejected zone and go back to the waiting state.

```toml
[loader.review]
mode = "manual"
on-reject = "discard"
```

`"halt"` will go to a halted state like before.

```toml
[loader.review]
mode = "manual"
on-reject = "halt"
```

The default value is `"discard"`. 

I'm currently restrictive because I don't allow `hook` to be present if `mode` is not `"script"` and I don't allow `on-reject` if `mode = "off"` but we can easily change that.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?

- If you are adding/deleting man pages:
  - [ ] Did you update the `man_pages` config in `doc/manual/source/conf.py`?
  - [ ] Did you update the packaged man pages in the `Cargo.toml`?
  - [ ] Did you commit the freshly built man pages?

- If you are modifying man pages:
  - [ ] Did you commit the updated built man pages?
