### PR TITLE
record timestamp and number of records on publication

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -466,10 +466,9 @@ pub struct ZoneStatus {
 pub struct LastPublishedZone {
     pub loaded_serial: Serial,
     pub signed_serial: Serial,
-    // TODO:
-    //  - time of publish
-    //  - number of records
-    //  - size in bytes
+    pub timestamp: SystemTime,
+    pub num_records: usize,
+    // TODO: size in bytes
 }
 
 #[derive(Deserialize, Serialize, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/cli/src/commands/zone.rs
+++ b/crates/cli/src/commands/zone.rs
@@ -631,8 +631,11 @@ impl Zone {
         if let Some(last) = &zone.last_published {
             println!("  loaded serial: {}", last.loaded_serial);
             println!("  signed serial: {}", last.signed_serial);
-            println!("  timestamp:     <TODO>");
-            println!("  size:          <TODO> records (<TODO>B)");
+            println!(
+                "  timestamp:     {}",
+                jiff::Timestamp::try_from(last.timestamp).unwrap()
+            );
+            println!("  size:          {} records", last.num_records);
         } else {
             println!("  <no versions published yet>");
         }

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -497,6 +497,8 @@ impl HttpServer {
                 .map(|p| LastPublishedZone {
                     loaded_serial: p.loaded_serial,
                     signed_serial: p.signed_serial,
+                    num_records: p.num_records,
+                    timestamp: p.timestamp,
                 });
 
             let mut found_error = None;

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -344,10 +344,16 @@ impl Default for ZoneState {
 pub struct LastPublished {
     pub loaded_serial: Serial,
     pub signed_serial: Serial,
-    // TODO:
-    //  - time of publish
-    //  - number of records
-    //  - size in bytes
+
+    /// Time of publication
+    pub timestamp: SystemTime,
+
+    /// Number of records in the signed zone
+    pub num_records: usize,
+    //
+    // TODO: add the size
+    // /// Size in bytes
+    // pub size: usize,
 }
 
 /// The state of an unsigned version of a zone.

--- a/src/zone/storage.rs
+++ b/src/zone/storage.rs
@@ -23,7 +23,7 @@
 //! such operations must wait. When the data storage becomes passive, it will
 //! call [`StorageZoneHandle::on_passive()`] to initiate enqueued operations.
 
-use std::{fmt, sync::Arc};
+use std::{fmt, sync::Arc, time::SystemTime};
 
 use cascade_zonedata::{
     DiffData, LoadedZoneBuilder, LoadedZoneBuilt, LoadedZonePersisted, LoadedZonePersister,
@@ -737,6 +737,12 @@ impl StorageZoneHandle<'_> {
         self.state.storage.published_soa = viewer.read().map(|r| r.soa().clone());
         self.state.storage.published_loaded_soa = viewer.read().map(|r| r.loaded().soa().clone());
 
+        // Compute the total number of records
+        let reader = viewer.read().unwrap();
+        let generated_records = reader.generated_records().len();
+        let loaded_records = reader.loaded().regular_records().len();
+        let num_records = 1 + generated_records + loaded_records;
+
         // Spawn a background task to update the publication server.
         let span = trace_span!("switch_publication_server");
         let zone = self.zone.clone();
@@ -766,29 +772,34 @@ impl StorageZoneHandle<'_> {
                 _ => unreachable!("just transitioned to 'Switching'"),
             };
 
+            let loaded_serial = Serial(
+                handle
+                    .state
+                    .storage
+                    .published_loaded_soa
+                    .as_ref()
+                    .unwrap()
+                    .rdata
+                    .serial
+                    .into(),
+            );
+            let signed_serial = Serial(
+                handle
+                    .state
+                    .storage
+                    .published_soa
+                    .as_ref()
+                    .unwrap()
+                    .rdata
+                    .serial
+                    .into(),
+            );
+            let timestamp = SystemTime::now();
             handle.state.last_published = Some(LastPublished {
-                loaded_serial: Serial(
-                    handle
-                        .state
-                        .storage
-                        .published_loaded_soa
-                        .as_ref()
-                        .unwrap()
-                        .rdata
-                        .serial
-                        .into(),
-                ),
-                signed_serial: Serial(
-                    handle
-                        .state
-                        .storage
-                        .published_soa
-                        .as_ref()
-                        .unwrap()
-                        .rdata
-                        .serial
-                        .into(),
-                ),
+                loaded_serial,
+                signed_serial,
+                timestamp,
+                num_records,
             });
 
             handle.finish_switch(cleaner);


### PR DESCRIPTION
Record the timestamp and number of records in the signed zone on publication and show that in the zone status:

```
zone:   example.com
policy: foo
source: /home/terts/data/zones/example.txt

review
  loaded: manual
  signed: manual

last published
  loaded serial: 2001062501
  signed serial: 2026052902
  timestamp:     2026-05-29T12:40:47.746456816Z
  size:          44 records

status: idle

Published zone available at:
  - 127.0.0.1:4542
  - [::1]:4542
```

Doesn't include the size in bytes yet because that's harder to compute, but this is a good start and the number of records is a nice sanity check.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [ ] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
