### PR TITLE
Fix position of colon ':' character in tsig add subcommand docs. (resolves #700)

### DIFF
--- a/crates/cli/src/commands/tsig.rs
+++ b/crates/cli/src/commands/tsig.rs
@@ -22,7 +22,7 @@ pub enum TsigCommand {
     Add {
         /// The name of the TSIG key to add.
         ///
-        /// Can also be in the form `[algorithm]:keyname:secret`.
+        /// Can also be in the form `[algorithm:]keyname:secret`.
         name: String,
 
         /// The TSIG algorithm to use.

--- a/doc/manual/build/man/cascade-tsig.1
+++ b/doc/manual/build/man/cascade-tsig.1
@@ -92,7 +92,7 @@ or if the key is still referenced by other configuration.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B [<ALGORITHM>]:<TSIG_KEY_NAME>:<SECRET>
+.B [<ALGORITHM>:]<TSIG_KEY_NAME>:<SECRET>
 The name of the TSIG key to add, or a complete TSIG key specification.
 .sp
 TSIG key names must be valid domain names.

--- a/doc/manual/source/man/cascade-tsig.rst
+++ b/doc/manual/source/man/cascade-tsig.rst
@@ -56,7 +56,7 @@ Arguments for :subcmd:`tsig add`
 --------------------------------
 
 .. option:: <TSIG_KEY_NAME>
-.. option:: [<ALGORITHM>]:<TSIG_KEY_NAME>:<SECRET>
+.. option:: [<ALGORITHM>:]<TSIG_KEY_NAME>:<SECRET>
 
    The name of the TSIG key to add, or a complete TSIG key specification.
 


### PR DESCRIPTION
- If you are modifying man pages:
  - [x] Did you commit the updated built man pages?
