### PR TITLE
Add missing stanza now used by all `system-test.yml` tests.

### DIFF
--- a/integration-tests/scripts/add-test.sh
+++ b/integration-tests/scripts/add-test.sh
@@ -67,4 +67,6 @@ tee -a "${workflow_file}" >/dev/null <<'EOF'
         with:
           build-profile: ${{ inputs.build-profile }}
       - uses: ./integration-tests/tests/${job}
+        with:
+          log-level: ${{ inputs.log-level }}
 EOF

--- a/integration-tests/scripts/add-test.sh
+++ b/integration-tests/scripts/add-test.sh
@@ -54,7 +54,7 @@ if [[ -n "$pr" ]]; then
   echo "  # Added for https://github.com/NLnetLabs/cascade/pull/$pr" >> "$workflow_file"
 fi
 
-tee -a "${workflow_file}" >/dev/null <<EOF
+tee -a "${workflow_file}" >/dev/null <<'EOF'
   ${job}:
     name: $description
     runs-on: ubuntu-latest
@@ -63,5 +63,8 @@ tee -a "${workflow_file}" >/dev/null <<EOF
         rust: [stable]
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/set-build-profile
+        with:
+          build-profile: ${{ inputs.build-profile }}
       - uses: ./integration-tests/tests/${job}
 EOF


### PR DESCRIPTION
When generating a new system test skeleton the generated fragment that gets added to `system-tests.yml` lacks elements that are now common to all other such stanzas in `system-tests.yml`. This PR catches the generation up with how we add tests now to `system-tests.yml`.
