### PR TITLE
Rename `accept-xfr-from` to `provide-xfr-to`. (resolves #702)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,9 @@ Released yyyy-mm-dd.
 
 ### Breaking changes
 
+- Rename policy field `server.outbound.accept-xfr-from` to
+  `server.outbound.provide-xfr-to`.
+
 ### New
 
 ### Bug fixes

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -900,7 +900,7 @@ pub struct ServerPolicyInfo {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct OutboundPolicyInfo {
-    pub accept_xfr_from: Vec<NameserverCommsPolicyInfo>,
+    pub provide_xfr_to: Vec<NameserverCommsPolicyInfo>,
     pub send_notify_to: Vec<NameserverCommsPolicyInfo>,
 }
 

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -164,7 +164,7 @@ fn print_policy(p: &PolicyInfo) {
     println!("  server:");
     println!("    outbound:");
     println!("      accept XFR from:");
-    print_nameserver_comms_policy(&p.server.outbound.accept_xfr_from);
+    print_nameserver_comms_policy(&p.server.outbound.provide_xfr_to);
     println!("      send NOTIFY to:");
     print_nameserver_comms_policy(&p.server.outbound.send_notify_to);
 }

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -163,7 +163,7 @@ fn print_policy(p: &PolicyInfo) {
     print_review(&p.signer.review);
     println!("  server:");
     println!("    outbound:");
-    println!("      accept XFR from:");
+    println!("      provide XFR to:");
     print_nameserver_comms_policy(&p.server.outbound.provide_xfr_to);
     println!("      send NOTIFY to:");
     print_nameserver_comms_policy(&p.server.outbound.send_notify_to);

--- a/doc/manual/build/man/cascaded-policy.toml.5
+++ b/doc/manual/build/man/cascaded-policy.toml.5
@@ -733,8 +733,8 @@ the nameserver.
 .B provide\-xfr\-to = []
 The set of nameservers to provide zone transfers to.
 .sp
-If no nameservers are specified, zone transfer requests will be provided to
-any nameserver.
+If no nameservers are specified, zone transfers will be provided to any
+nameserver.
 .sp
 Each nameserver must be specified as a string in the form:
 .sp

--- a/doc/manual/build/man/cascaded-policy.toml.5
+++ b/doc/manual/build/man/cascaded-policy.toml.5
@@ -730,11 +730,11 @@ the nameserver.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B accept\-xfr\-from = []
-The set of nameservers to accept zone transfer requests from.
+.B provide\-xfr\-to = []
+The set of nameservers to provide zone transfers to.
 .sp
-If no nameservers are specified, zone transfer requests will be accepted
-from any nameserver.
+If no nameservers are specified, zone transfer requests will be provided to
+any nameserver.
 .sp
 Each nameserver must be specified as a string in the form:
 .sp

--- a/doc/manual/source/man/cascaded-policy.toml.rst
+++ b/doc/manual/source/man/cascaded-policy.toml.rst
@@ -587,12 +587,12 @@ The ``[server.outbound]`` section.
    Cascade TSIG key store and will be used to authenticate communication with
    the nameserver.
 
-.. option:: accept-xfr-from = []
+.. option:: provide-xfr-to = []
 
-   The set of nameservers to accept zone transfer requests from.
+   The set of nameservers to provide zone transfers to.
 
-   If no nameservers are specified, zone transfer requests will be accepted
-   from any nameserver.
+   If no nameservers are specified, zone transfer requests will be provided to
+   any nameserver.
    
    Each nameserver must be specified as a string in the form:
 

--- a/doc/manual/source/man/cascaded-policy.toml.rst
+++ b/doc/manual/source/man/cascaded-policy.toml.rst
@@ -591,8 +591,8 @@ The ``[server.outbound]`` section.
 
    The set of nameservers to provide zone transfers to.
 
-   If no nameservers are specified, zone transfer requests will be provided to
-   any nameserver.
+   If no nameservers are specified, zone transfers will be provided to any
+   nameserver.
    
    Each nameserver must be specified as a string in the form:
 

--- a/doc/manual/source/nsd.rst
+++ b/doc/manual/source/nsd.rst
@@ -121,4 +121,4 @@ nameserver such as NSD you must set the required policy settings and reload
 the policy. The relevant policy settings in Cascade are:
 
 - ``server.outbound.send-notify-to``
-- ``server.outbound.accept-xfr-from```
+- ``server.outbound.provide-xfr-to``

--- a/etc/policy.template.toml
+++ b/etc/policy.template.toml
@@ -452,7 +452,7 @@ mode = "off"
 # If not specified, no NOTIFY messages will be sent.
 send-notify-to = []
 
-# The set of nameservers to accept zone transfer requests from.
+# The set of nameservers to provide zone transfers to.
 # 
 # Each nameserver must be specified as a string in the form:
 #
@@ -462,6 +462,8 @@ send-notify-to = []
 # Cascade TSIG key store and will be used to authenticate communication with
 # the nameserver.
 #
-# If not specified, zone transfer requests will be accepted from any
-# nameserver.
-accept-xfr-from = []
+# Zone transfer will be provided to any nameserver that initiates a transfer
+# request from one of the specified IP addresses.
+#
+# If not specified, zone transfers will be provided to any nameserver.
+provide-xfr-to = []

--- a/etc/policy.template.toml
+++ b/etc/policy.template.toml
@@ -462,7 +462,7 @@ send-notify-to = []
 # Cascade TSIG key store and will be used to authenticate communication with
 # the nameserver.
 #
-# Zone transfer will be provided to any nameserver that initiates a transfer
+# Zone transfers will be provided to any nameserver that initiates a transfer
 # request from one of the specified IP addresses.
 #
 # If not specified, zone transfers will be provided to any nameserver.

--- a/integration-tests/system-tests.yml
+++ b/integration-tests/system-tests.yml
@@ -286,7 +286,7 @@ jobs:
       fail-fast: true
       matrix:
         send-notify-to: [ '',  '127.0.0.1:1054', '127.0.0.1:1054^tsig-key' ]
-        accept-xfr-from: [ '', '127.0.0.1', '127.0.0.1^tsig-key' ]
+        provide-xfr-to: [ '', '127.0.0.1', '127.0.0.1^tsig-key' ]
         downstream-expects-tsig: [ 0, 1 ]
         downstream-uses-tsig: [ 0, 1 ]
     steps:
@@ -298,7 +298,7 @@ jobs:
         with:
           log-level: ${{ inputs.log-level }}
           send-notify-to: ${{ matrix.send-notify-to }}
-          accept-xfr-from: ${{ matrix.accept-xfr-from }}
+          provide-xfr-to: ${{ matrix.provide-xfr-to }}
           downstream-expects-tsig: ${{ matrix.downstream-expects-tsig }}
           downstream-uses-tsig: ${{ matrix.downstream-uses-tsig }}
 

--- a/integration-tests/tests/downstream-tsig/action.yml
+++ b/integration-tests/tests/downstream-tsig/action.yml
@@ -23,7 +23,7 @@ inputs:
     required: false
     default: ''
     type: string
-  accept-xfr-from:
+  provide-xfr-to:
     description: The IP address, port and name of the TSIG key to permit when replying to SOA and XFR requests from downstream nameservers.
     required: false
     default: ''
@@ -101,14 +101,14 @@ runs:
     - name: Add a custom policy
       run: |
         POLICY_DIR=$(integration-tests/scripts/get-default-path.sh policy-dir)
-        cascade template policy | grep -Ev '(send-notify-to|accept-xfr-from)' > "${POLICY_DIR}/restricted.toml"
-        if [ "${{ inputs.accept-xfr-from }}" != "" ]; then
-          echo 'accept-xfr-from = ["${{ inputs.accept-xfr-from }}"]' >> "${POLICY_DIR}/restricted.toml"
+        cascade template policy | grep -Ev '(send-notify-to|provide-xfr-to)' > "${POLICY_DIR}/restricted.toml"
+        if [ "${{ inputs.provide-xfr-to }}" != "" ]; then
+          echo 'provide-xfr-to = ["${{ inputs.provide-xfr-to }}"]' >> "${POLICY_DIR}/restricted.toml"
         fi
         if [ "${{ inputs.send-notify-to }}" != "" ]; then
           echo 'send-notify-to = ["${{ inputs.send-notify-to }}"]' >> "${POLICY_DIR}/restricted.toml"
         fi
-        if [[ "${{ inputs.accept-xfr-from}}" == *"^tsig-key"* || "${{ inputs.send-notify-to }}" == *"^tsig-key"* ]]; then
+        if [[ "${{ inputs.provide-xfr-to}}" == *"^tsig-key"* || "${{ inputs.send-notify-to }}" == *"^tsig-key"* ]]; then
           cascade tsig add tsig-key hmac-sha256 "COzoVsYQmXeXiyq1Quhp0bbVnMyxjPxsaGSoIWR98i0="
         fi
         cascade policy reload

--- a/src/policy/file/v1.rs
+++ b/src/policy/file/v1.rs
@@ -932,11 +932,11 @@ impl ServerSpec {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields, default)]
 pub struct OutboundSpec {
-    /// The set of nameservers from which SOA and XFR requests may be received.
+    /// The set of nameservers to which zone transfers may be provided.
     ///
-    /// If empty, any nameserver may request XFR from us.
+    /// If empty, zone transfers will be provided to any nameserver.
     #[serde(default = "empty_list")]
-    pub accept_xfr_from: Vec<NameserverCommsSpec>,
+    pub provide_xfr_to: Vec<NameserverCommsSpec>,
 
     /// The set of nameservers to which NOTIFY messages should be sent.
     ///
@@ -957,11 +957,7 @@ impl OutboundSpec {
     /// Parse from this specification.
     pub fn parse(self) -> OutboundPolicy {
         OutboundPolicy {
-            accept_xfr_from: self
-                .accept_xfr_from
-                .into_iter()
-                .map(|v| v.parse())
-                .collect(),
+            provide_xfr_to: self.provide_xfr_to.into_iter().map(|v| v.parse()).collect(),
             send_notify_to: self.send_notify_to.into_iter().map(|v| v.parse()).collect(),
         }
     }
@@ -969,8 +965,8 @@ impl OutboundSpec {
     /// Build into this specification.
     pub fn build(policy: &OutboundPolicy) -> Self {
         Self {
-            accept_xfr_from: policy
-                .accept_xfr_from
+            provide_xfr_to: policy
+                .provide_xfr_to
                 .iter()
                 .map(NameserverCommsSpec::build)
                 .collect(),

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -218,7 +218,7 @@ fn check_policy(policy: &PolicyVersion, tsig_store: &TsigStore) -> Result<(), Po
         .key_manager
         .publication_nameservers
         .iter()
-        .chain(policy.server.outbound.accept_xfr_from.iter())
+        .chain(policy.server.outbound.provide_xfr_to.iter())
         .chain(policy.server.outbound.send_notify_to.iter())
         .filter_map(|ns| ns.tsig_key_name.as_ref());
 
@@ -551,10 +551,10 @@ pub struct ServerPolicy {
 /// Policy for restricting to whom data may be sent.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct OutboundPolicy {
-    /// The set of nameservers from which SOA and XFR requests may be received.
+    /// The set of nameservers to which zone transfers may be provided.
     ///
-    /// If empty, any nameserver may request XFR from us.
-    pub accept_xfr_from: Vec<NameserverCommsPolicy>,
+    /// If empty, zone transfers will be provided to any nameserver.
+    pub provide_xfr_to: Vec<NameserverCommsPolicy>,
 
     /// The set of nameservers to which NOTIFY messages should be sent.
     ///

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -201,7 +201,7 @@ mod compat {
         if let Some(acls) = zone_state
             .policy
             .as_ref()
-            .map(|p| &p.server.outbound.accept_xfr_from)
+            .map(|p| &p.server.outbound.provide_xfr_to)
         {
             // If at least one ACL was specified, enforce it.
             if !acls.is_empty() {

--- a/src/tsig/mod.rs
+++ b/src/tsig/mod.rs
@@ -310,7 +310,7 @@ pub fn remove_key(center: &Arc<Center>, name: &tsig::KeyName) -> Result<(), Remo
                 .any(|ns| ns.tsig_key_name.as_ref() == Some(name))
                 || p.server
                     .outbound
-                    .accept_xfr_from
+                    .provide_xfr_to
                     .iter()
                     .any(|acl| acl.tsig_key_name.as_ref() == Some(name))
                 || p.server

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -1016,8 +1016,8 @@ impl HttpServer {
         let p_outbound = &p.latest.server.outbound;
         let server = ServerPolicyInfo {
             outbound: OutboundPolicyInfo {
-                accept_xfr_from: p_outbound
-                    .accept_xfr_from
+                provide_xfr_to: p_outbound
+                    .provide_xfr_to
                     .iter()
                     .map(|v| NameserverCommsPolicyInfo { addr: v.addr })
                     .collect(),
@@ -1285,7 +1285,7 @@ impl HttpServer {
                 .key_manager
                 .publication_nameservers
                 .iter()
-                .chain(policy.latest.server.outbound.accept_xfr_from.iter())
+                .chain(policy.latest.server.outbound.provide_xfr_to.iter())
                 .chain(policy.latest.server.outbound.send_notify_to.iter())
                 .filter_map(|acl| acl.tsig_key_name.as_ref())
                 .peekable();


### PR DESCRIPTION
As requested by @jpmens via #702.

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?

- If you are modifying man pages:
  - [x] Did you commit the updated built man pages?
