### PR TITLE
Add canonical_cmp to par_sort.

### DIFF
--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -580,7 +580,8 @@ impl ZoneSigner {
         // Use a stable sort; the stable sort algorithm detects runs of sorted
         // elements ('records' contains two concatenated pre-sorted runs) and
         // can efficiently sort around them.
-        records.par_sort();
+        records.par_sort_by(|e1, e2| e1.canonical_cmp(e2));
+
         let unsigned_records = records;
         let denial_time = denial_start.elapsed();
         let denial_rr_count = unsigned_records.len() - unsigned_rr_count;

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -580,7 +580,7 @@ impl ZoneSigner {
         // Use a stable sort; the stable sort algorithm detects runs of sorted
         // elements ('records' contains two concatenated pre-sorted runs) and
         // can efficiently sort around them.
-        records.par_sort_by(|e1, e2| e1.canonical_cmp(e2));
+        records.par_sort_by(CanonicalOrd::canonical_cmp);
 
         let unsigned_records = records;
         let denial_time = denial_start.elapsed();


### PR DESCRIPTION
Sorting records for signing need canonical_cmp.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?

