### PR TITLE
Prepare `main` for development.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ dependencies = [
 
 [[package]]
 name = "cascade"
-version = "0.1.0-beta1"
+version = "0.1.0-beta2-dev"
 dependencies = [
  "anstream",
  "camino",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "cascade-api"
-version = "0.1.0-beta1"
+version = "0.1.0-beta2-dev"
 dependencies = [
  "bytes",
  "camino",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "cascade-cfg"
-version = "0.1.0-beta1"
+version = "0.1.0-beta2-dev"
 dependencies = [
  "camino",
  "clap",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "cascade-zonedata"
-version = "0.1.0-beta1"
+version = "0.1.0-beta2-dev"
 dependencies = [
  "bytes",
  "domain",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "cascaded"
-version = "0.1.0-beta1"
+version = "0.1.0-beta2-dev"
 dependencies = [
  "assert-json-diff",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://cascade.docs.nlnetlabs.nl"
 repository = "https://github.com/NLnetLabs/cascade"
 license = "BSD-3-Clause"
 
-version = "0.1.0-beta1"
+version = "0.1.0-beta2-dev"
 rust-version = "1.88"
 edition = "2024"
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,24 @@ Released yyyy-mm-dd.
 ### Acknowledgements
 -->
 
+## Unreleased version
+
+Released yyyy-mm-dd.
+
+### Breaking changes
+
+### New
+
+### Bug fixes
+
+### Other changes
+
+### Documentation improvements
+
+### Known issues
+
+### Acknowledgements
+
 ## 0.1.0-beta1 'Slàinte mhath'
 
 Released 2026-06-05.


### PR DESCRIPTION
Set the version so that it doesn't seem like later builds from main are also beta1.

We do this for other projects, e.g. see [here](https://github.com/NLnetLabs/routinator/commit/629c93f300f915fce05a7fa9042e65709203a3bf) for Routinator.

However:
1. I note that Routinator doesn't always do it. The link I gave above is not that recent, some interim releases didn't bump `main` to a `-dev` version suffix, though it was more recently set back to `-dev` again [here](https://github.com/NLnetLabs/routinator/commit/74fe58228fd4fa01d48f2b7b6a690a9abd7a90d4).
2. There was some discussion about this in the team which led to having git commit hashes in the build reported by `--version`. However, that is still confusing as it will still say 0.1.0-beta1 even though the commits are newer than the 0.1.0-beta1 release.

This PR also makes `Changelog.md` ready for new updates.