### PR TITLE
Recompute the resign timer when policy changes.

### DIFF
--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -910,6 +910,10 @@ impl HttpServer {
             }
         }
 
+        // We should have an on_zone_policy_changed per zone. For now, just
+        // call it once.
+        center.signer.on_zone_policy_changed();
+
         let mut changes: Vec<(String, _)> =
             changes.into_iter().map(|(p, c)| (p.into(), c)).collect();
         changes.sort_unstable_by(|l, r| l.0.cmp(&r.0));

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -275,6 +275,13 @@ impl ZoneSigner {
         let _ = self.next_resign_time_tx.send(self.next_resign_time(center));
     }
 
+    pub fn on_zone_policy_changed(&self) {
+        // Just recompute the resign timer. In the future we may want to
+        // react to changes in policy, for example, whether NSEC is used
+        // or NSEC3.
+        let _ = self.next_resign_time_tx.send(Some(Instant::now()));
+    }
+
     /// Enqueue a zone for signing, waiting until it can begin.
     pub async fn wait_to_sign(
         &self,


### PR DESCRIPTION
Recompute the resign timer when policy changes.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?

