### PR TITLE
Prevent crashes if a signed instance is rejected

### DIFF
--- a/crates/zonedata/src/storage/transitions.rs
+++ b/crates/zonedata/src/storage/transitions.rs
@@ -645,9 +645,9 @@ impl CleanSignedPendingStorage {
             Arc::ptr_eq(old_reviewer.data(), &self.data),
             "'old_reviewer' is for a different zone"
         );
+        // TODO: Verify 'old_review.loaded_index' appears correct.
         assert!(
-            old_reviewer.loaded_index != self.curr_loaded_index
-                && old_reviewer.signed_index != self.curr_signed_index,
+            old_reviewer.signed_index != self.curr_signed_index,
             "'old_reviewer' does not point to the new instance",
         );
 
@@ -673,9 +673,9 @@ impl CleanWholePendingStorage {
             Arc::ptr_eq(old_reviewer.data(), &self.data),
             "'old_reviewer' is for a different zone"
         );
+        // TODO: Verify 'old_review.loaded_index' appears correct.
         assert!(
-            old_reviewer.loaded_index != self.curr_loaded_index
-                && old_reviewer.signed_index != self.curr_signed_index,
+            old_reviewer.signed_index != self.curr_signed_index,
             "'old_reviewer' does not point to the new instance",
         );
 

--- a/src/zone/machine.rs
+++ b/src/zone/machine.rs
@@ -361,6 +361,10 @@ impl<'a> ZoneHandle<'a> {
         };
 
         transition.move_to(ZoneStateMachine::Waiting(signed.soft_reject()));
+
+        // TODO: This should be handled by 'Instances'.
+        self.state.next_min_expiration = None;
+
         self.storage().abandon_signed_review();
     }
 
@@ -422,10 +426,18 @@ impl<'a> ZoneHandle<'a> {
             ZoneStateMachine::HaltSigned(halt_signed) => {
                 let waiting = halt_signed.reset();
                 transition.move_to(ZoneStateMachine::Waiting(waiting));
+
+                // TODO: This should be handled by 'Instances'.
+                self.state.next_min_expiration = None;
+
                 self.storage().abandon_signed_review();
             }
             ZoneStateMachine::SigningFailed(signing_failed) => {
                 let waiting = signing_failed.reset();
+
+                // TODO: This should be handled by 'Instances'.
+                self.state.next_min_expiration = None;
+
                 transition.move_to(ZoneStateMachine::Waiting(waiting));
             }
             _ => {


### PR DESCRIPTION
Caught by @Philip-NLnetLabs; Cascade's internal state was not being updated consistently when a signed instance was rejected.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?