### PR TITLE
Persist and restore TSIG keys for zone sources

### DIFF
--- a/src/center.rs
+++ b/src/center.rs
@@ -378,8 +378,6 @@ impl State {
         let path = config.daemon.state_file.value();
         let spec = crate::state::Spec::load(path)?;
 
-        info!("Loaded the global state file (from '{path}')");
-
         Ok(spec.parse(zones, policies))
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,10 +76,19 @@ fn main() -> ExitCode {
     // Load the global state file or build one from scratch.
     let mut zones = Default::default();
     let mut policies = Default::default();
-    let mut state = match center::State::init_from_file(&config, &mut zones, &mut policies) {
+    let state = match center::State::init_from_file(&config, &mut zones, &mut policies) {
         Ok(mut state) => {
-            // TODO: Restore the TSIG key store here, so that keys are available
-            // to the zones and policies being restored.
+            // Load the TSIG store file.
+            match state.tsig_store.init_from_file(&config) {
+                Ok(()) => debug!("Loaded the TSIG store"),
+                Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                    debug!("No TSIG store found; will create one");
+                }
+                Err(err) => {
+                    error!("Failed to load the TSIG store: {err}");
+                    return ExitCode::FAILURE;
+                }
+            }
 
             // Restore pending zones.
             for name in zones {
@@ -87,10 +96,11 @@ fn main() -> ExitCode {
                     !state.zones.contains(&name),
                     "Zone '{name}' was encountered twice"
                 );
-                let zone = match Zone::restore(&config, name, &mut state.policies) {
-                    Ok(zone) => zone,
-                    Err(_) => return ExitCode::FAILURE,
-                };
+                let zone =
+                    match Zone::restore(&config, name, &mut state.policies, &state.tsig_store) {
+                        Ok(zone) => zone,
+                        Err(_) => return ExitCode::FAILURE,
+                    };
                 state.zones.insert(ZoneByName(Arc::new(zone)));
             }
 
@@ -136,6 +146,18 @@ fn main() -> ExitCode {
             }
 
             let mut state = center::State::default();
+
+            // Load the TSIG store file.
+            match state.tsig_store.init_from_file(&config) {
+                Ok(()) => debug!("Loaded the TSIG store"),
+                Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                    debug!("No TSIG store found; will create one");
+                }
+                Err(err) => {
+                    error!("Failed to load the TSIG store: {err}");
+                    return ExitCode::FAILURE;
+                }
+            }
 
             // Load all policies.
             let mut updates = Vec::new();
@@ -185,20 +207,6 @@ fn main() -> ExitCode {
         warn!(
             "No review server configured for [signer.review], therefore no signed zone transfer available for review."
         );
-    }
-
-    // Load the TSIG store file.
-    //
-    // TODO: Track which TSIG keys are in use by zones.
-    match state.tsig_store.init_from_file(&config) {
-        Ok(()) => debug!("Loaded the TSIG store"),
-        Err(err) if err.kind() == io::ErrorKind::NotFound => {
-            debug!("No TSIG store found; will create one");
-        }
-        Err(err) => {
-            error!("Failed to load the TSIG store: {err}");
-            return ExitCode::FAILURE;
-        }
     }
 
     // Bind to listen addresses before daemonizing.

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,14 +78,25 @@ fn main() -> ExitCode {
     let mut policies = Default::default();
     let state = match center::State::init_from_file(&config, &mut zones, &mut policies) {
         Ok(mut state) => {
+            info!(
+                "Loaded the global state file (from '{}')",
+                config.daemon.state_file.value()
+            );
+
             // Load the TSIG store file.
             match state.tsig_store.init_from_file(&config) {
-                Ok(()) => debug!("Loaded the TSIG store"),
+                Ok(()) => debug!("Loaded the TSIG store (from '{}')", config.tsig_store_path),
                 Err(err) if err.kind() == io::ErrorKind::NotFound => {
-                    debug!("No TSIG store found; will create one");
+                    debug!(
+                        "TSIG store file '{}' did not exist; it will be created",
+                        config.tsig_store_path
+                    );
                 }
                 Err(err) => {
-                    error!("Failed to load the TSIG store: {err}");
+                    error!(
+                        "TSIG store file '{}' could not be read: {err}",
+                        config.tsig_store_path
+                    );
                     return ExitCode::FAILURE;
                 }
             }
@@ -117,11 +128,17 @@ fn main() -> ExitCode {
 
         Err(err) => {
             if err.kind() != io::ErrorKind::NotFound {
-                error!("Could not load the state file: {err}");
+                error!(
+                    "State file '{}' could not be read: {err}",
+                    config.daemon.state_file.value()
+                );
                 return ExitCode::FAILURE;
             }
 
-            info!("State file not found; starting from scratch");
+            info!(
+                "State file '{}' did not exist; starting from scratch",
+                config.daemon.state_file.value()
+            );
 
             // Create required subdirectories (and their parents) if they don't
             // exist. This is only needed for directories to which we write files

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -6,7 +6,6 @@ use std::{
     cmp::Ordering,
     fmt,
     hash::{Hash, Hasher},
-    io,
     sync::{Arc, Mutex},
     time::{Duration, SystemTime},
 };
@@ -26,6 +25,7 @@ use crate::{
     persistence::zone::{PersistenceState, ZonePersistenceHandle},
     policy::{Policy, PolicyVersion},
     signer::zone::{SignerState, SignerZoneHandle},
+    tsig::TsigStore,
     util::{deserialize_duration_from_secs, serialize_duration_as_secs},
     zone::machine::ZoneStateMachine,
 };
@@ -96,15 +96,19 @@ impl Zone {
         config: &Config,
         name: Name<Bytes>,
         policies: &mut foldhash::HashMap<Box<str>, Policy>,
-    ) -> io::Result<Self> {
+        tsig_store: &TsigStore,
+    ) -> Result<Self, state::LoadError> {
         let path = config.zone_state_dir.join(format!("{name}.db"));
 
         // Load the underlying state file.
         let state = match state::Spec::load(&path) {
-            Ok(spec) => spec.parse(&name, policies),
-            Err(err) => {
-                error!("Failed to load the state of zone '{name}' from '{path}': {err}");
-                return Err(err);
+            Ok(spec) => spec.parse(&name, policies, tsig_store)?,
+            Err(error) => {
+                error!("Failed to load the state of zone '{name}' from '{path}': {error}");
+                return Err(state::LoadError::Read {
+                    path: path.into(),
+                    error,
+                });
             }
         };
 

--- a/src/zone/state/mod.rs
+++ b/src/zone/state/mod.rs
@@ -2,20 +2,22 @@
 
 use std::{
     collections::hash_map,
-    fs,
+    error::Error,
+    fmt, fs,
     io::{self, BufReader},
     sync::Arc,
 };
 
 use bytes::Bytes;
 use camino::Utf8Path;
-use domain::base::Name;
+use domain::{base::Name, dep::octseq::Array};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use crate::{
     loader::zone::LoaderState,
     policy::{Policy, PolicyVersion},
+    tsig::TsigStore,
     zone::ZoneState,
 };
 
@@ -39,7 +41,8 @@ impl Spec {
         self,
         zone_name: &Name<Bytes>,
         policies: &mut foldhash::HashMap<Box<str>, Policy>,
-    ) -> ZoneState {
+        tsig_store: &TsigStore,
+    ) -> Result<ZoneState, LoadError> {
         /// Synchronize a loaded policy with global state.
         fn sync_policy(
             known_version: PolicyVersion,
@@ -93,7 +96,9 @@ impl Spec {
                 history,
             }) => {
                 let loader = LoaderState {
-                    source: source.parse(),
+                    source: source
+                        .parse(tsig_store)
+                        .map_err(LoadError::MissingSourceTsigKey)?,
                     ..Default::default()
                 };
 
@@ -106,7 +111,7 @@ impl Spec {
                 }
                 let policy = policy.map(|p| p.latest.clone());
 
-                ZoneState {
+                Ok(ZoneState {
                     policy,
                     min_expiration,
                     next_min_expiration,
@@ -119,7 +124,7 @@ impl Spec {
                     loader,
                     history,
                     ..Default::default()
-                }
+                })
             }
         }
     }
@@ -144,5 +149,67 @@ impl Spec {
     pub fn save(&self, path: &Utf8Path) -> io::Result<()> {
         let text = serde_json::to_string(self)?;
         crate::util::write_file(path, text.as_bytes())
+    }
+}
+
+//============ Errors ==========================================================
+
+//----------- LoadError --------------------------------------------------------
+
+/// An error loading a zone state file.
+#[derive(Debug)]
+pub enum LoadError {
+    /// The file could not be read.
+    Read {
+        /// The path being read from.
+        path: Box<Utf8Path>,
+
+        /// The I/O error.
+        error: io::Error,
+    },
+
+    /// The TSIG key for the zone source could not be found.
+    MissingSourceTsigKey(MissingTsigKeyError),
+}
+
+impl Error for LoadError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Read { error, .. } => Some(error),
+            Self::MissingSourceTsigKey(error) => Some(error),
+        }
+    }
+}
+
+impl fmt::Display for LoadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Read { path, error } => {
+                write!(f, "could not read the zone state file '{path}': {error}")
+            }
+            Self::MissingSourceTsigKey(error) => {
+                write!(f, "could not load the zone source setting: {error}")
+            }
+        }
+    }
+}
+
+//----------- MissingTsigKeyError ----------------------------------------------
+
+/// A TSIG key could not be found.
+///
+/// A zone's state file indicated that it was using a TSIG key, but the key
+/// could not be found in the configured TSIG key store.
+#[derive(Clone, Debug)]
+pub struct MissingTsigKeyError {
+    /// The name of the TSIG key.
+    pub name: Box<Name<Array<255>>>,
+}
+
+impl Error for MissingTsigKeyError {}
+
+impl fmt::Display for MissingTsigKeyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TSIG key '{}' could not be found", self.name)
     }
 }

--- a/src/zone/state/v1.rs
+++ b/src/zone/state/v1.rs
@@ -3,9 +3,9 @@
 use std::collections::HashSet;
 use std::net::SocketAddr;
 
-use bytes::Bytes;
 use camino::Utf8Path;
 use domain::base::{Rtype, Serial, Ttl};
+use domain::dep::octseq::Array;
 use domain::dnssec::sign::keys::keyset::UnixTime;
 use domain::{base::Name, rdata::dnssec::Timestamp};
 use serde::{Deserialize, Serialize};
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::loader::Source;
 use crate::policy::file::v1::{NameserverCommsSpec, OutboundSpec};
 use crate::policy::{AutoConfig, DsAlgorithm, KeyParameters};
+use crate::tsig::TsigStore;
 use crate::zone::HistoryItem;
 use crate::{
     policy::{
@@ -21,6 +22,8 @@ use crate::{
     },
     zone::ZoneState,
 };
+
+use super::MissingTsigKeyError;
 
 //----------- Spec -------------------------------------------------------------
 
@@ -547,7 +550,7 @@ pub enum ZoneLoadSourceSpec {
         addr: SocketAddr,
 
         /// The TSIG key to use, if any.
-        tsig_key: Option<Name<Bytes>>,
+        tsig_key: Option<Box<Name<Array<255>>>>,
     },
 }
 
@@ -555,15 +558,23 @@ pub enum ZoneLoadSourceSpec {
 
 impl ZoneLoadSourceSpec {
     /// Parse from this specification.
-    pub fn parse(self) -> Source {
+    pub fn parse(self, tsig_store: &TsigStore) -> Result<Source, MissingTsigKeyError> {
         match self {
-            Self::None => Source::None,
-            Self::Zonefile { path } => Source::Zonefile { path },
-            // TODO: Look up the TSIG key in the key store.
-            Self::Server { addr, tsig_key: _ } => Source::Server {
-                addr,
-                tsig_key: None,
-            },
+            Self::None => Ok(Source::None),
+            Self::Zonefile { path } => Ok(Source::Zonefile { path }),
+            Self::Server { addr, tsig_key } => {
+                // Look up the TSIG key from the key store.
+                let tsig_key = tsig_key
+                    .map(|name| {
+                        tsig_store
+                            .get(&name)
+                            .map(|key| key.inner.clone())
+                            .ok_or(MissingTsigKeyError { name })
+                    })
+                    .transpose()?;
+
+                Ok(Source::Server { addr, tsig_key })
+            }
         }
     }
 
@@ -574,11 +585,7 @@ impl ZoneLoadSourceSpec {
             Source::Zonefile { path } => Self::Zonefile { path },
             Source::Server { addr, tsig_key } => Self::Server {
                 addr,
-                tsig_key: tsig_key.map(|key| {
-                    let bytes = key.name().as_slice();
-                    let bytes = Bytes::copy_from_slice(bytes);
-                    Name::from_octets(bytes).unwrap()
-                }),
+                tsig_key: tsig_key.map(|key| key.name().clone().into()),
             },
         }
     }


### PR DESCRIPTION
A re-implementation of #590. GH seems confused about that PR, so it's hard to see it's original diff, but I think this is the core of it.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
