### PR TITLE
Signing policy check and signature refresh improvements.

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -779,6 +779,7 @@ pub struct KeyMsg {
 pub enum PolicyReloadError {
     Io(Utf8PathBuf, String),
     NoSuchTsigKey(TsigKeyName),
+    BadValue(String),
 }
 
 impl Display for PolicyReloadError {
@@ -786,6 +787,7 @@ impl Display for PolicyReloadError {
         match self {
             PolicyReloadError::Io(p, e) => write!(f, "{p}: {e}"),
             PolicyReloadError::NoSuchTsigKey(k) => write!(f, "no TSIG key with name '{k}' exists"),
+            PolicyReloadError::BadValue(e) => write!(f, "bad value in policy variable: {e}"),
         }
     }
 }

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -227,6 +227,79 @@ fn check_policy(policy: &PolicyVersion, tsig_store: &TsigStore) -> Result<(), Po
             .get(tsig_name)
             .ok_or(PolicyReloadError::NoSuchTsigKey(tsig_name.clone()))?;
     }
+
+    // Check signer policy.
+
+    // sig_validity_time
+    //
+    // The maximum sig_validity_time is determined by what we can put in
+    // the expiration time. Expiration time is effectively a 32-bit signed
+    // value. So sig_validity_time has to be less then 0x8000_0000. To
+    // give ourselves some headroom, set the limit to 0x4000_0000.
+    if policy.signer.sig_validity_time >= 0x4000_0000 {
+        return Err(PolicyReloadError::BadValue(format!(
+            "signature-lifetime {} too big (>= 0x4000_0000)",
+            policy.signer.sig_validity_time
+        )));
+    }
+
+    // The minimum value of sig_validity_time is bounded by sig_remain_time
+    // and signature_refresh_interval. We get to this later.
+
+    // sig_remain_time
+    //
+    // The effective lifetime of a signature is
+    // sig_validity_time - sig_remain_time. This needs to be greater than
+    // zero. So the maximum value of sig_remain_time is bounded by
+    // sig_validity_time. We will check this later.
+    //
+    // Ideally, sig_remain_time should be larger than the maximum TTL
+    // to make sure that old signature are removed from caches before
+    // they expire. We don't have a maximum TTL value. So what the signer
+    // does is add the TTL of an RRset to sig_remain_time to determine
+    // if a signature needs to be refreshed. For this reason, the lower bound
+    // of sig_remain_time is zero. However, this does not leave any margin
+    // for error.
+
+    // signature_refresh_interval
+    //
+    // The maximum is again bounded by sig_validity_time.
+    //
+    // Each signature_refresh_interval seconds, the signer will generate a
+    // new version of the zone with some refreshed signatures. For this reason,
+    // signature_refresh_interval should not be too low. Enforce a lower
+    // bound of 60 seconds to avoid accidentally generating new zone versions
+    // at a high rate.
+    if policy.signer.signature_refresh_interval < 60 {
+        return Err(PolicyReloadError::BadValue(format!(
+            "signature-refresh-interval {} too small (< 60)",
+            policy.signer.signature_refresh_interval
+        )));
+    }
+
+    // Check if everything fits together. The effective lifetime of a
+    // signature is sig_validity_time - sig_remain_time. This needs to be
+    // greater than zero. We need to take TTL into account. Assume a reasonable
+    // TTL of one hour (3600 seconds). This could cause signing a zone to
+    // be aborted, but there is not much we can do. So now we have
+    // sig_validity_time - sig_remain_time - 3600 > 0.
+    // We sign every signature_refresh_interval so we need to take that into
+    // account as. Which gives:
+    // sig_validity_time - sig_remain_time - 3600 - signature_refresh_interval > 0
+    // Which can be written as:
+    // sig_validity_time > sig_remain_time + 3600 + signature_refresh_interval
+    if policy.signer.sig_validity_time
+        <= policy.signer.sig_remain_time + 3600 + policy.signer.signature_refresh_interval
+    {
+        return Err(PolicyReloadError::BadValue(format!(
+            "signature-lifetime ({}) too small (<= signature-remain-time ({}) + room for TTL (3600) + signature-refresh-interval ({}))",
+            policy.signer.sig_validity_time,
+            policy.signer.sig_remain_time,
+            policy.signer.signature_refresh_interval
+        )));
+    }
+
+    // key_roll_time
     Ok(())
 }
 

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -280,14 +280,22 @@ fn check_policy(policy: &PolicyVersion, tsig_store: &TsigStore) -> Result<(), Po
     // Check if everything fits together. The effective lifetime of a
     // signature is sig_validity_time - sig_remain_time. This needs to be
     // greater than zero. We need to take TTL into account. Assume a reasonable
-    // TTL of one hour (3600 seconds). This could cause signing a zone to
-    // be aborted, but there is not much we can do. So now we have
+    // TTL of one hour (3600 seconds). So now we have
     // sig_validity_time - sig_remain_time - 3600 > 0.
     // We sign every signature_refresh_interval so we need to take that into
     // account. Which gives:
     // sig_validity_time - sig_remain_time - 3600 - signature_refresh_interval > 0
     // Which can be written as:
     // sig_validity_time > sig_remain_time + 3600 + signature_refresh_interval
+    //
+    // If an RRset has a high TTL such that
+    // sig_remain_time + TTL + signature_refresh_interval >= sig_validity_time
+    // then the signature will be refreshed every signature_refresh_interval
+    // and an error will be logged. In extreme cases, i.e. when
+    // TTL + signature_refresh_interval > sig_validity_time
+    // then validation errors may happen due to caching. However, this only
+    // affects RRsets with too high TTLs. The rest of the zone will be
+    // unaffected.
     if policy.signer.sig_validity_time
         <= policy.signer.sig_remain_time + 3600 + policy.signer.signature_refresh_interval
     {

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -254,7 +254,7 @@ fn check_policy(policy: &PolicyVersion, tsig_store: &TsigStore) -> Result<(), Po
     // sig_validity_time. We will check this later.
     //
     // Ideally, sig_remain_time should be larger than the maximum TTL
-    // to make sure that old signature are removed from caches before
+    // to make sure that old signatures are removed from caches before
     // they expire. We don't have a maximum TTL value. So what the signer
     // does is add the TTL of an RRset to sig_remain_time to determine
     // if a signature needs to be refreshed. For this reason, the lower bound

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -284,7 +284,7 @@ fn check_policy(policy: &PolicyVersion, tsig_store: &TsigStore) -> Result<(), Po
     // be aborted, but there is not much we can do. So now we have
     // sig_validity_time - sig_remain_time - 3600 > 0.
     // We sign every signature_refresh_interval so we need to take that into
-    // account as. Which gives:
+    // account. Which gives:
     // sig_validity_time - sig_remain_time - 3600 - signature_refresh_interval > 0
     // Which can be written as:
     // sig_validity_time > sig_remain_time + 3600 + signature_refresh_interval

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -300,6 +300,12 @@ fn check_policy(policy: &PolicyVersion, tsig_store: &TsigStore) -> Result<(), Po
     }
 
     // key_roll_time
+    //
+    // If the value is too high then the key roll never completes. It is not
+    // clear if there is a sensible upper bound.
+    //
+    // It is fine to set this value to zero, the key roll will just complete
+    // the next time the refresh timer expires.
     Ok(())
 }
 

--- a/src/signer/incremental.rs
+++ b/src/signer/incremental.rs
@@ -38,6 +38,7 @@ use rayon::slice::ParallelSliceMut;
 use ring::digest;
 use tokio::time::Instant;
 use tracing::debug;
+use tracing::error;
 
 use crate::center::Center;
 use crate::policy::{PolicyVersion, SignerDenialPolicy, SignerSerialPolicy};
@@ -246,13 +247,25 @@ impl WorkSpace<'_> {
         &mut self,
         iss: &mut IncrementalSigningState,
     ) -> Result<(), SignerError> {
+        // In policy we check that for a new policy the following holds:
+        // sig_validity_time > sig_remain_time + signature_refresh_interval.
+        // The calculation below is safe but ignores TTL. In general,
+        // effective_lifetime is expected to be much larger than most TTLs.
+        // If that is not true, then nothing bad will happen, but this
+        // algorithm will fail to properly spread out signature refresh.
         let effective_lifetime = Duration::from_secs(
-            (self.policy.signer.sig_validity_time - self.policy.signer.sig_remain_time) as u64,
+            (self.policy.signer.sig_validity_time
+                - self.policy.signer.sig_remain_time
+                - self.policy.signer.signature_refresh_interval) as u64,
         );
         let now = faketime_or_now();
         let now_system_time = UNIX_EPOCH + Duration::from(now.clone());
-        let min_expire =
-            now_system_time + Duration::from_secs(self.policy.signer.sig_remain_time as u64);
+
+        // Note that min_expire does not take TTL into account. We will
+        // correct for that later.
+        let min_expire = now_system_time
+            + Duration::from_secs(self.policy.signer.sig_remain_time as u64)
+            + Duration::from_secs(self.policy.signer.signature_refresh_interval as u64);
 
         let curr_last_signature_refresh = &self.local_state.last_signature_refresh;
 
@@ -279,8 +292,32 @@ impl WorkSpace<'_> {
             / effective_lifetime.as_secs_f64();
         let to_sign = to_sign.ceil() as usize;
 
+        // Check the TTL of all signatures. Just generate an error. Maybe
+        // zone versions with too high TTLs should be rejected during loading.
+        // A too high TTL causes the record to be signed each interval.
+        // With high TTLs signatures may be cached beyond expiration. We
+        // could return a failure, but that would affect the entire zone.
+        for ((owner, rtype), r) in &iss.rrsigs {
+            let ttl = r[0].ttl();
+            if self.policy.signer.sig_validity_time
+                <= self.policy.signer.sig_remain_time
+                    + ttl.as_secs()
+                    + self.policy.signer.signature_refresh_interval
+            {
+                error!(
+                    "TTL of {}/{} too large: signature-remain-time ({}) + TTL ({}) + signature-refresh-interval ({}) >= signature-lifetime ({})",
+                    owner,
+                    rtype,
+                    self.policy.signer.sig_remain_time,
+                    ttl.as_secs(),
+                    self.policy.signer.signature_refresh_interval,
+                    self.policy.signer.sig_validity_time,
+                );
+            }
+        }
+
         // Collect expiration times, owner names, and types to figure out what
-        // to sign.
+        // to sign. Subtract TTL to account for caching.
         let mut expire_sigs = vec![];
         for ((owner, rtype), r) in &iss.rrsigs {
             let min_expiration = r
@@ -290,6 +327,7 @@ impl WorkSpace<'_> {
                         panic!("Rrsig expected");
                     };
                     rrsig.expiration().to_system_time(now_system_time)
+                        - Duration::from_secs(rrsig.original_ttl().as_secs() as u64)
                 })
                 .min()
                 .expect("minimum should exist");


### PR DESCRIPTION
Consistency check for signature lifetime time, remain time and fresh interval. Improve signature refresh calculations.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?

