### PR TITLE
Fix override not starting signing

### DIFF
--- a/crates/zonedata/src/persister.rs
+++ b/crates/zonedata/src/persister.rs
@@ -10,6 +10,7 @@ use crate::{Data, DiffData, LoadedZoneReader, SignedZoneReader};
 ///
 /// A [`LoadedZonePersister`] persists a newly-approved loaded instance of a
 /// zone to disk.
+#[must_use]
 pub struct LoadedZonePersister {
     /// The underlying data.
     data: Arc<Data>,
@@ -88,6 +89,7 @@ impl LoadedZonePersister {
 ///
 /// A [`SignedZonePersister`] persists a newly-approved signed instance of a
 /// zone to disk.
+#[must_use]
 pub struct SignedZonePersister {
     /// The underlying data.
     data: Arc<Data>,

--- a/src/zone/machine.rs
+++ b/src/zone/machine.rs
@@ -344,6 +344,13 @@ impl<'a> ZoneHandle<'a> {
             None, // TODO
         );
 
+        // Move to the 'Waiting' state.
+        let (transition, state) = self.state.machine.transition();
+        let ZoneStateMachine::SignedReview(signed) = state else {
+            panic!("The zone must be in signer review")
+        };
+        transition.move_to(ZoneStateMachine::Waiting(signed.approve()));
+
         // Persist the signed instance while remaining in the 'SignedReview'
         // state. Once persistence is complete, 'switch()' will be called, which
         // will transition to the 'Waiting' state.
@@ -396,13 +403,6 @@ impl<'a> ZoneHandle<'a> {
 
     /// Finish switching to a new instance of the zone.
     pub(crate) fn finish_switch(&mut self, cleaner: cascade_zonedata::ZoneCleaner) {
-        // Move to the 'Waiting' state.
-        let (transition, state) = self.state.machine.transition();
-        let ZoneStateMachine::SignedReview(signed) = state else {
-            panic!("The zone must be in signer review")
-        };
-        transition.move_to(ZoneStateMachine::Waiting(signed.approve()));
-
         self.storage().start_cleanup(cleaner);
     }
 }

--- a/src/zone/machine.rs
+++ b/src/zone/machine.rs
@@ -206,13 +206,12 @@ impl<'a> ZoneHandle<'a> {
 
         let (transition, state) = self.state.machine.transition();
         let ZoneStateMachine::LoadedReview(loaded) = state else {
-            panic!("cannot soft reject loaded in this state");
+            panic!("cannot approve loaded in this state");
         };
         transition.move_to(ZoneStateMachine::Signing(loaded.approve()));
 
-        // Persist the loaded instance while remaining in the 'LoadedReview'
-        // state. Once persistence is complete, 'begin_signing()' will be
-        // called, which will transition to the 'Signing' state.
+        // We move to the signing state and start persisting. The actual signing
+        // will be triggered by the zone storage when persisting is done.
         let persister = self.storage().accept_loaded();
         self.persistence().start_loaded_persistence(persister);
     }
@@ -351,9 +350,9 @@ impl<'a> ZoneHandle<'a> {
         };
         transition.move_to(ZoneStateMachine::Waiting(signed.approve()));
 
-        // Persist the signed instance while remaining in the 'SignedReview'
-        // state. Once persistence is complete, 'switch()' will be called, which
-        // will transition to the 'Waiting' state.
+        // Persist the signed instance while we are already in the Waiting state.
+        // The state machine will only start a new operation when the zone storage
+        // is ready, so this is safe to do.
         let persister = self.storage().accept_signed();
         self.persistence().start_signed_persistence(persister);
     }
@@ -449,9 +448,8 @@ impl<'a> ZoneHandle<'a> {
 
         transition.move_to(ZoneStateMachine::Signing(halt.override_rejection()));
 
-        // Persist the loaded instance while remaining in the 'LoadedReview'
-        // state. Once persistence is complete, 'begin_signing()' will be
-        // called, which will transition to the 'Signing' state.
+        // We move to the signing state and start persisting. The actual signing
+        // will be triggered by the zone storage when persisting is done.
         let persister = self.storage().accept_loaded();
         self.persistence().start_loaded_persistence(persister);
 
@@ -471,9 +469,9 @@ impl<'a> ZoneHandle<'a> {
 
         transition.move_to(ZoneStateMachine::Waiting(halt_signed.override_rejection()));
 
-        // Persist the signed instance while remaining in the 'SignedReview'
-        // state. Once persistence is complete, 'switch()' will be called, which
-        // will transition to the 'Waiting' state.
+        // Persist the signed instance while we are already in the Waiting state.
+        // The state machine will only start a new operation when the zone storage
+        // is ready, so this is safe to do.
         let persister = self.storage().accept_signed();
         self.persistence().start_signed_persistence(persister);
 

--- a/src/zone/machine.rs
+++ b/src/zone/machine.rs
@@ -204,6 +204,12 @@ impl<'a> ZoneHandle<'a> {
             None, // TODO
         );
 
+        let (transition, state) = self.state.machine.transition();
+        let ZoneStateMachine::LoadedReview(loaded) = state else {
+            panic!("cannot soft reject loaded in this state");
+        };
+        transition.move_to(ZoneStateMachine::Signing(loaded.approve()));
+
         // Persist the loaded instance while remaining in the 'LoadedReview'
         // state. Once persistence is complete, 'begin_signing()' will be
         // called, which will transition to the 'Signing' state.
@@ -251,16 +257,6 @@ impl<'a> ZoneHandle<'a> {
 impl<'a> ZoneHandle<'a> {
     /// Begin signing a new approved and persisted loaded instance.
     pub(crate) fn start_new_sign(&mut self, persisted: cascade_zonedata::LoadedZonePersisted) {
-        // NOTE: The underlying state machine does not track persistence, so we
-        // only transition out of 'LoadedReview' once persistence is complete.
-        let (transition, state) = self.state.machine.transition();
-        let ZoneStateMachine::LoadedReview(loaded) = state else {
-            unreachable!(
-                "A 'LoadedZonePersisted' can only exist when the zone is in loader review"
-            );
-        };
-        transition.move_to(ZoneStateMachine::Signing(loaded.approve()));
-
         let builder = self.storage().start_new_sign(persisted);
         self.signer().enqueue_new_sign(builder);
     }
@@ -395,12 +391,6 @@ impl<'a> ZoneHandle<'a> {
 impl<'a> ZoneHandle<'a> {
     /// Begin switching to an approved instance of the zone.
     pub(crate) fn start_switch(&mut self, persisted: cascade_zonedata::SignedZonePersisted) {
-        // Make sure the current state is 'SignedReview'.
-        assert!(
-            matches!(self.state.machine, ZoneStateMachine::SignedReview(_)),
-            "A 'SignedZonePersisted' exists but the zone is not in signer review"
-        );
-
         self.storage().start_switch(persisted);
     }
 
@@ -459,7 +449,11 @@ impl<'a> ZoneHandle<'a> {
 
         transition.move_to(ZoneStateMachine::Signing(halt.override_rejection()));
 
-        self.storage().accept_loaded();
+        // Persist the loaded instance while remaining in the 'LoadedReview'
+        // state. Once persistence is complete, 'begin_signing()' will be
+        // called, which will transition to the 'Signing' state.
+        let persister = self.storage().accept_loaded();
+        self.persistence().start_loaded_persistence(persister);
 
         Ok(())
     }
@@ -477,7 +471,11 @@ impl<'a> ZoneHandle<'a> {
 
         transition.move_to(ZoneStateMachine::Waiting(halt_signed.override_rejection()));
 
-        self.storage().accept_signed();
+        // Persist the signed instance while remaining in the 'SignedReview'
+        // state. Once persistence is complete, 'switch()' will be called, which
+        // will transition to the 'Waiting' state.
+        let persister = self.storage().accept_signed();
+        self.persistence().start_signed_persistence(persister);
 
         Ok(())
     }


### PR DESCRIPTION
Override seems to be broken since we started doing persistence as the persistence was not taking into account that signing could be triggered from the halted state. To fix that, we now trigger persistence on override as well. To allow for that, I had to move the transition to the signing state to *before* the persistence instead of after. I believe this is still correct and maybe even nicer because it guards against approving or overriding twice.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
