### PR TITLE
On restart populate the zones field in Policy.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,18 @@ fn main() -> ExitCode {
                     (name, policy)
                 }));
 
+            // Update policy.zones
+            for zone in &state.zones {
+                let zone_state = zone.0.state.lock().expect("zone state lock should work");
+                if let Some(ref policy) = zone_state.policy {
+                    let pol = state
+                        .policies
+                        .get_mut(&policy.name)
+                        .expect("zone policy should exist");
+                    pol.zones.insert(zone.0.name.clone());
+                }
+            }
+
             state
         }
 


### PR DESCRIPTION
Populate the zones field in Policy. This should fix the bug where zones cannot be removed after a restart.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?

