### PR TITLE
Show zone server addrs

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -762,6 +762,9 @@ impl fmt::Display for ZoneReloadError {
 pub struct ServerStatusResult {
     pub halted_zones: Vec<(ZoneName, String)>,
     pub signing_queue: Vec<SigningQueueReport>,
+    pub loaded_review_addrs: Vec<SocketAddr>,
+    pub signed_review_addrs: Vec<SocketAddr>,
+    pub server_addrs: Vec<SocketAddr>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -452,13 +452,13 @@ pub struct ZoneStatus {
     pub receipt_report: Option<ZoneLoaderReport>,
     pub unsigned_serial: Option<Serial>,
     pub unsigned_review_status: Option<TimestampedZoneReviewStatus>,
-    pub unsigned_review_addr: Option<SocketAddr>,
+    pub unsigned_review_addr: Vec<SocketAddr>,
     pub signed_serial: Option<Serial>,
     pub signed_review_status: Option<TimestampedZoneReviewStatus>,
-    pub signed_review_addr: Option<SocketAddr>,
+    pub signed_review_addr: Vec<SocketAddr>,
     pub signing_report: Option<SigningReport>,
     pub published_serial: Option<Serial>,
-    pub publish_addr: SocketAddr,
+    pub publish_addr: Vec<SocketAddr>,
     pub halted_reason: Option<String>,
 }
 

--- a/crates/cli/src/commands/status.rs
+++ b/crates/cli/src/commands/status.rs
@@ -1,7 +1,9 @@
+use std::net::SocketAddr;
+
 use crate::ansi;
 use crate::api::{KeyMsg, KeyStatusResult, KeysPerZone, ServerStatusResult, SigningStageReport};
 use crate::client::CascadeApiClient;
-use crate::{eprintln, println};
+use crate::println;
 
 #[derive(Clone, Debug, clap::Args)]
 pub struct Status {
@@ -59,12 +61,32 @@ impl Status {
             None => {
                 let response: ServerStatusResult = client.get_json("/status").await?;
 
-                if !response.halted_zones.is_empty() {
-                    eprintln!("The following zones are halted:");
-                    for (zone_name, err) in response.halted_zones {
-                        eprintln!("   {}\u{78}{} {zone_name}: {err}", ansi::RED, ansi::RESET);
+                let print_addrs = |addrs: &[SocketAddr]| {
+                    if addrs.is_empty() {
+                        println!(" <none>");
+                    } else {
+                        println!();
                     }
-                    eprintln!();
+                    for addr in addrs {
+                        println!("    - {addr}");
+                    }
+                };
+
+                println!("Serving zones at the following addresses:");
+                print!("  Loaded review:");
+                print_addrs(&response.loaded_review_addrs);
+                print!("  Signed review: ");
+                print_addrs(&response.signed_review_addrs);
+                print!("  Server: ");
+                print_addrs(&response.server_addrs);
+                println!();
+
+                if !response.halted_zones.is_empty() {
+                    println!("The following zones are halted:");
+                    for (zone_name, err) in response.halted_zones {
+                        println!("   {}\u{78}{} {zone_name}: {err}", ansi::RED, ansi::RESET);
+                    }
+                    println!();
                 }
 
                 println!("Signing queue:");

--- a/crates/cli/src/commands/zone.rs
+++ b/crates/cli/src/commands/zone.rs
@@ -644,7 +644,10 @@ impl Zone {
 
         if zone.last_published.is_some() {
             println!("");
-            println!("Published zone available at {}", zone.publish_addr);
+            println!("Published zone available at:");
+            for addr in zone.publish_addr {
+                println!("  - {addr}")
+            }
         }
 
         if let Some(error) = zone.error {
@@ -719,14 +722,26 @@ pub fn print_status(current: Progress, zone: &ZoneStatus, policy: &PolicyInfo) {
     }
 
     print_load_phase(current, zone.unsigned_serial, &zone.receipt_report);
-    print_loaded_review_phase(&zone.name, zone.unsigned_serial, policy, current);
+    print_loaded_review_phase(
+        &zone.name,
+        zone.unsigned_serial,
+        policy,
+        current,
+        &zone.unsigned_review_addr,
+    );
     print_sign_phase(
         current,
         zone.unsigned_serial,
         zone.signed_serial,
         &zone.signing_report,
     );
-    print_signed_review_phase(&zone.name, zone.signed_serial, policy, current);
+    print_signed_review_phase(
+        &zone.name,
+        zone.signed_serial,
+        policy,
+        current,
+        &zone.signed_review_addr,
+    );
     print_publish_phase();
 }
 
@@ -787,6 +802,7 @@ fn print_loaded_review_phase(
     serial: Option<Serial>,
     policy: &PolicyInfo,
     current: Progress,
+    addrs: &[SocketAddr],
 ) {
     use ansi::{BLUE, DIM, RED, RESET, YELLOW};
 
@@ -807,6 +823,14 @@ fn print_loaded_review_phase(
             let serial = serial.map_or_else(|| "<SERIAL>".into(), |s| s.to_string());
             println!("  {Stopped} review loaded zone");
             println!("  |   {YELLOW}zone must be reviewed manually{RESET}");
+            if addrs.is_empty() {
+                println!("  |   {RED}no loaded review addresses were specified{RESET}");
+            } else {
+                println!("  |   loaded zone is available at:");
+                for addr in addrs {
+                    println!("  |     - {addr}");
+                }
+            }
             println!("  |   possible actions:");
             println!("  |     {BLUE}cascade zone approve --unsigned {zone} {serial}{RESET}");
             println!("  |     {BLUE}cascade zone reject --unsigned {zone} {serial}{RESET}");
@@ -866,6 +890,7 @@ fn print_signed_review_phase(
     signed_serial: Option<Serial>,
     policy: &PolicyInfo,
     current: Progress,
+    addrs: &[SocketAddr],
 ) {
     use ansi::{BLUE, DIM, RED, RESET, YELLOW};
 
@@ -885,6 +910,14 @@ fn print_signed_review_phase(
             let serial = signed_serial.map_or_else(|| "<SERIAL>".into(), |s| s.to_string());
             println!("  {Stopped} review signed zone");
             println!("  |   {YELLOW}zone must be reviewed manually{RESET}");
+            if addrs.is_empty() {
+                println!("  |   {RED}no signed review addresses were specified{RESET}");
+            } else {
+                println!("  |   signed zone is available at:");
+                for addr in addrs {
+                    println!("  |     - {addr}");
+                }
+            }
             println!("  |   possible actions:");
             println!("  |     {BLUE}cascade zone approve --signed {zone} {serial}{RESET}");
             println!("  |     {BLUE}cascade zone reject --signed {zone} {serial}{RESET}");

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -229,9 +229,17 @@ impl HttpServer {
         // Fetch the signing queue.
         let signing_queue = center.signer.on_queue_report(center);
 
+        let f = |x: &Vec<cascade_cfg::SocketConfig>| x.iter().map(|s| s.addr()).collect::<Vec<_>>();
+        let loaded_review_addrs = f(&center.config.loader.review.servers);
+        let signed_review_addrs = f(&center.config.signer.review.servers);
+        let server_addrs = f(&center.config.server.servers);
+
         Json(ServerStatusResult {
             halted_zones,
             signing_queue,
+            loaded_review_addrs,
+            signed_review_addrs,
+            server_addrs,
         })
     }
 

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -412,24 +412,26 @@ impl HttpServer {
                 .loader
                 .review
                 .servers
-                .first()
-                .map(|v| v.addr());
+                .iter()
+                .map(|s| s.addr())
+                .collect();
             signed_review_addr = state
                 .center
                 .config
                 .signer
                 .review
                 .servers
-                .first()
-                .map(|v| v.addr());
+                .iter()
+                .map(|s| s.addr())
+                .collect();
             publish_addr = state
                 .center
                 .config
                 .server
                 .servers
-                .first()
-                .expect("Server must have a publish address")
-                .addr();
+                .iter()
+                .map(|s| s.addr())
+                .collect();
 
             unsigned_review_status = zone_state
                 .find_last_event(HistoricalEventType::UnsignedZoneReview, None)


### PR DESCRIPTION
Adds the addresses for the zone servers in two places:
- Show the relevant review server in `cascade zone status` we are at a manual review
- Show all addresses in `cascade status`

We now also show multiple addresses under "Published zone available at" in `zone status`.

```
❯ cascade zone status example.com
zone:   example.com
policy: foo
source: /home/terts/data/zones/example.txt

review
  loaded: manual
  signed: manual

last published
  <no versions published yet>

status: waiting for loaded review
  ✔ load (serial: 2001062501)
  ■ review loaded zone
  |   zone must be reviewed manually
  |   loaded zone is available at:
  |     - 127.0.0.1:4540
  |     - [::1]:4540
  |   possible actions:
  |     cascade zone approve --unsigned example.com 2001062501
  |     cascade zone reject --unsigned example.com 2001062501
  |
  ○ sign
  ○ review signed zone
  ○ publish

❯ cascade status
Serving zones at the following addresses:
  Loaded review:
    - 127.0.0.1:4540
    - [::1]:4540
  Signed review:
    - 127.0.0.1:4541
    - [::1]:4541
  Server:
    - 127.0.0.1:4542
    - [::1]:4542

Signing queue:
  The signing queue is currently empty.
```

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
