### PR TITLE
Disable signing for non-apex DNSKEY/CDS/CDNSKEY in the incremental signer.

### DIFF
--- a/src/signer/incremental.rs
+++ b/src/signer/incremental.rs
@@ -1683,6 +1683,16 @@ impl IncrementalSigningState {
         let mut new_sigs = vec![];
         for new_rrset in self.new_data.values_mut() {
             let key = (new_rrset[0].owner().clone(), new_rrset[0].rtype());
+
+            // XXX for compatibility with the full zone signer, always
+            // ignore DNSKEY/CDS/CDNSKEY when not at apex.
+            let rtype = new_rrset[0].rtype();
+            if (rtype == Rtype::DNSKEY || rtype == Rtype::CDS || rtype == Rtype::CDNSKEY)
+                && *new_rrset[0].owner() != self.origin
+            {
+                continue;
+            }
+
             if let Some(mut old_rrset) = self.old_data.remove(&key) {
                 let rtype = new_rrset[0].rtype();
                 if (rtype == Rtype::DNSKEY || rtype == Rtype::CDS || rtype == Rtype::CDNSKEY)


### PR DESCRIPTION
Disable signing for non-apex DNSKEY/CDS/CDNSKEY in the incremental signer. This avoid confusion between the incremental signer and the full zone signer. On the whole this is not good because it breaks RFC 9615 (Automatic DNSSEC Bootstrapping Using Authenticated Signals from the Zone's Operator).

---
- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?

