### PR TITLE
Add auto-remove-delay policy option.

### DIFF
--- a/doc/manual/build/man/cascaded-policy.toml.5
+++ b/doc/manual/build/man/cascaded-policy.toml.5
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "CASCADED-POLICY.TOML" "5" "Apr 30, 2026" "0.1.0-alpha5" "Cascade"
+.TH "CASCADED-POLICY.TOML" "5" "May 07, 2026" "0.1.0-alpha5" "Cascade"
 .SH NAME
 cascaded-policy.toml \- Cascade policy file format
 .sp
@@ -72,7 +72,7 @@ version = \(dqv1\(dq
 
 [loader]
 [loader.review]
-required = false
+mode = \(dqoff\(dq
 
 [key\-manager]
 ksk.validity = \(dq365d\(dq
@@ -96,6 +96,7 @@ csk.auto\-done = true
 algorithm.auto\-done = true
 ds\-algorithm = \(dqSHA256\(dq
 auto\-remove = true
+auto\-remove\-delay = \(dq7d\(dq
 publication\-nameservers = []
 
 [key\-manager.records]
@@ -121,7 +122,7 @@ signature\-remain\-time = \(dq1w\(dq
 type = \(dqnsec\(dq
 
 [signer.review]
-required = false
+mode = \(dqoff\(dq
 
 [server.outbound]
 send\-notify\-to = []
@@ -154,17 +155,29 @@ Review offers an opportunity to perform external checks on the zone contents
 loaded by Cascade.
 .INDENT 0.0
 .TP
-.B required = false
-Whether review is required.
+.B mode = \(dqoff\(dq
+The mode for loader review.
 .sp
-If this is \fBtrue\fP, a loaded version of a zone will not be signed or
-published until it is approved.  If it is \fBfalse\fP, loaded zones will be
-signed immediately.  At the moment, the review hook will only be run if this
-is set to true.
+This can be one of the following values:
+.INDENT 7.0
+.INDENT 3.5
+.INDENT 0.0
+.IP \(bu 2
+\fB\(dqoff\(dq\fP will disable review
+.IP \(bu 2
+\fB\(dqmanual\(dq\fP will enable manual review via the CLI.
+.IP \(bu 2
+\fB\(dqscript\(dq\fP will enable automatic review via a hook. The \fBhook\fP field
+must be specified in this case.
+.UNINDENT
+.UNINDENT
+.UNINDENT
+.sp
+The default value is \fB\(dqoff\(dq\fP\&.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B cmd\-hook = \(dq\(dq
+.B hook = \(dq\(dq
 A hook for reviewing a loaded zone. This is a path to an executable.
 .sp
 This command string will be executed in the user\(aqs shell when a new version
@@ -186,12 +199,33 @@ the zone for review, formatted as \fB<ip\-addr>:<port>\fP\&.
 \fBCASCADE_SERVER_PORT\fP: Just the port of the above server.
 .UNINDENT
 .sp
-Added in version 0.1.0\-alpha2: \fBCASCADE_SERVER_IP\fP and \fBCASCADE_SERVER_PORT\fP\&.
+New in version 0.1.0\-alpha2: \fBCASCADE_SERVER_IP\fP and \fBCASCADE_SERVER_PORT\fP\&.
 
 .sp
 The command will be called from an unspecified directory, and it must be
 accessible to Cascade (i.e. after it has dropped privileges). Its exit code
 will determine whether the zone is approved or not.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B on\-reject = \(dqdiscard\(dq
+What to do when a zone is rejected by review.
+.sp
+This field can only be specified if \fBmode\(ga\fP is either \fB\(dqmanual\(dq\fP or
+\fB\(dqscript\(dq\fP and can have one of the following values:
+.INDENT 7.0
+.INDENT 3.5
+.INDENT 0.0
+.IP \(bu 2
+\fB\(dqdiscard\(dq\fP will discard the rejected zone and go back to an idle state
+.IP \(bu 2
+\fB\(dqhalt\(dq\fP will halt the pipeline until an operator either resets the pipeline
+or overrides the rejection.
+.UNINDENT
+.UNINDENT
+.UNINDENT
+.sp
+The default value is \fB\(dqdiscard\(dq\fP\&.
 .UNINDENT
 .SS DNSSEC key management.
 .sp
@@ -341,6 +375,15 @@ deleting the files for on\-disk keys or removing it from the HSM).
 .UNINDENT
 .INDENT 0.0
 .TP
+.B auto\-remove\-delay = \(dq7d\(dq
+Delay after which expired keys will be removed when auto\-remove is true.
+.sp
+An integer value is interpreted as seconds. A string is interpreted as
+time string with a number followed by a unit (i.e. \(dqs\(dq, \(dqm\(dq, \(dqh\(dq, \(dqd\(dq,
+or \(dqw\(dq).
+.UNINDENT
+.INDENT 0.0
+.TP
 .B publication\-nameservers = []
 The set of nameservers to use when checking for RRSIG propagation during a
 key roll.
@@ -441,7 +484,7 @@ The HSM server to use.
 If this is set, the named HSM server (which must be configured via \fBcascade
 hsm add\fP) will be used for generating new DNSSEC keys.
 .sp
-See \X'tty: link https://cascade.docs.nlnetlabs.nl/en/latest/hsms.html'\fI\%https://cascade.docs.nlnetlabs.nl/en/latest/hsms.html\fP\X'tty: link' for more
+See \fI\%https://cascade.docs.nlnetlabs.nl/en/latest/hsms.html\fP for more
 information.
 .UNINDENT
 .INDENT 0.0
@@ -575,9 +618,9 @@ The type of denial\-of\-existence records to generate.
 Supported options:
 .INDENT 7.0
 .IP \(bu 2
-\fBnsec\fP: Use NSEC records (\X'tty: link https://datatracker.ietf.org/doc/html/rfc4034.html'\fI\%RFC 4034\fP\X'tty: link').
+\fBnsec\fP: Use NSEC records (\fI\%RFC 4034\fP).
 .IP \(bu 2
-\fBnsec3\fP: Use NSEC3 records (\X'tty: link https://datatracker.ietf.org/doc/html/rfc5155.html'\fI\%RFC 5155\fP\X'tty: link').
+\fBnsec3\fP: Use NSEC3 records (\fI\%RFC 5155\fP).
 .UNINDENT
 .UNINDENT
 .INDENT 0.0
@@ -677,7 +720,7 @@ Default policies directory
 .SH SEE ALSO
 .INDENT 0.0
 .TP
-.B \X'tty: link https://cascade.docs.nlnetlabs.nl'\fI\%https://cascade.docs.nlnetlabs.nl\fP\X'tty: link'
+.B \fI\%https://cascade.docs.nlnetlabs.nl\fP
 Cascade online documentation
 .TP
 \fBcascade\fP(1)

--- a/doc/manual/source/man/cascaded-policy.toml.rst
+++ b/doc/manual/source/man/cascaded-policy.toml.rst
@@ -62,6 +62,7 @@ Example
     algorithm.auto-done = true
     ds-algorithm = "SHA256"
     auto-remove = true
+    auto-remove-delay = "7d"
     publication-nameservers = []
 
     [key-manager.records]
@@ -273,6 +274,14 @@ The ``[key-manager]`` section.
 
    If this option is set, expired keys will be removed automatically (by
    deleting the files for on-disk keys or removing it from the HSM).
+
+.. option:: auto-remove-delay = "7d"
+
+    Delay after which expired keys will be removed when auto-remove is true.
+
+    An integer value is interpreted as seconds. A string is interpreted as
+    time string with a number followed by a unit (i.e. "s", "m", "h", "d",
+    or "w").
 
 .. option:: publication-nameservers = []
 

--- a/etc/policy.template.toml
+++ b/etc/policy.template.toml
@@ -167,9 +167,14 @@ ds-algorithm = "SHA-256"
 #
 # If this is set, expired keys will be removed automatically (by deleting the
 # files for on-disk keys or removing it from the HSM).
-#
-# TODO: Perhaps support removing keys after a certain delay?
 auto-remove = true
+
+# Delay after which expired keys will be removed when auto-remove is true.
+#
+# An integer value is interpreted as seconds. A string is interpreted as
+# time string with a number followed by a unit (i.e. "s", "m", "h", "d",
+# or "w").
+auto-remove-delay = "7d"
 
 # The set of nameservers to use when checking for RRSIG propagation during a
 # key roll.

--- a/src/policy/file/v1.rs
+++ b/src/policy/file/v1.rs
@@ -57,7 +57,7 @@ const SIGNATURE_REFRESH_INTERVAL: u32 = 12 * 3600;
 // sign more records.
 const KEY_ROLL_TIME: u32 = 24 * 3600;
 
-// When auto remove is enable, remove old keys after one week.
+// When auto remove is enabled, remove old keys after one week.
 const AUTO_REMOVE_DELAY: u32 = 7 * 24 * 3600;
 
 //----------- Spec -------------------------------------------------------------

--- a/src/policy/file/v1.rs
+++ b/src/policy/file/v1.rs
@@ -1,5 +1,6 @@
 //! Version 1 of the policy file.
 
+use std::time::Duration;
 use std::{
     fmt::{self, Display},
     net::{IpAddr, SocketAddr},
@@ -55,6 +56,9 @@ const SIGNATURE_REFRESH_INTERVAL: u32 = 12 * 3600;
 // the DNSKEY RRset contains an extra KSK and how disruptive it is to
 // sign more records.
 const KEY_ROLL_TIME: u32 = 24 * 3600;
+
+// When auto remove is enable, remove old keys after one week.
+const AUTO_REMOVE_DELAY: u32 = 7 * 24 * 3600;
 
 //----------- Spec -------------------------------------------------------------
 
@@ -149,8 +153,11 @@ pub struct KeyManagerSpec {
     /// The DS hash algorithm.
     pub ds_algorithm: DsAlgorithm,
 
-    /// Automatically remove keys that are no long in use.
+    /// Automatically remove keys that are no longer in use.
     pub auto_remove: bool,
+
+    /// How long to wait before removing old keys.
+    pub auto_remove_delay: TimeSpan,
 
     /// How special DNS records are managed.
     pub records: KeyManagerRecordsSpec,
@@ -259,6 +266,7 @@ impl KeyManagerSpec {
             default_ttl: self.records.ttl.as_ttl(),
             ds_algorithm: self.ds_algorithm,
             auto_remove: self.auto_remove,
+            auto_remove_delay: Duration::from_secs(self.auto_remove_delay.as_secs().into()),
             publication_nameservers: self
                 .publication_nameservers
                 .into_iter()
@@ -295,6 +303,7 @@ impl KeyManagerSpec {
 
             ds_algorithm: policy.ds_algorithm.clone(),
             auto_remove: policy.auto_remove,
+            auto_remove_delay: TimeSpan::from_secs(policy.auto_remove_delay.as_secs() as u32),
             publication_nameservers: policy
                 .publication_nameservers
                 .iter()
@@ -348,6 +357,7 @@ impl Default for KeyManagerSpec {
             algorithm: Default::default(),
             ds_algorithm: DsAlgorithm::Sha256,
             auto_remove: true,
+            auto_remove_delay: TimeSpan::from_secs(AUTO_REMOVE_DELAY),
             publication_nameservers: Default::default(),
             records: Default::default(),
             generation: Default::default(),

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -2,6 +2,7 @@
 
 use std::fmt::{Display, Formatter};
 use std::net::SocketAddr;
+use std::time::Duration;
 use std::{fs, io, sync::Arc};
 
 use bytes::Bytes;
@@ -314,8 +315,11 @@ pub struct KeyManagerPolicy {
     /// The TTL to use when creating DNSKEY/CDS/CDNSKEY records.
     pub default_ttl: Ttl,
 
-    /// Automatically remove keys that are no long in use.
+    /// Automatically remove keys that are no longer in use.
     pub auto_remove: bool,
+
+    /// Remove keys after this amount of time.
+    pub auto_remove_delay: Duration,
 
     /// Nameservers to check for RRSIG propagation during a key roll.
     pub publication_nameservers: Vec<NameserverCommsPolicy>,

--- a/src/state/v1.rs
+++ b/src/state/v1.rs
@@ -244,6 +244,9 @@ pub struct KeyManagerPolicySpec {
     /// Automatically remove keys that are no long in use.
     auto_remove: bool,
 
+    /// Remove old keys after this amount of time.
+    auto_remove_delay: u64,
+
     /// Nameservers to check for RRSIG propagation during a key roll.
     pub publication_nameservers: Vec<NameserverCommsSpec>,
 }
@@ -273,6 +276,7 @@ impl KeyManagerPolicySpec {
             ds_algorithm: self.ds_algorithm,
             default_ttl: self.default_ttl,
             auto_remove: self.auto_remove,
+            auto_remove_delay: Duration::from_secs(self.auto_remove_delay),
             publication_nameservers: self
                 .publication_nameservers
                 .into_iter()
@@ -303,6 +307,7 @@ impl KeyManagerPolicySpec {
             ds_algorithm: policy.ds_algorithm.clone(),
             default_ttl: policy.default_ttl,
             auto_remove: policy.auto_remove,
+            auto_remove_delay: policy.auto_remove_delay.as_secs(),
             publication_nameservers: policy
                 .publication_nameservers
                 .iter()

--- a/src/units/key_manager.rs
+++ b/src/units/key_manager.rs
@@ -781,6 +781,10 @@ fn policy_to_commands(center: &Arc<Center>, policy: &PolicyVersion) -> Vec<Vec<S
         strs!["ds-algorithm", km.ds_algorithm],
         strs!["default-ttl".to_string(), km.default_ttl.as_secs(),],
         strs!["autoremove", km.auto_remove],
+        strs![
+            "autoremove-delay",
+            seconds(km.auto_remove_delay.as_secs() as u32)
+        ],
         publication_nameservers_cmd,
     ]);
     cmds

--- a/src/zone/state/v1.rs
+++ b/src/zone/state/v1.rs
@@ -246,7 +246,7 @@ pub struct KeyManagerPolicySpec {
     /// The TTL to use when creating DNSKEY/CDS/CDNSKEY records.
     default_ttl: Ttl,
 
-    /// Automatically remove keys that are no lerong in use.
+    /// Automatically remove keys that are no longer in use.
     auto_remove: bool,
 
     /// Remove old keys after this amount of time.

--- a/src/zone/state/v1.rs
+++ b/src/zone/state/v1.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashSet;
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use camino::Utf8Path;
 use domain::base::{Rtype, Serial, Ttl};
@@ -245,8 +246,11 @@ pub struct KeyManagerPolicySpec {
     /// The TTL to use when creating DNSKEY/CDS/CDNSKEY records.
     default_ttl: Ttl,
 
-    /// Automatically remove keys that are no long in use.
+    /// Automatically remove keys that are no lerong in use.
     auto_remove: bool,
+
+    /// Remove old keys after this amount of time.
+    auto_remove_delay: u64,
 
     /// Nameservers to check for RRSIG propagation during a key roll.
     publication_nameservers: Vec<NameserverCommsSpec>,
@@ -277,6 +281,7 @@ impl KeyManagerPolicySpec {
             ds_algorithm: self.ds_algorithm,
             default_ttl: self.default_ttl,
             auto_remove: self.auto_remove,
+            auto_remove_delay: Duration::from_secs(self.auto_remove_delay),
             publication_nameservers: self
                 .publication_nameservers
                 .into_iter()
@@ -307,6 +312,7 @@ impl KeyManagerPolicySpec {
             ds_algorithm: policy.ds_algorithm.clone(),
             default_ttl: policy.default_ttl,
             auto_remove: policy.auto_remove,
+            auto_remove_delay: policy.auto_remove_delay.as_secs(),
             publication_nameservers: policy
                 .publication_nameservers
                 .iter()


### PR DESCRIPTION
Auto remove delay was added to keyset a while ago but never made it to Cascade.
---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?

