### PR TITLE
required=true no longer seems to exist, hence remove its mention from…

### DIFF
--- a/doc/manual/source/man/cascaded-policy.toml.rst
+++ b/doc/manual/source/man/cascaded-policy.toml.rst
@@ -149,8 +149,7 @@ loaded by Cascade.
    A hook for reviewing a loaded zone. This is a path to an executable.
 
    This command string will be executed in the user's shell when a new version
-   of a zone is loaded.  At the moment, it will only be run if ``required`` is
-   true.
+   of a zone is loaded.
 
    It will receive the following information via environment variables:
 

--- a/etc/policy.template.toml
+++ b/etc/policy.template.toml
@@ -54,7 +54,7 @@ mode = "off"
 # A hook for reviewing a loaded zone.
 #
 # This command string will be executed in the user's shell when a new version of
-# a zone is loaded.  At the moment, it will only be run if 'required' is true.
+# a zone is loaded.
 #
 # It will receive the following information via environment variables:
 #
@@ -408,7 +408,7 @@ mode = "off"
 # A hook for reviewing a signed zone.
 #
 # This command string will be executed in the user's shell when a new version of
-# a zone is signed.  At the moment, it will only be run if 'required' is true.
+# a zone is signed.
 #
 # It will receive the following information via environment variables:
 #


### PR DESCRIPTION
comments in the templated policy mention a `required` option which no longer appears to exist.