### PR TITLE
Add all policy info to the policy show command

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -841,6 +841,34 @@ pub struct LoaderPolicyInfo {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct KeyManagerPolicyInfo {
     pub hsm_server_id: Option<String>,
+    pub use_csk: bool,
+    pub algorithm: String,
+    pub ksk_validity: Option<u32>,
+    pub zsk_validity: Option<u32>,
+    pub csk_validity: Option<u32>,
+    pub auto_ksk: AutoConfigPolicyInfo,
+    pub auto_zsk: AutoConfigPolicyInfo,
+    pub auto_csk: AutoConfigPolicyInfo,
+    pub auto_algorithm: AutoConfigPolicyInfo,
+    pub dnskey_inception_offset: u32,
+    pub dnskey_signature_lifetime: u32,
+    pub dnskey_remain_time: u32,
+    pub cds_inception_offset: u32,
+    pub cds_signature_lifetime: u32,
+    pub cds_remain_time: u32,
+    pub ds_algorithm: String,
+    pub default_ttl: u32,
+    pub auto_remove: bool,
+    pub auto_remove_delay: Duration,
+    pub publication_nameservers: Vec<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct AutoConfigPolicyInfo {
+    pub start: bool,
+    pub report: bool,
+    pub expire: bool,
+    pub done: bool,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -868,6 +896,9 @@ pub struct SignerPolicyInfo {
     // TODO: These fields should have a type that explains that they represent durations.
     pub sig_inception_offset: u32,
     pub sig_validity_offset: u32,
+    pub sig_remain_time: u32,
+    pub signature_refresh_interval: u32,
+    pub key_roll_time: u32,
     pub denial: SignerDenialPolicyInfo,
     pub review: ReviewPolicyInfo,
 }

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -1,7 +1,8 @@
 use std::fmt::Display;
 
 use cascade_api::{
-    KeyManagerPolicyInfo, LoaderPolicyInfo, ReviewPolicyMode, ServerPolicyInfo, SignerPolicyInfo,
+    AutoConfigPolicyInfo, KeyManagerPolicyInfo, LoaderPolicyInfo, ReviewPolicyMode,
+    ServerPolicyInfo, SignerPolicyInfo,
 };
 
 use crate::{
@@ -170,34 +171,30 @@ fn print_key_manager_policy(
     // TODO: we should probably condense this information a lot or hide unnecessary details. For example, only
     // show CSK info when `use_csk` is `true`.
     println!("  key manager:");
-    println!("    hsm server: {}", or_none(hsm_server_id));
-    println!("    use csk: {use_csk}");
-    println!("    ds algorithm: {ds_algorithm}");
-    println!("    auto-remove: {auto_remove}");
-    println!("    auto-remove delay: {}s", auto_remove_delay.as_secs());
+    println!("    HSM server: {}", or_none(hsm_server_id));
+    println!("    DS algorithm: {ds_algorithm}");
+    if *auto_remove {
+        println!(
+            "    auto-remove: true (delay {}s)",
+            auto_remove_delay.as_secs()
+        );
+    } else {
+        println!("    auto-remove: false",);
+    }
     println!("    algorithm: {algorithm}");
-    println!("      auto-start: {}", auto_algorithm.start);
-    println!("      auto-report: {}", auto_algorithm.report);
-    println!("      auto-expire: {}", auto_algorithm.expire);
-    println!("      auto-done: {}", auto_algorithm.done);
-    println!("    ksk:");
-    println!("      validity: {}", or_none(ksk_validity));
-    println!("      auto-start: {}", auto_ksk.start);
-    println!("      auto-report: {}", auto_ksk.report);
-    println!("      auto-expire: {}", auto_ksk.expire);
-    println!("      auto-done: {}", auto_ksk.done);
-    println!("    zsk:");
-    println!("      validity: {}", or_none(zsk_validity));
-    println!("      auto-start: {}", auto_zsk.start);
-    println!("      auto-report: {}", auto_zsk.report);
-    println!("      auto-expire: {}", auto_zsk.expire);
-    println!("      auto-done: {}", auto_zsk.done);
-    println!("    csk:");
-    println!("      validity: {}", or_none(csk_validity));
-    println!("      auto-start: {}", auto_csk.start);
-    println!("      auto-report: {}", auto_csk.report);
-    println!("      auto-expire: {}", auto_csk.expire);
-    println!("      auto-done: {}", auto_csk.done);
+    print_auto_flags(auto_algorithm);
+    if *use_csk {
+        println!("    CSK:");
+        println!("      validity: {}s", or_none(csk_validity));
+        print_auto_flags(auto_csk);
+    } else {
+        println!("    KSK:");
+        println!("      validity: {}s", or_none(ksk_validity));
+        print_auto_flags(auto_ksk);
+        println!("    ZSK:");
+        println!("      validity: {}s", or_none(zsk_validity));
+        print_auto_flags(auto_zsk);
+    }
     println!("    records:");
     println!("      TTL: {default_ttl}s");
     println!("      DNSKEY:");
@@ -218,6 +215,27 @@ fn print_key_manager_policy(
             println!("     - {ns}")
         }
     }
+}
+
+fn print_auto_flags(auto: &AutoConfigPolicyInfo) {
+    print!("      auto flags:");
+    if !auto.start && !auto.report && !auto.expire && !auto.done {
+        println!(" <none>");
+        return;
+    }
+    if auto.start {
+        print!(" start");
+    }
+    if auto.report {
+        print!(" report");
+    }
+    if auto.expire {
+        print!(" expire");
+    }
+    if auto.done {
+        print!(" done");
+    }
+    println!();
 }
 
 fn print_signer_policy(
@@ -251,9 +269,9 @@ fn print_signer_policy(
     println!("    serial policy: {serial_policy}");
     println!("    signature inception offset: {sig_inception_offset}s");
     println!("    signature validity offset: {sig_validity_offset}s");
-    println!("    signature remain time: {sig_remain_time}");
-    println!("    signature refresh interval: {signature_refresh_interval}");
-    println!("    key roll time: {key_roll_time}");
+    println!("    signature remain time: {sig_remain_time}s");
+    println!("    signature refresh interval: {signature_refresh_interval}s");
+    println!("    key roll time: {key_roll_time}s");
     println!("    denial: {denial}");
     print_review(review);
 }
@@ -274,11 +292,18 @@ fn print_server_policy(
 }
 
 fn print_review(ReviewPolicyInfo { mode, on_reject }: &ReviewPolicyInfo) {
-    println!("    review:");
+    print!("    review:");
     match mode {
-        ReviewPolicyMode::Off => println!("      mode: off"),
-        ReviewPolicyMode::Manual => println!("      mode: manual"),
+        ReviewPolicyMode::Off => {
+            println!(" off");
+            return;
+        }
+        ReviewPolicyMode::Manual => {
+            println!("");
+            println!("      mode: manual");
+        }
         ReviewPolicyMode::Script { hook } => {
+            println!("");
             println!("      mode: script");
             println!("      hook: {hook}")
         }

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -1,4 +1,8 @@
-use cascade_api::ReviewPolicyMode;
+use std::fmt::Display;
+
+use cascade_api::{
+    KeyManagerPolicyInfo, LoaderPolicyInfo, ReviewPolicyMode, ServerPolicyInfo, SignerPolicyInfo,
+};
 
 use crate::{
     ansi,
@@ -100,10 +104,18 @@ impl Policy {
 }
 
 fn print_policy(p: &PolicyInfo) {
-    let none = "<none>".to_string();
-    let name = &p.name;
+    let PolicyInfo {
+        name,
+        zones,
+        loader,
+        key_manager,
+        signer,
+        server,
+    } = p;
 
-    let zones: Vec<_> = p.zones.iter().map(|z| format!("{}", z)).collect();
+    let none = "<none>".to_string();
+
+    let zones: Vec<_> = zones.iter().map(|z| format!("{}", z)).collect();
 
     let zones = if !zones.is_empty() {
         zones.join(", ")
@@ -111,17 +123,123 @@ fn print_policy(p: &PolicyInfo) {
         none.clone()
     };
 
-    let serial_policy = match p.signer.serial_policy {
+    println!("{name}:");
+    println!("  zones: {zones}");
+    print_loader_policy(loader);
+    print_key_manager_policy(key_manager);
+    print_signer_policy(signer);
+    print_server_policy(server);
+}
+
+fn or_none(x: &Option<impl Display>) -> String {
+    x.as_ref()
+        .map(ToString::to_string)
+        .unwrap_or("<none>".into())
+}
+
+fn print_loader_policy(LoaderPolicyInfo { review }: &LoaderPolicyInfo) {
+    println!("  loader:");
+    print_review(review);
+}
+
+fn print_key_manager_policy(
+    KeyManagerPolicyInfo {
+        hsm_server_id,
+        use_csk,
+        algorithm,
+        ksk_validity,
+        zsk_validity,
+        csk_validity,
+        auto_ksk,
+        auto_zsk,
+        auto_csk,
+        auto_algorithm,
+        dnskey_inception_offset,
+        dnskey_signature_lifetime,
+        dnskey_remain_time,
+        cds_inception_offset,
+        cds_signature_lifetime,
+        cds_remain_time,
+        ds_algorithm,
+        default_ttl,
+        auto_remove,
+        auto_remove_delay,
+        publication_nameservers,
+    }: &KeyManagerPolicyInfo,
+) {
+    // TODO: we should probably condense this information a lot or hide unnecessary details. For example, only
+    // show CSK info when `use_csk` is `true`.
+    println!("  key manager:");
+    println!("    hsm server: {}", or_none(hsm_server_id));
+    println!("    use csk: {use_csk}");
+    println!("    ds algorithm: {ds_algorithm}");
+    println!("    auto-remove: {auto_remove}");
+    println!("    auto-remove delay: {}s", auto_remove_delay.as_secs());
+    println!("    algorithm: {algorithm}");
+    println!("      auto-start: {}", auto_algorithm.start);
+    println!("      auto-report: {}", auto_algorithm.report);
+    println!("      auto-expire: {}", auto_algorithm.expire);
+    println!("      auto-done: {}", auto_algorithm.done);
+    println!("    ksk:");
+    println!("      validity: {}", or_none(ksk_validity));
+    println!("      auto-start: {}", auto_ksk.start);
+    println!("      auto-report: {}", auto_ksk.report);
+    println!("      auto-expire: {}", auto_ksk.expire);
+    println!("      auto-done: {}", auto_ksk.done);
+    println!("    zsk:");
+    println!("      validity: {}", or_none(zsk_validity));
+    println!("      auto-start: {}", auto_zsk.start);
+    println!("      auto-report: {}", auto_zsk.report);
+    println!("      auto-expire: {}", auto_zsk.expire);
+    println!("      auto-done: {}", auto_zsk.done);
+    println!("    csk:");
+    println!("      validity: {}", or_none(csk_validity));
+    println!("      auto-start: {}", auto_csk.start);
+    println!("      auto-report: {}", auto_csk.report);
+    println!("      auto-expire: {}", auto_csk.expire);
+    println!("      auto-done: {}", auto_csk.done);
+    println!("    records:");
+    println!("      TTL: {default_ttl}s");
+    println!("      DNSKEY:");
+    println!("        signature inception offset: {dnskey_inception_offset}s");
+    println!("        signature lifetime: {dnskey_signature_lifetime}s");
+    println!("        signature remain time: {dnskey_remain_time}s");
+    println!("      CDS:");
+    println!("        signature inception offset: {cds_inception_offset}s");
+    println!("        signature lifetime: {cds_signature_lifetime}s");
+    println!("        signature remain time: {cds_remain_time}s");
+
+    if publication_nameservers.is_empty() {
+        println!("    publication nameservers: <none>");
+    } else {
+        println!("    publication nameservers:");
+
+        for ns in publication_nameservers {
+            println!("     - {ns}")
+        }
+    }
+}
+
+fn print_signer_policy(
+    SignerPolicyInfo {
+        review,
+        serial_policy,
+        sig_inception_offset,
+        sig_validity_offset,
+        sig_remain_time,
+        signature_refresh_interval,
+        key_roll_time,
+        denial,
+    }: &SignerPolicyInfo,
+) {
+    let serial_policy = match serial_policy {
         SignerSerialPolicyInfo::Keep => "keep",
         SignerSerialPolicyInfo::Counter => "counter",
         SignerSerialPolicyInfo::UnixTime => "unix time",
         SignerSerialPolicyInfo::DateCounter => "date counter",
     };
 
-    let inc = p.signer.sig_inception_offset;
-    let val = p.signer.sig_validity_offset;
-
-    let denial = match &p.signer.denial {
+    let denial = match &denial {
         SignerDenialPolicyInfo::NSec => "NSEC",
         SignerDenialPolicyInfo::NSec3 { opt_out } => match opt_out {
             true => "NSEC3 (opt-out: disabled)",
@@ -129,42 +247,56 @@ fn print_policy(p: &PolicyInfo) {
         },
     };
 
-    let hsm_server_id = p.key_manager.hsm_server_id.as_ref().unwrap_or(&none);
-
-    fn print_review(r: &ReviewPolicyInfo) {
-        println!("    review:");
-        match &r.mode {
-            ReviewPolicyMode::Off => println!("      mode: off"),
-            ReviewPolicyMode::Manual => println!("      mode: manual"),
-            ReviewPolicyMode::Script { hook } => {
-                println!("      mode: script");
-                println!("      hook: {hook}")
-            }
-        }
-    }
-
-    fn print_nameserver_comms_policy(n: &[NameserverCommsPolicyInfo]) {
-        for item in n {
-            println!("        {item}");
-        }
-    }
-
-    println!("{name}:");
-    println!("  zones: {zones}");
-    println!("  loader:");
-    print_review(&p.loader.review);
-    println!("  key manager:");
-    println!("    hsm server: {hsm_server_id}");
     println!("  signer:");
     println!("    serial policy: {serial_policy}");
-    println!("    signature inception offset: {inc} seconds",);
-    println!("    signature validity offset: {val} seconds",);
+    println!("    signature inception offset: {sig_inception_offset}s");
+    println!("    signature validity offset: {sig_validity_offset}s");
+    println!("    signature remain time: {sig_remain_time}");
+    println!("    signature refresh interval: {signature_refresh_interval}");
+    println!("    key roll time: {key_roll_time}");
     println!("    denial: {denial}");
-    print_review(&p.signer.review);
+    print_review(review);
+}
+
+fn print_server_policy(
+    ServerPolicyInfo {
+        outbound:
+            cascade_api::OutboundPolicyInfo {
+                provide_xfr_to,
+                send_notify_to,
+            },
+    }: &ServerPolicyInfo,
+) {
     println!("  server:");
     println!("    outbound:");
-    println!("      provide XFR to:");
-    print_nameserver_comms_policy(&p.server.outbound.provide_xfr_to);
-    println!("      send NOTIFY to:");
-    print_nameserver_comms_policy(&p.server.outbound.send_notify_to);
+    print_nameserver_comms_policy("provide XFR to", provide_xfr_to);
+    print_nameserver_comms_policy("send NOTIFY to", send_notify_to);
+}
+
+fn print_review(ReviewPolicyInfo { mode, on_reject }: &ReviewPolicyInfo) {
+    println!("    review:");
+    match mode {
+        ReviewPolicyMode::Off => println!("      mode: off"),
+        ReviewPolicyMode::Manual => println!("      mode: manual"),
+        ReviewPolicyMode::Script { hook } => {
+            println!("      mode: script");
+            println!("      hook: {hook}")
+        }
+    }
+    let on_reject = match on_reject {
+        cascade_api::ReviewPolicyOnReject::Discard => "discard",
+        cascade_api::ReviewPolicyOnReject::Halt => "halt",
+    };
+    println!("      on reject: {on_reject}")
+}
+
+fn print_nameserver_comms_policy(name: &str, n: &[NameserverCommsPolicyInfo]) {
+    if n.is_empty() {
+        println!("      {name}: <none>");
+        return;
+    }
+    println!("      {name}:");
+    for item in n {
+        println!("        {item}");
+    }
 }

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -39,6 +39,7 @@ use crate::center::get_zone;
 use crate::loader;
 use crate::manager::Terminated;
 use crate::metrics::MetricsCollection;
+use crate::policy::AutoConfig;
 use crate::policy::SignerDenialPolicy;
 use crate::policy::SignerSerialPolicy;
 use crate::server::LoadedReviewServer;
@@ -969,68 +970,170 @@ impl HttpServer {
         };
 
         let zones = p.zones.iter().cloned().collect();
-        let loader = LoaderPolicyInfo {
-            review: ReviewPolicyInfo {
-                mode: match p.latest.loader.review.mode.clone() {
-                    crate::policy::ReviewMode::Off => ReviewPolicyMode::Off,
-                    crate::policy::ReviewMode::Manual => ReviewPolicyMode::Manual,
-                    crate::policy::ReviewMode::Script { hook } => ReviewPolicyMode::Script { hook },
+
+        let crate::policy::PolicyVersion {
+            name,
+            loader,
+            key_manager,
+            signer,
+            server,
+        } = &*p.latest;
+
+        let loader = {
+            let crate::policy::LoaderPolicy { review } = loader;
+
+            LoaderPolicyInfo {
+                review: ReviewPolicyInfo {
+                    mode: match review.mode.clone() {
+                        crate::policy::ReviewMode::Off => ReviewPolicyMode::Off,
+                        crate::policy::ReviewMode::Manual => ReviewPolicyMode::Manual,
+                        crate::policy::ReviewMode::Script { hook } => {
+                            ReviewPolicyMode::Script { hook }
+                        }
+                    },
+                    on_reject: match review.on_reject {
+                        crate::policy::OnReject::Discard => ReviewPolicyOnReject::Discard,
+                        crate::policy::OnReject::Halt => ReviewPolicyOnReject::Halt,
+                    },
                 },
-                on_reject: match p.latest.loader.review.on_reject {
-                    crate::policy::OnReject::Discard => ReviewPolicyOnReject::Discard,
-                    crate::policy::OnReject::Halt => ReviewPolicyOnReject::Halt,
-                },
-            },
+            }
         };
 
-        let signer = SignerPolicyInfo {
-            serial_policy: match p.latest.signer.serial_policy {
-                SignerSerialPolicy::Keep => SignerSerialPolicyInfo::Keep,
-                SignerSerialPolicy::Counter => SignerSerialPolicyInfo::Counter,
-                SignerSerialPolicy::UnixTime => SignerSerialPolicyInfo::UnixTime,
-                SignerSerialPolicy::DateCounter => SignerSerialPolicyInfo::DateCounter,
-            },
-            sig_inception_offset: p.latest.signer.sig_inception_offset,
-            sig_validity_offset: p.latest.signer.sig_validity_time,
-            denial: match p.latest.signer.denial {
-                SignerDenialPolicy::NSec => SignerDenialPolicyInfo::NSec,
-                SignerDenialPolicy::NSec3 { opt_out } => SignerDenialPolicyInfo::NSec3 { opt_out },
-            },
-            review: ReviewPolicyInfo {
-                mode: match p.latest.signer.review.mode.clone() {
-                    crate::policy::ReviewMode::Off => ReviewPolicyMode::Off,
-                    crate::policy::ReviewMode::Manual => ReviewPolicyMode::Manual,
-                    crate::policy::ReviewMode::Script { hook } => ReviewPolicyMode::Script { hook },
+        let signer = {
+            let &crate::policy::SignerPolicy {
+                serial_policy,
+                sig_inception_offset,
+                sig_validity_time,
+                sig_remain_time,
+                signature_refresh_interval,
+                key_roll_time,
+                ref denial,
+                ref review,
+            } = signer;
+
+            SignerPolicyInfo {
+                serial_policy: match serial_policy {
+                    SignerSerialPolicy::Keep => SignerSerialPolicyInfo::Keep,
+                    SignerSerialPolicy::Counter => SignerSerialPolicyInfo::Counter,
+                    SignerSerialPolicy::UnixTime => SignerSerialPolicyInfo::UnixTime,
+                    SignerSerialPolicy::DateCounter => SignerSerialPolicyInfo::DateCounter,
                 },
-                on_reject: match p.latest.signer.review.on_reject {
-                    crate::policy::OnReject::Discard => ReviewPolicyOnReject::Discard,
-                    crate::policy::OnReject::Halt => ReviewPolicyOnReject::Halt,
+                sig_inception_offset,
+                sig_validity_offset: sig_validity_time,
+                sig_remain_time,
+                signature_refresh_interval,
+                key_roll_time,
+                denial: match denial {
+                    SignerDenialPolicy::NSec => SignerDenialPolicyInfo::NSec,
+                    &SignerDenialPolicy::NSec3 { opt_out } => {
+                        SignerDenialPolicyInfo::NSec3 { opt_out }
+                    }
                 },
-            },
+                review: ReviewPolicyInfo {
+                    mode: match review.mode.clone() {
+                        crate::policy::ReviewMode::Off => ReviewPolicyMode::Off,
+                        crate::policy::ReviewMode::Manual => ReviewPolicyMode::Manual,
+                        crate::policy::ReviewMode::Script { hook } => {
+                            ReviewPolicyMode::Script { hook }
+                        }
+                    },
+                    on_reject: match review.on_reject {
+                        crate::policy::OnReject::Discard => ReviewPolicyOnReject::Discard,
+                        crate::policy::OnReject::Halt => ReviewPolicyOnReject::Halt,
+                    },
+                },
+            }
         };
 
-        let key_manager = KeyManagerPolicyInfo {
-            hsm_server_id: p.latest.key_manager.hsm_server_id.clone(),
-        };
+        let key_manager = {
+            let &crate::policy::KeyManagerPolicy {
+                ref hsm_server_id,
+                use_csk,
+                ref algorithm,
+                ksk_validity,
+                zsk_validity,
+                csk_validity,
+                ref auto_ksk,
+                ref auto_zsk,
+                ref auto_csk,
+                ref auto_algorithm,
+                dnskey_inception_offset,
+                dnskey_signature_lifetime,
+                dnskey_remain_time,
+                cds_inception_offset,
+                cds_signature_lifetime,
+                cds_remain_time,
+                ref ds_algorithm,
+                default_ttl,
+                auto_remove,
+                auto_remove_delay,
+                ref publication_nameservers,
+            } = key_manager;
 
-        let p_outbound = &p.latest.server.outbound;
-        let server = ServerPolicyInfo {
-            outbound: OutboundPolicyInfo {
-                provide_xfr_to: p_outbound
-                    .provide_xfr_to
+            fn map_auto(
+                &AutoConfig {
+                    start,
+                    report,
+                    expire,
+                    done,
+                }: &AutoConfig,
+            ) -> AutoConfigPolicyInfo {
+                AutoConfigPolicyInfo {
+                    start,
+                    report,
+                    expire,
+                    done,
+                }
+            }
+
+            KeyManagerPolicyInfo {
+                hsm_server_id: hsm_server_id.clone(),
+                algorithm: algorithm.to_string(),
+                use_csk,
+                ksk_validity,
+                zsk_validity,
+                csk_validity,
+                auto_ksk: map_auto(auto_ksk),
+                auto_zsk: map_auto(auto_zsk),
+                auto_csk: map_auto(auto_csk),
+                auto_algorithm: map_auto(auto_algorithm),
+                dnskey_inception_offset,
+                dnskey_signature_lifetime,
+                dnskey_remain_time,
+                cds_inception_offset,
+                cds_signature_lifetime,
+                cds_remain_time,
+                ds_algorithm: ds_algorithm.to_string(),
+                default_ttl: default_ttl.as_secs(),
+                auto_remove,
+                auto_remove_delay,
+                publication_nameservers: publication_nameservers
                     .iter()
-                    .map(|v| NameserverCommsPolicyInfo { addr: v.addr })
+                    .map(ToString::to_string)
                     .collect(),
-                send_notify_to: p_outbound
-                    .send_notify_to
-                    .iter()
-                    .map(|v| NameserverCommsPolicyInfo { addr: v.addr })
-                    .collect(),
-            },
+            }
+        };
+
+        let server = {
+            let crate::policy::ServerPolicy { outbound } = server;
+            ServerPolicyInfo {
+                outbound: OutboundPolicyInfo {
+                    provide_xfr_to: outbound
+                        .provide_xfr_to
+                        .iter()
+                        .map(|v| NameserverCommsPolicyInfo { addr: v.addr })
+                        .collect(),
+                    send_notify_to: outbound
+                        .send_notify_to
+                        .iter()
+                        .map(|v| NameserverCommsPolicyInfo { addr: v.addr })
+                        .collect(),
+                },
+            }
         };
 
         Json(Ok(PolicyInfo {
-            name: p.latest.name.clone(),
+            name: name.clone(),
             zones,
             loader,
             key_manager,


### PR DESCRIPTION
Closes #598
Closes #640

This is for the `cascade policy show` command.

Changes the code related to displaying the policy to use destructuring so that Rust can give us warnings when we're missing anything. I added everything that was missing. It looks kind of bad now; suggestions for improving that are welcome.

```
default:
  zones: <none>
  loader:
    review: off
  key manager:
    HSM server: <none>
    DS algorithm: SHA-256
    auto-remove: true (delay 604800s)
    algorithm: ECDSAP256SHA256
      auto flags: start report expire done
    KSK:
      validity: 31536000s
      auto flags: start report expire done
    ZSK:
      validity: 2592000s
      auto flags: start report expire done
    records:
      TTL: 3600s
      DNSKEY:
        signature inception offset: 86400s
        signature lifetime: 1209600s
        signature remain time: 604800s
      CDS:
        signature inception offset: 86400s
        signature lifetime: 1209600s
        signature remain time: 604800s
    publication nameservers: <none>
  signer:
    serial policy: date counter
    signature inception offset: 86400s
    signature validity offset: 1209600s
    signature remain time: 604800s
    signature refresh interval: 43200s
    key roll time: 86400s
    denial: NSEC
    review: off
  server:
    outbound:
      provide XFR to: <none>
      send NOTIFY to: <none>
```

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
