### PR TITLE
Send current SOA as 'unsecure hint' in the ANSWER section with a NOTIFY. (resolves #661)

### DIFF
--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
+use cascade_zonedata::{OldRecord, SoaRecord};
 use domain::base::iana::{Class, Opcode};
 use domain::base::{MessageBuilder, Name, Rtype, Serial, ToName};
 use domain::net::client::dgram::Connection;
@@ -220,7 +221,7 @@ impl ZoneServer {
         info!("[{unit_name}]: Publishing signed zone '{zone_name}' at serial {zone_serial}.",);
 
         // Move next_min_expiration to min_expiration, and determine policy.
-        let policy = {
+        let (policy, soa) = {
             // Use a block to make sure that the mutex is clearly dropped.
             let mut zone_state = zone.state.lock().unwrap();
 
@@ -230,7 +231,10 @@ impl ZoneServer {
             zone_state.next_min_expiration = None;
             zone.mark_dirty(&mut zone_state, center);
 
-            zone_state.policy.clone()
+            (
+                zone_state.policy.clone(),
+                zone_state.storage.signed_review_soa.clone().unwrap(),
+            )
         };
 
         // Send NOTIFY if configured to do so.
@@ -251,7 +255,7 @@ impl ZoneServer {
                     .iter()
                     .filter(|s| s.addr.port() != 0);
 
-                send_notify_to_addrs(zone_name.clone(), addrs, center);
+                send_notify_to_addrs(zone_name.clone(), soa.clone(), addrs, center);
             }
         }
     }
@@ -784,6 +788,7 @@ impl Notifiable for LoaderNotifier {
 
 pub fn send_notify_to_addrs<'a>(
     apex_name: StoredName,
+    soa: SoaRecord,
     notify_set: impl Iterator<Item = &'a NameserverCommsPolicy>,
     center: &Arc<Center>,
 ) {
@@ -797,6 +802,13 @@ pub fn send_notify_to_addrs<'a>(
     msg.header_mut().set_opcode(Opcode::NOTIFY);
     let mut msg = msg.question();
     msg.push((apex_name, Rtype::SOA)).unwrap();
+
+    // Include the current zone SOA as an RFC 1996 "unsecure hint" (see
+    // section 3.7) to the receiving nameserver so that it can choose to avoid
+    // sending a SOA query if it deems that it has this version of the zone
+    // already.
+    let mut msg = msg.answer();
+    msg.push(OldRecord::from(soa)).unwrap();
 
     for nameserver in notify_set {
         let dgram_config = dgram_config.clone();


### PR DESCRIPTION
With this change the `downstream-tsig` system test NSD secondary logs show the serial number being received with the NOTIFY, without it NSD logs receipt of the NOTIFY but no serial number.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
