### PR TITLE
Note in CLI help that source to zone add can include a TSIG key name. (resolves #712)

### DIFF
--- a/crates/cli/src/commands/zone.rs
+++ b/crates/cli/src/commands/zone.rs
@@ -23,8 +23,8 @@ pub enum ZoneCommand {
     Add {
         name: ZoneName,
 
-        /// The zone source can be an IP address (with or without port,
-        /// defaults to port 53) or a file path.
+        /// The source to obtain the zone content from:
+        /// IP:[PORT][^TSIG_KEY_NAME] or a file path.
         // TODO: allow supplying different tcp and/or udp port?
         #[arg(long = "source")]
         source: ZoneSource,

--- a/crates/cli/src/commands/zone.rs
+++ b/crates/cli/src/commands/zone.rs
@@ -24,7 +24,8 @@ pub enum ZoneCommand {
         name: ZoneName,
 
         /// The source to obtain the zone content from:
-        /// IP:[PORT][^TSIG_KEY_NAME] or a file path.
+        /// IP:[PORT][^TSIG_KEY_NAME] (port defaults to 53) or the path to a
+        /// zone file locally available to the `cascaded` daemon.
         // TODO: allow supplying different tcp and/or udp port?
         #[arg(long = "source")]
         source: ZoneSource,

--- a/crates/cli/src/commands/zone.rs
+++ b/crates/cli/src/commands/zone.rs
@@ -24,8 +24,8 @@ pub enum ZoneCommand {
         name: ZoneName,
 
         /// The source to obtain the zone content from:
-        /// IP:[PORT][^TSIG_KEY_NAME] (port defaults to 53) or the path to a
-        /// zone file locally available to the `cascaded` daemon.
+        /// `IP:[PORT][^TSIG_KEY_NAME]` (port defaults to 53) or the path to
+        /// a zone file locally available to the `cascaded` daemon.
         // TODO: allow supplying different tcp and/or udp port?
         #[arg(long = "source")]
         source: ZoneSource,


### PR DESCRIPTION
Before:

```
$ cascade zone add --help
Usage: cascade zone add [OPTIONS] --source <SOURCE> --policy <POLICY> <NAME>
...
      --source <SOURCE>
          The zone source can be an IP address (with or without port, defaults to
          port 53) or a file path
```

After:

```
$ cascade zone add -h
Usage: cascade zone add [OPTIONS] --source <SOURCE> --policy <POLICY> <NAME>
...
      --source <SOURCE>
          The source to obtain the zone content from: IP:[PORT][^TSIG_KEY_NAME] (port
          defaults to 53) or the path to a zone file locally available to the
          `cascaded` daemon
```

The new text both includes mention of the TSIG key support and more closely matches the [ReadTheDocs zone add documentation](https://cascade.docs.nlnetlabs.nl/en/latest/man/cascade-zone.html#options-for-zone-add) noting the important point that the path if provided cannot be local to the client host but most be available on the server host.

@jpmens: Would this resolve #712 for you?