### PR TITLE
Restore policies before zones

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,14 @@ fn main() -> ExitCode {
                 }
             }
 
+            // Restore pending policies.
+            state
+                .policies
+                .extend(policies.into_iter().map(|(name, spec)| {
+                    let policy = spec.parse(&name);
+                    (name, policy)
+                }));
+
             // Restore pending zones.
             for name in zones {
                 assert!(
@@ -114,14 +122,6 @@ fn main() -> ExitCode {
                     };
                 state.zones.insert(ZoneByName(Arc::new(zone)));
             }
-
-            // Restore pending policies.
-            state
-                .policies
-                .extend(policies.into_iter().map(|(name, spec)| {
-                    let policy = spec.parse(&name);
-                    (name, policy)
-                }));
 
             // Update policy.zones
             for zone in &state.zones {


### PR DESCRIPTION
Resolves #673.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?