### PR TITLE
Implement a new signing queue

### DIFF
--- a/src/persistence/zone.rs
+++ b/src/persistence/zone.rs
@@ -201,8 +201,8 @@ fn abandon_signed_restoration(
 
 fn reset_state_due_to_abandoned_restore(center: &Arc<Center>, zone: &Arc<Zone>) {
     {
-        let mut state = zone.write(center);
-        clear_persisted_zone_data(center, &mut state);
+        let mut handle = zone.write_handle(center);
+        clear_persisted_zone_data(center, &mut handle.state);
 
         // In case this zone was signed in the past we have to make sure that
         // any attempt to enqueue a re-signing operation will be skipped as
@@ -210,13 +210,13 @@ fn reset_state_due_to_abandoned_restore(center: &Arc<Center>, zone: &Arc<Zone>) 
         // TODO: Find a better way to prevent this issue as changing the
         // min_expiration timestamps is a very indirect and non-obvious way of
         // preventing re-signing.
-        state.min_expiration = None;
-        state.next_min_expiration = None;
+        handle.state.min_expiration = None;
+        handle.state.next_min_expiration = None;
 
         // Also remove any already enqueued signing operation that is blocked
         // by the ongoing restore as it will otherwise immediately start once
         // the restore completes.
-        state.signer.cancel_enqueued_signing_operations();
+        handle.signer().cancel_enqueued_signing_operations();
     }
     save_state_now(center, zone);
 }

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -29,7 +29,10 @@ use crate::{
     center::Center,
     zone::{HistoricalEvent, Zone},
 };
-use crate::{signer::status::SigningStatusPerZone, units::zone_signer::SignerError};
+use crate::{
+    signer::queue::SigningPermit, signer::status::SigningStatusPerZone,
+    units::zone_signer::SignerError,
+};
 
 pub mod incremental;
 pub mod queue;
@@ -59,6 +62,7 @@ async fn sign(
     zone: Arc<Zone>,
     mut builder: SignedZoneBuilder,
     trigger: SigningTrigger,
+    permit: SigningPermit,
     status: Arc<RwLock<SigningStatusPerZone>>,
 ) {
     let (_status, _permits) = center.signer.wait_to_sign(&zone).await;
@@ -80,6 +84,7 @@ async fn sign(
     let mut status = status.write().unwrap();
     let mut handle = zone.write_handle(&center);
     handle.state.signer.ongoing.finish();
+    center.signer.queue.finish(permit, &center);
     // TODO: Remove `status` from `handle.state.signer.active_signing_status`?
 
     match result {

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -32,6 +32,7 @@ use crate::{
 use crate::{signer::status::SigningStatusPerZone, units::zone_signer::SignerError};
 
 pub mod incremental;
+pub mod queue;
 pub mod status;
 pub mod zone;
 

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -57,7 +57,7 @@ pub mod zone;
     skip_all,
     fields(zone = %zone.name, ?trigger),
 )]
-async fn sign(
+fn sign(
     center: Arc<Center>,
     zone: Arc<Zone>,
     mut builder: SignedZoneBuilder,
@@ -65,21 +65,9 @@ async fn sign(
     permit: SigningPermit,
     status: Arc<RwLock<SigningStatusPerZone>>,
 ) {
-    let (_status, _permits) = center.signer.wait_to_sign(&zone).await;
-
-    let (result, builder) = tokio::task::spawn_blocking({
-        let center = center.clone();
-        let zone = zone.clone();
-        let status = status.clone();
-        move || {
-            let result = center
-                .signer
-                .sign_zone(&center, &zone, &mut builder, trigger, status);
-            (result, builder)
-        }
-    })
-    .await
-    .unwrap();
+    let result = center
+        .signer
+        .sign_zone(&center, &zone, &mut builder, trigger, status.clone());
 
     let mut status = status.write().unwrap();
     let mut handle = zone.write_handle(&center);

--- a/src/signer/queue.rs
+++ b/src/signer/queue.rs
@@ -56,6 +56,23 @@ impl SigningQueue {
         }
     }
 
+    /// The set concurrency limit.
+    #[must_use]
+    pub const fn concurrency_limit(&self) -> NonZeroUsize {
+        self.concurrency_limit
+    }
+
+    /// Export a list of all zones in the queue.
+    ///
+    /// This can be used for reporting on Cascade's status. The first `N` zones,
+    /// where `N` is [`Self::concurrency_limit()`], are actively being signed
+    /// (or are about to be signed); the remainder are waiting to be signed.
+    #[must_use]
+    pub fn export(&self) -> Vec<Arc<Zone>> {
+        let zones = self.zones.lock().unwrap_or_else(handle_poison);
+        zones.iter().cloned().collect()
+    }
+
     /// Enqueue signing for a zone.
     ///
     /// If the queue has capacity, a [`SigningPermit`] is returned immediately.

--- a/src/signer/queue.rs
+++ b/src/signer/queue.rs
@@ -1,0 +1,374 @@
+//! Enqueueing zones for (re-)signing.
+//
+// TODO: Is there some way to unit-test this code? This is difficult because it
+// interacts with `ZoneState` directly.
+
+use core::fmt;
+use std::{
+    collections::VecDeque,
+    mem::ManuallyDrop,
+    num::NonZeroUsize,
+    sync::{Arc, Mutex, PoisonError},
+};
+
+use cascade_zonedata::SignedZoneBuilder;
+use tracing::{debug, trace};
+
+use crate::{center::Center, util::FmtBy, zone::Zone};
+
+//----------- SigningQueue -----------------------------------------------------
+
+/// A queue of zones pending signing.
+///
+/// This is a thread-safe queue of zones which need to be (re-)signed but are
+/// waiting due to a limit on the number of concurrent signing operations. This
+/// queue enforces that limit and initiates signing for zones once capacity is
+/// available.
+pub struct SigningQueue {
+    /// The maximum number of concurrent operations to allow.
+    concurrency_limit: NonZeroUsize,
+
+    /// The underlying queue of zones.
+    ///
+    /// The first `concurrency_limit` elements of this queue are undergoing
+    /// signing (or signing will be initiated for them shortly). The remainder
+    /// wait for the earlier ones to finish.
+    ///
+    /// Duplicates of the same zone must not be present.
+    zones: Mutex<VecDeque<Arc<Zone>>>,
+}
+
+/// A lock on the [`SigningQueue`].
+///
+/// This is sometimes passed around explicitly to prevent deadlocks.
+pub struct SigningQueueLock<'a> {
+    /// The underlying queue.
+    zones: &'a mut VecDeque<Arc<Zone>>,
+}
+
+impl SigningQueue {
+    /// Construct a new [`SigningQueue`].
+    #[must_use]
+    pub fn new(concurrency_limit: NonZeroUsize) -> Self {
+        Self {
+            concurrency_limit,
+            zones: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    /// Enqueue signing for a zone.
+    ///
+    /// If the queue has capacity, a [`SigningPermit`] is returned immediately.
+    /// Otherwise, the zone is enqueued and it must wait until capacity is
+    /// available; once capacity is available, the returned [`SigningPending`]
+    /// can be traded for a [`SigningPermit`]. A [`SignedZoneBuilder`] is taken
+    /// as proof that the caller intends to perform signing.
+    ///
+    /// ## Panics
+    ///
+    /// May cause panics (indirectly) if the same zone is enqueued twice. Make
+    /// sure to return the [`SigningPermit`] for a zone from any previous
+    /// signing operation before enqueueing the same zone again.
+    #[tracing::instrument(
+        level = "trace",
+        skip_all,
+        fields(zone = %zone.name),
+    )]
+    pub fn enqueue(
+        &self,
+        zone: Arc<Zone>,
+        _builder: &SignedZoneBuilder,
+    ) -> Result<SigningPermit, SigningPending> {
+        trace!("Enqueueing for signing");
+        let mut zones = self.zones.lock().unwrap_or_else(handle_poison);
+
+        zones.push_back(zone.clone());
+
+        if zones.len() <= self.concurrency_limit.get() {
+            // The inserted zone fits within the concurrency limit.
+
+            trace!("Within concurrency limit, offering permit now");
+
+            Ok(SigningPermit {
+                zone,
+                _assertion: (),
+            })
+        } else {
+            debug!(
+                "Zone '{}' is ready to be signed, but is waiting for other zones to finish first.",
+                zone.name
+            );
+
+            Err(SigningPending {
+                zone,
+                _assertion: (),
+            })
+        }
+    }
+
+    /// Abandon a [`SigningPending`].
+    ///
+    /// A pending permit may need to be abandoned if a re-signing operation is
+    /// canceled. If this is called when the zone would have received a permit,
+    /// the permit will be passed on to the next zone in the queue.
+    #[tracing::instrument(
+        level = "trace",
+        skip_all,
+        fields(zone = %pending.zone.name),
+    )]
+    pub fn abandon(&self, pending: SigningPending, center: &Arc<Center>) {
+        trace!("Abandoning the position in the signing queue");
+        let mut zones = self.zones.lock().unwrap_or_else(handle_poison);
+
+        // Consume the token.
+        let zone = pending.consume();
+
+        // Locate this zone in the queue and remove it.
+        let Some(pos) = zones.iter().position(|z| Arc::ptr_eq(z, &zone)) else {
+            unreachable!(
+                "Zone '{}' has a permit but is not present in the signing queue",
+                zone.name
+            )
+        };
+        let _ = zones.remove(pos);
+        let finished_zone = zone;
+
+        // If the zone was within signing capacity, try activating a new zone.
+        if pos >= self.concurrency_limit.get() {
+            return;
+        }
+
+        trace!("The zone was within signing capacity");
+        let mut lock = SigningQueueLock { zones: &mut zones };
+        self.initiate_resigning(&finished_zone, &mut lock, center);
+    }
+
+    /// Accept a signing permit.
+    ///
+    /// A [`SigningPending`] is exchanged for a [`SigningPermit`] following a
+    /// check that the zone is now within signing capacity.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the zone is not within signing capacity.
+    #[tracing::instrument(
+        level = "trace",
+        skip_all,
+        fields(zone = %pending.zone.name),
+    )]
+    pub fn accept(
+        &self,
+        pending: SigningPending,
+        lock: &mut SigningQueueLock<'_>,
+    ) -> SigningPermit {
+        trace!("Exchanging a pending token for a permit");
+        let zones = &mut *lock.zones;
+
+        // Consume the token.
+        let zone = pending.consume();
+
+        // Ensure the zone is within the signing capacity.
+        let pos = zones.iter().position(|z| Arc::ptr_eq(z, &zone));
+        let pos = pos.unwrap_or_else(|| {
+            panic!(
+                "Zone '{}' has a `SigningPending` but could not be found in the signing queue",
+                zone.name
+            )
+        });
+        assert!(
+            pos < self.concurrency_limit.get(),
+            "Zone '{}' is not within the signing capacity (position {pos}, limit {})",
+            zone.name,
+            self.concurrency_limit.get()
+        );
+
+        // We have validated the zone is now within signing capacity.
+        SigningPermit {
+            zone,
+            _assertion: (),
+        }
+    }
+
+    /// Finish using a signing permit.
+    ///
+    /// This must be called for every [`SigningPermit`] provided once the
+    /// associated signing operation is complete. It initiates re-signing for
+    /// the next zone in the queue.
+    #[tracing::instrument(
+        level = "trace",
+        skip_all,
+        fields(zone = %permit.zone.name),
+    )]
+    pub fn finish(&self, permit: SigningPermit, center: &Arc<Center>) {
+        trace!("Finishing using a permit");
+        let mut zones = self.zones.lock().unwrap_or_else(handle_poison);
+
+        // Consume the permit.
+        let zone = permit.consume();
+
+        // Locate this zone in the queue and remove it.
+        let Some(pos) = zones.iter().position(|z| Arc::ptr_eq(z, &zone)) else {
+            unreachable!(
+                "Zone '{}' has a permit but is not present in the signing queue",
+                zone.name
+            )
+        };
+        let _ = zones.remove(pos);
+        let finished_zone = zone;
+
+        // Initiate re-signing for a zone that now fits within capacity.
+        let mut lock = SigningQueueLock { zones: &mut zones };
+        self.initiate_resigning(&finished_zone, &mut lock, center);
+    }
+
+    /// Initiate re-signing due to the freeing up of signing capacity.
+    fn initiate_resigning(
+        &self,
+        finished_zone: &Arc<Zone>,
+        lock: &mut SigningQueueLock<'_>,
+        center: &Arc<Center>,
+    ) {
+        // Look for a zone that now fits within capacity.
+        if let Some(zone) = lock.zones.get(self.concurrency_limit.get() - 1) {
+            // Make sure 'finished_zone' doesn't appear again, otherwise we
+            // might cause a deadlock!
+            assert!(
+                !Arc::ptr_eq(zone, finished_zone),
+                "Zone '{}' appeared twice in the signing queue",
+                finished_zone.name
+            );
+
+            // Try initiating the zone's signing operation.
+
+            trace!("Passing on the queue permit to '{}'", zone.name);
+
+            // NOTE: We lock `zone` and then tell it to obtain a permit. It
+            // will call `SigningQueue::accept()` to do so. This could easily
+            // lead to a deadlock --- this is why we explicitly pass `lock` and
+            // make `accept()` consume `lock`.
+            zone.clone()
+                .write_handle(center)
+                .signer()
+                .accept_queue_permit(lock);
+        }
+    }
+}
+
+impl fmt::Debug for SigningQueue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let concurrency_limit = self.concurrency_limit.get();
+        let zones = self.zones.lock().unwrap_or_else(handle_poison);
+        let zones = &*zones;
+        let active = zones.iter().take(concurrency_limit);
+        let pending = zones.iter().skip(concurrency_limit);
+        f.debug_struct("SigningQueue")
+            .field("concurrency_limit", &concurrency_limit)
+            .field(
+                "active",
+                &FmtBy(|f| f.debug_list().entries(active.clone()).finish()),
+            )
+            .field(
+                "pending",
+                &FmtBy(|f| f.debug_list().entries(pending.clone()).finish()),
+            )
+            .finish()
+    }
+}
+
+//----------- SigningPermit ----------------------------------------------------
+
+/// A permit from the signing queue.
+///
+/// This token asserts that the caller is allowed to initiate signing. It is
+/// provided by the [`SigningQueue`] and must be returned to it when signing
+/// completes.
+#[must_use = "Return this permit to `SigningQueue::finish()`"]
+pub struct SigningPermit {
+    /// The zone associated with this permit.
+    ///
+    /// This is used to find the zone's entry in the signing queue.
+    zone: Arc<Zone>,
+
+    /// The underlying assertion, local to this module.
+    _assertion: (),
+}
+
+impl SigningPermit {
+    /// Consume a [`SigningPermit`], returning the underlying zone.
+    ///
+    /// This is a module-local function, asserting that the permit is finished.
+    fn consume(self) -> Arc<Zone> {
+        // NOTE: Rust (currently?) disallows moving out of `self` because of the
+        // `Drop` impl. Clone `zone` out while preventing the drop hook (which
+        // tries to panic) from running.
+        ManuallyDrop::new(self).zone.clone()
+    }
+}
+
+impl Drop for SigningPermit {
+    /// Panic because [`SigningPermit`] should not be dropped.
+    fn drop(&mut self) {
+        panic!("Dropped {self:?}")
+    }
+}
+
+impl fmt::Debug for SigningPermit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Write a single line for brevity, even for `{#?}`.
+        write!(f, "SigningPermit {{ zone: \"{}\" }}", self.zone.name)
+    }
+}
+
+//----------- SigningPending ---------------------------------------------------
+
+/// Proof a zone is waiting in the [`SigningQueue`].
+///
+/// This token asserts that the caller is in the [`SigningQueue`] and is waiting
+/// for signing capacity. It is provided by the [`SigningQueue`] and must be
+/// returned to it in exchange for a [`SigningPermit`].
+#[must_use = "Call `SigningQueue::abandon()` instead of dropping"]
+pub struct SigningPending {
+    /// The zone associated with this permit.
+    ///
+    /// This is used to find the zone's entry in the signing queue.
+    zone: Arc<Zone>,
+
+    /// The underlying assertion, local to this module.
+    _assertion: (),
+}
+
+impl SigningPending {
+    /// Consume a [`SigningPending`], returning the underlying zone.
+    ///
+    /// This is a module-local function, asserting that the permit is finished.
+    fn consume(self) -> Arc<Zone> {
+        // NOTE: Rust (currently?) disallows moving out of `self` because of the
+        // `Drop` impl. Clone `zone` out while preventing the drop hook (which
+        // tries to panic) from running.
+        ManuallyDrop::new(self).zone.clone()
+    }
+}
+
+impl Drop for SigningPending {
+    /// Panic because [`SigningPending`] should not be dropped.
+    fn drop(&mut self) {
+        panic!("Dropped {self:?}")
+    }
+}
+
+impl fmt::Debug for SigningPending {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Write a single line for brevity, even for `{#?}`.
+        write!(f, "SigningPending {{ zone: \"{}\" }}", self.zone.name)
+    }
+}
+
+//------------------------------------------------------------------------------
+
+/// Handle a lock poisoning failure.
+//
+// TODO: Return '!'.
+#[track_caller]
+fn handle_poison<T, R>(_: PoisonError<T>) -> R {
+    panic!("The zone signing queue is poisoned because a panic occurred elsewhere")
+}

--- a/src/signer/zone.rs
+++ b/src/signer/zone.rs
@@ -351,17 +351,12 @@ impl SignerZoneHandle<'_> {
         // initiating signing operations, and does not really matter for the
         // actual signing function. Start with an empty logging context.
         let span = tracing::Span::none();
-        self.state.signer.ongoing.spawn(
-            span,
-            super::sign(
-                self.center.clone(),
-                self.zone.clone(),
-                builder,
-                trigger,
-                permit,
-                status.clone(),
-            ),
-        );
+        self.state.signer.ongoing.spawn_blocking(span, {
+            let center = self.center.clone();
+            let zone = self.zone.clone();
+            let status = status.clone();
+            move || super::sign(center, zone, builder, trigger, permit, status)
+        });
         self.state.signer.active_signing_status = Some(status);
     }
 }

--- a/src/signer/zone.rs
+++ b/src/signer/zone.rs
@@ -12,6 +12,7 @@ use crate::{
     center::Center,
     signer::{
         ResigningTrigger, SigningTrigger,
+        queue::SigningQueueLock,
         status::{SigningStatusPerZone, ZoneSigningStatus},
     },
     util::BackgroundTasks,
@@ -230,6 +231,20 @@ impl SignerZoneHandle<'_> {
         self.start_op(builder, SigningTrigger::Resign(trigger));
 
         true
+    }
+
+    /// Accept a signing queue permit.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the zone does not have an enqueued signing operation.
+    #[tracing::instrument(
+        level = "trace",
+        skip_all,
+        fields(zone = %self.zone.name),
+    )]
+    pub fn accept_queue_permit(&mut self, lock: &mut SigningQueueLock<'_>) {
+        todo!()
     }
 
     /// Start a signing operation immediately.

--- a/src/signer/zone.rs
+++ b/src/signer/zone.rs
@@ -12,7 +12,7 @@ use crate::{
     center::Center,
     signer::{
         ResigningTrigger, SigningTrigger,
-        queue::SigningQueueLock,
+        queue::{SigningPending, SigningPermit, SigningQueueLock},
         status::{SigningStatusPerZone, ZoneSigningStatus},
     },
     util::BackgroundTasks,
@@ -68,16 +68,26 @@ impl SignerZoneHandle<'_> {
         // A zone can have at most one 'SignedZoneBuilder' at a time. Because
         // we have 'builder', we are guaranteed that no other signing operations
         // are ongoing right now. A re-signing operation may be enqueued, but it
-        // has lower priority than this (for now).
+        // has lower priority than this (TODO: for now).
 
         assert!(self.state.signer.enqueued_new_sign.is_none());
 
-        // TODO: Keep state for a queue of pending (re-)signing operations, so
-        // that the number of simultaneous operations can be limited. At the
-        // moment, this queue is opaque and is handled within the asynchronous
-        // task.
+        // Try to get a spot in the signing queue.
+        match self
+            .center
+            .signer
+            .queue
+            .enqueue(self.zone.clone(), &builder)
+        {
+            Ok(permit) => {
+                self.start_op(builder, SigningTrigger::Load, permit);
+            }
 
-        self.start_op(builder, SigningTrigger::Load);
+            Err(pending) => {
+                // Save the operation for later.
+                self.state.signer.enqueued_new_sign = Some(EnqueuedSign { builder, pending })
+            }
+        }
     }
 
     /// Enqueue a re-signing operation for the zone.
@@ -141,15 +151,11 @@ impl SignerZoneHandle<'_> {
             .state
             .next_min_expiration
             .or(self.state.min_expiration)
-            .expect("checked for a published/upcoming signed instance")
+            .unwrap_or_else(|| panic!("re-sign enqueued but the zone has not been signed"))
             .to_system_time(SystemTime::now());
 
-        // TODO: Keep state for a queue of pending (re-)signing operations, so
-        // that the number of simultaneous operations can be limited. At the
-        // moment, this queue is opaque and is handled within the asynchronous
-        // task.
-
-        // Try to initiate the re-sign immediately.
+        // Make sure a published instance exists.
+        // Then, try to obtain a `SignedZoneBuilder` so building can begin.
         if self.state.min_expiration.is_some()
             && let Some(builder) = self.zone().try_start_resign()
         {
@@ -159,10 +165,33 @@ impl SignerZoneHandle<'_> {
 
             assert!(self.state.signer.enqueued_new_sign.is_none());
 
-            self.start_op(builder, SigningTrigger::Resign(trigger));
+            // Try to get a spot in the signing queue.
+            match self
+                .center
+                .signer
+                .queue
+                .enqueue(self.zone.clone(), &builder)
+            {
+                Ok(permit) => {
+                    // Start signing immediately.
+                    self.start_op(builder, SigningTrigger::Resign(trigger), permit);
+                }
+
+                Err(pending) => {
+                    // Give up and save the operation for later.
+                    self.state.signer.enqueued_resign = Some(EnqueuedResign {
+                        builder: Some(builder),
+                        pending: Some(pending),
+                        trigger,
+                        expiration_time,
+                    });
+                }
+            }
         } else {
+            // Give up and save the operation for later.
             self.state.signer.enqueued_resign = Some(EnqueuedResign {
                 builder: None,
+                pending: None,
                 trigger,
                 expiration_time,
             });
@@ -192,8 +221,9 @@ impl SignerZoneHandle<'_> {
         // Load the one enqueued re-sign operation, if it exists.
         let Some(EnqueuedResign {
             builder,
+            pending,
             trigger,
-            expiration_time: _, // TODO
+            expiration_time,
         }) = self.state.signer.enqueued_resign.take()
         else {
             // A re-sign is not enqueued, nothing to do.
@@ -203,6 +233,10 @@ impl SignerZoneHandle<'_> {
         // As mentioned above, 'SignedZoneBuilder' cannot exist when the zone
         // data storage is in the passive state.
         assert!(builder.is_none());
+        assert!(
+            pending.is_none(),
+            "`pending` can only exist when `builder` exists"
+        );
 
         // Since the zone data storage is passive, there is no upcoming instance
         // of the zone. If a published signed instance does not exist either,
@@ -223,12 +257,27 @@ impl SignerZoneHandle<'_> {
             .try_start_resign()
             .expect("the zone data storage is passive");
 
-        // TODO: Once an explicit queue of signing operations has been
-        // implemented (for limiting the number of simultaneous operations),
-        // add the operation to the queue before starting the re-sign. If the
-        // queue is too full to start the operation yet, leave it enqueued.
-
-        self.start_op(builder, SigningTrigger::Resign(trigger));
+        // Add the zone to the signing queue.
+        match self
+            .center
+            .signer
+            .queue
+            .enqueue(self.zone.clone(), &builder)
+        {
+            Ok(permit) => {
+                // Start signing immediately.
+                self.start_op(builder, SigningTrigger::Resign(trigger), permit);
+            }
+            Err(pending) => {
+                // Save the pending operation back in state.
+                self.state.signer.enqueued_resign = Some(EnqueuedResign {
+                    builder: Some(builder),
+                    pending: Some(pending),
+                    trigger,
+                    expiration_time,
+                });
+            }
+        }
 
         true
     }
@@ -244,11 +293,55 @@ impl SignerZoneHandle<'_> {
         fields(zone = %self.zone.name),
     )]
     pub fn accept_queue_permit(&mut self, lock: &mut SigningQueueLock<'_>) {
-        todo!()
+        if let Some(op) = self.state.signer.enqueued_new_sign.take() {
+            let EnqueuedSign { builder, pending } = op;
+            let permit = self.center.signer.queue.accept(pending, lock);
+
+            self.start_op(builder, SigningTrigger::Load, permit);
+        } else if let Some(op) = self.state.signer.enqueued_resign.take() {
+            let EnqueuedResign {
+                builder,
+                pending,
+                trigger,
+                expiration_time: _, // TODO
+            } = op;
+
+            let Some(pending) = pending else {
+                panic!("The zone did not have an enqueued signing operation");
+            };
+            let Some(builder) = builder else {
+                unreachable!("`pending` must only exist when `builder` exists");
+            };
+            let permit = self.center.signer.queue.accept(pending, lock);
+
+            self.start_op(builder, SigningTrigger::Resign(trigger), permit);
+        }
+    }
+
+    /// Cancel enqueued signing operations.
+    pub fn cancel_enqueued_signing_operations(&mut self) {
+        // NOTE: This method is called while a `{Loaded,Signed}ZoneRestorer` is
+        // held, so `SignedZoneBuilder`s cannot exist.
+
+        // An enqueued new-sign would have a `SignedZoneBuilder`, which cannot
+        // exist at this stage.
+        assert!(self.state.signer.enqueued_new_sign.is_none());
+
+        if let Some(op) = self.state.signer.enqueued_resign.take() {
+            // NOTE: Even if `op` exists, it should not contain a builder at
+            // this stage, and `op.pending` only exists iff `op.builder` exists.
+            assert!(op.builder.is_none());
+            assert!(op.pending.is_none());
+        }
     }
 
     /// Start a signing operation immediately.
-    fn start_op(&mut self, builder: SignedZoneBuilder, trigger: SigningTrigger) {
+    fn start_op(
+        &mut self,
+        builder: SignedZoneBuilder,
+        trigger: SigningTrigger,
+        permit: SigningPermit,
+    ) {
         let status = Arc::new(RwLock::new(SigningStatusPerZone {
             current_action: "Initiating signing".into(),
             status: ZoneSigningStatus::new(),
@@ -265,6 +358,7 @@ impl SignerZoneHandle<'_> {
                 self.zone.clone(),
                 builder,
                 trigger,
+                permit,
                 status.clone(),
             ),
         );
@@ -292,13 +386,6 @@ pub struct SignerState {
     pub active_signing_status: Option<Arc<RwLock<SigningStatusPerZone>>>,
 }
 
-impl SignerState {
-    pub fn cancel_enqueued_signing_operations(&mut self) {
-        self.enqueued_new_sign = None;
-        self.enqueued_resign = None;
-    }
-}
-
 //----------- EnqueuedSign -----------------------------------------------------
 
 /// An enqueued sign of a zone.
@@ -306,6 +393,12 @@ impl SignerState {
 pub struct EnqueuedSign {
     /// The zone builder.
     pub builder: SignedZoneBuilder,
+
+    /// The zone's position in the signing queue.
+    ///
+    /// If the zone can be signed immediately (i.e. a [`SigningPermit`] is
+    /// received instead of a [`SigningPending`]), it should be.
+    pub pending: SigningPending,
 }
 
 //----------- EnqueuedResign ---------------------------------------------------
@@ -320,6 +413,14 @@ pub struct EnqueuedResign {
     /// Even if the builder is obtained, the operation might not be ready
     /// to start.
     pub builder: Option<SignedZoneBuilder>,
+
+    /// The zone's position in the signing queue.
+    ///
+    /// This must be [`Some`] exactly when [`Self::builder`] is [`Some`]; that
+    /// is, re-signing cannot be enqueued until a builder is available. If the
+    /// zone can be re-signed immediately (i.e. a [`SigningPermit`] is received
+    /// instead of a [`SigningPending`]), it should be.
+    pub pending: Option<SigningPending>,
 
     /// The trigger causing this operation.
     pub trigger: ResigningTrigger,

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -223,7 +223,26 @@ impl HttpServer {
         }
 
         // Fetch the signing queue.
-        let signing_queue = center.signer.on_queue_report(center);
+        let signing_queue = {
+            let mut report = Vec::new();
+
+            // Get a list of zones in the queue.
+            let zones = center.signer.queue.export();
+
+            for zone in zones {
+                let zone_state = zone.read();
+                if let Some(status) = &zone_state.signer.active_signing_status
+                    && let Some(stage_report) = status.read().unwrap().mk_signing_report()
+                {
+                    report.push(SigningQueueReport {
+                        zone_name: zone.name.clone(),
+                        signing_report: stage_report,
+                    });
+                }
+            }
+
+            report
+        };
 
         let f = |x: &Vec<cascade_cfg::SocketConfig>| x.iter().map(|s| s.addr()).collect::<Vec<_>>();
         let loaded_review_addrs = f(&center.config.loader.review.servers);

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -50,8 +50,8 @@ use crate::center::Center;
 use crate::manager::{Terminated, record_zone_event};
 use crate::policy::{PolicyVersion, SignerDenialPolicy, SignerSerialPolicy};
 use crate::signer::incremental::{LocalState, sign_incrementally};
-use crate::signer::status::{SigningStatusPerZone, ZoneSigningStatus};
 use crate::signer::queue::SigningQueue;
+use crate::signer::status::{SigningStatusPerZone, ZoneSigningStatus};
 use crate::signer::{ResigningTrigger, SigningTrigger};
 use crate::units::http_server::KmipServerState;
 use crate::units::key_manager::{

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -1,5 +1,5 @@
 use std::cmp::{Ordering, min};
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet};
 use std::env::{self, VarError};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, RwLock};
@@ -40,12 +40,11 @@ use rayon::iter::{
 };
 use rayon::slice::ParallelSliceMut;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{OwnedSemaphorePermit, Semaphore, watch};
+use tokio::sync::watch;
 use tokio::time::Instant;
-use tracing::{Level, debug, error, info, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 use url::Url;
 
-use crate::api::SigningQueueReport;
 use crate::center::Center;
 use crate::manager::{Terminated, record_zone_event};
 use crate::policy::{PolicyVersion, SignerDenialPolicy, SignerSerialPolicy};
@@ -77,10 +76,6 @@ use crate::zone::{HistoricalEvent, Zone, ZoneByName};
 //------------ ZoneSigner ----------------------------------------------------
 
 pub struct ZoneSigner {
-    // TODO: Discuss whether this semaphore is necessary.
-    max_concurrent_operations: usize,
-    concurrent_operation_permits: Arc<Semaphore>,
-    signer_status: ZoneSignerStatus,
     pub kmip_servers: Arc<Mutex<HashMap<String, SyncConnPool>>>,
 
     /// A live view of the next scheduled global resigning time.
@@ -99,9 +94,6 @@ impl ZoneSigner {
         let queue = SigningQueue::new(max_concurrent_operations.try_into().unwrap());
 
         Self {
-            max_concurrent_operations,
-            concurrent_operation_permits: Arc::new(Semaphore::new(max_concurrent_operations)),
-            signer_status: ZoneSignerStatus::new(),
             kmip_servers: Default::default(),
             next_resign_time_tx,
             next_resign_time_rx,
@@ -194,24 +186,6 @@ impl ZoneSigner {
         Ok(public_key_info)
     }
 
-    pub fn on_queue_report(&self, _center: &Arc<Center>) -> Vec<SigningQueueReport> {
-        let mut report = vec![];
-        let zone_signer_status = &self.signer_status;
-        let q = zone_signer_status.zones_being_signed.read().unwrap();
-        for (zone, _q_item) in q.iter().rev() {
-            let zone_state = zone.read();
-            if let Some(status) = &zone_state.signer.active_signing_status
-                && let Some(stage_report) = status.read().unwrap().mk_signing_report()
-            {
-                report.push(SigningQueueReport {
-                    zone_name: zone.name.clone(),
-                    signing_report: stage_report,
-                });
-            }
-        }
-        report
-    }
-
     pub fn on_publish_signed_zone(&self, center: &Arc<Center>) {
         trace!("[ZS]: a zone is published, recompute next time to re-sign");
         let _ = self.next_resign_time_tx.send(self.next_resign_time(center));
@@ -222,43 +196,6 @@ impl ZoneSigner {
         // react to changes in policy, for example, whether NSEC is used
         // or NSEC3.
         let _ = self.next_resign_time_tx.send(Some(Instant::now()));
-    }
-
-    /// Enqueue a zone for signing, waiting until it can begin.
-    pub async fn wait_to_sign(
-        &self,
-        zone: &Arc<Zone>,
-    ) -> (Arc<RwLock<SigningStatusPerZone>>, [OwnedSemaphorePermit; 3]) {
-        let zone_name = &zone.name;
-        info!("[ZS]: Waiting to enqueue signing operation for zone '{zone_name}'.");
-
-        self.signer_status.dump_queue();
-
-        let (q_size, q_permit, zone_permit, status) = {
-            let signer_status = &self.signer_status;
-            // TODO: Propagate the error properly.
-            signer_status
-                .enqueue(zone)
-                .await
-                .unwrap_or_else(|err| panic!("{err}"))
-        };
-
-        let num_ops_in_progress =
-            self.max_concurrent_operations - self.concurrent_operation_permits.available_permits();
-        info!(
-            "[ZS]: Waiting to start signing operation for zone '{zone_name}': {num_ops_in_progress} signing operations are in progress and {} operations are queued ahead of us.",
-            q_size - 1
-        );
-
-        let permit = self
-            .concurrent_operation_permits
-            .clone()
-            .acquire_owned()
-            .await
-            .unwrap();
-
-        // TODO: Why do we need three different permits?
-        (status, [q_permit, zone_permit, permit])
     }
 
     pub fn sign_zone(
@@ -934,140 +871,6 @@ fn parse_nsec3_config(opt_out: bool) -> GenerateNsec3Config<Bytes, MultiThreaded
 impl std::fmt::Debug for ZoneSigner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ZoneSigner").finish()
-    }
-}
-
-//------------ ZoneSignerStatus ----------------------------------------------
-
-const SIGNING_QUEUE_SIZE: usize = 100;
-
-struct ZoneSignerStatus {
-    // Maps zone names to signing status, keeping records of previous signing.
-    // Use VecDeque for its ability to act as a ring buffer: check size, if
-    // at max desired capacity pop_front(), then in both cases push_back().
-    //
-    // TODO: Separate out signing request queuing from signing statistics
-    // tracking.
-    #[allow(clippy::type_complexity)] // TODO: Finish removing `ZoneSignerStatus`
-    zones_being_signed: Arc<RwLock<VecDeque<(Arc<Zone>, Arc<RwLock<SigningStatusPerZone>>)>>>,
-
-    // Sign each zone only once at a time.
-    zone_semaphores: Arc<RwLock<HashMap<Name<Bytes>, Arc<Semaphore>>>>,
-
-    queue_semaphore: Arc<Semaphore>,
-}
-
-impl ZoneSignerStatus {
-    pub fn new() -> Self {
-        Self {
-            zones_being_signed: Arc::new(std::sync::RwLock::new(VecDeque::with_capacity(
-                SIGNING_QUEUE_SIZE,
-            ))),
-            zone_semaphores: Default::default(),
-            queue_semaphore: Arc::new(Semaphore::new(SIGNING_QUEUE_SIZE)),
-        }
-    }
-
-    fn dump_queue(&self) {
-        if tracing::event_enabled!(Level::DEBUG) {
-            let zones_being_signed = self.zones_being_signed.read().unwrap();
-            for (zone, q_item) in zones_being_signed.iter().rev() {
-                let q_item = q_item.read().unwrap();
-                match q_item.status {
-                    ZoneSigningStatus::Requested(_) => {
-                        debug!("[ZS]: Queue item: {} => requested", zone.name)
-                    }
-                    ZoneSigningStatus::InProgress(_) => {
-                        debug!("[ZS]: Queue item: {} => in-progress", zone.name)
-                    }
-                    ZoneSigningStatus::Finished(_) => {
-                        debug!("[ZS]: Queue item: {} => finished", zone.name)
-                    }
-                    ZoneSigningStatus::Aborted => {
-                        debug!("[ZS]: Queue item: {} => aborted", zone.name)
-                    }
-                };
-            }
-        }
-    }
-
-    /// Enqueue a zone for signing.
-    pub async fn enqueue(
-        &self,
-        zone: &Arc<Zone>,
-    ) -> Result<
-        (
-            usize,
-            OwnedSemaphorePermit,
-            OwnedSemaphorePermit,
-            Arc<RwLock<SigningStatusPerZone>>,
-        ),
-        SignerError,
-    > {
-        let zone_name = &zone.name;
-        debug!("SIGNER[{zone_name}]: Adding to the queue");
-        let status = Arc::new(RwLock::new(SigningStatusPerZone {
-            current_action: "Waiting for any existing signing operation for this zone to finish"
-                .to_string(),
-            status: ZoneSigningStatus::new(),
-        }));
-        {
-            let mut zones_being_signed = self.zones_being_signed.write().unwrap();
-            zones_being_signed.push_back((zone.clone(), status.clone()));
-        }
-
-        let approx_q_size = SIGNING_QUEUE_SIZE - self.queue_semaphore.available_permits() + 1;
-        debug!("SIGNER[{zone_name}]: Approx queue size = {approx_q_size}");
-
-        debug!("SIGNER[{zone_name}]: Acquiring zone permit");
-        let zone_semaphore = self
-            .zone_semaphores
-            .write()
-            .unwrap()
-            .entry(zone_name.clone())
-            .or_insert(Arc::new(Semaphore::new(1)))
-            .clone();
-        let zone_permit = zone_semaphore.acquire_owned().await.map_err(|_| {
-            SignerError::InternalError("Cannot acquire the zone semaphore".to_string())
-        })?;
-        debug!("SIGNER[{zone_name}]: Zone permit acquired");
-
-        status.write().unwrap().current_action = "Waiting for a signing queue slot".to_string();
-
-        debug!("SIGNER: Acquiring queue permit");
-        let queue_permit = self
-            .queue_semaphore
-            .clone()
-            .acquire_owned()
-            .await
-            .map_err(|_| SignerError::SignerNotReady)?;
-        debug!("SIGNER[{zone_name}]: Queue permit acquired");
-
-        // If we were able to acquire a permit that means that a signing operation completed
-        // and so we are safe to remove one item from the ring buffer.
-        let mut zones_being_signed = self.zones_being_signed.write().unwrap();
-        if zones_being_signed.len() == zones_being_signed.capacity() {
-            // Discard oldest.
-            let signing_status = zones_being_signed.pop_front();
-            if let Some((_zone, signing_status)) = signing_status {
-                // Old items in the queue should have reached a final state,
-                // either finished or aborted. If not, something is wrong with
-                // the queueing logic.
-                if !matches!(
-                    signing_status.read().unwrap().status,
-                    ZoneSigningStatus::Finished(_) | ZoneSigningStatus::Aborted
-                ) {
-                    return Err(SignerError::InternalError(
-                        "Signing queue not in the expected state".to_string(),
-                    ));
-                }
-            }
-        }
-
-        status.write().unwrap().current_action = "Queued for signing".to_string();
-
-        debug!("SIGNER[{zone_name}]: Enqueuing complete.");
-        Ok((approx_q_size, queue_permit, zone_permit, status))
     }
 }
 

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -51,6 +51,7 @@ use crate::manager::{Terminated, record_zone_event};
 use crate::policy::{PolicyVersion, SignerDenialPolicy, SignerSerialPolicy};
 use crate::signer::incremental::{LocalState, sign_incrementally};
 use crate::signer::status::{SigningStatusPerZone, ZoneSigningStatus};
+use crate::signer::queue::SigningQueue;
 use crate::signer::{ResigningTrigger, SigningTrigger};
 use crate::units::http_server::KmipServerState;
 use crate::units::key_manager::{
@@ -85,6 +86,9 @@ pub struct ZoneSigner {
     /// A live view of the next scheduled global resigning time.
     next_resign_time_tx: watch::Sender<Option<tokio::time::Instant>>,
     next_resign_time_rx: watch::Receiver<Option<tokio::time::Instant>>,
+
+    /// The signing queue.
+    pub queue: SigningQueue,
 }
 
 impl ZoneSigner {
@@ -92,6 +96,7 @@ impl ZoneSigner {
     pub fn new() -> Self {
         let max_concurrent_operations = 1;
         let (next_resign_time_tx, next_resign_time_rx) = watch::channel(None);
+        let queue = SigningQueue::new(max_concurrent_operations.try_into().unwrap());
 
         Self {
             max_concurrent_operations,
@@ -100,6 +105,7 @@ impl ZoneSigner {
             kmip_servers: Default::default(),
             next_resign_time_tx,
             next_resign_time_rx,
+            queue,
         }
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -119,6 +119,36 @@ impl fmt::Debug for BackgroundTasks {
     }
 }
 
+//----------- FmtBy() ----------------------------------------------------------
+
+/// Format using the given closure.
+///
+/// This is a polyfill for [`std::fmt::from_fn()`], which does not yet fit in
+/// our MSRV.
+///
+/// [`std::fmt::from_fn()`]: https://doc.rust-lang.org/stable/std/fmt/fn.from_fn.html
+pub struct FmtBy<F>(pub F)
+where
+    F: Fn(&mut fmt::Formatter<'_>) -> fmt::Result;
+
+impl<F> fmt::Debug for FmtBy<F>
+where
+    F: Fn(&mut fmt::Formatter<'_>) -> fmt::Result,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (self.0)(f)
+    }
+}
+
+impl<F> fmt::Display for FmtBy<F>
+where
+    F: Fn(&mut fmt::Formatter<'_>) -> fmt::Result,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (self.0)(f)
+    }
+}
+
 //------------------------------------------------------------------------------
 
 /// Force a [`Future`] to evaluate synchronously.


### PR DESCRIPTION
The new signing queue uses synchronous code and integrates directly with `ZoneState`. It offers us better visibility when a zone is waiting in the signing queue (there is now an explicit indication of this in `ZoneState`). The control flow in `src/signer/zone.rs` was already built to accommodate this change, so the resulting diff is not so big.

Solves #741. Blocks #740.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?