### PR TITLE
Disentangle zone signing status from the queue

### DIFF
--- a/src/signer/incremental.rs
+++ b/src/signer/incremental.rs
@@ -44,10 +44,11 @@ use crate::center::Center;
 use crate::manager::record_zone_event;
 use crate::policy::{PolicyVersion, SignerDenialPolicy, SignerSerialPolicy};
 use crate::signer::SigningTrigger;
+use crate::signer::status::SigningStatusPerZone;
 use crate::units::key_manager::mk_dnst_keyset_state_file_path;
 use crate::units::zone_signer::{
-    KeyPair, KeySetState, MinTimestamp, PassThroughMode, SignerError, SigningStatusPerZone,
-    ZoneSigner, faketime_or_now, load_keys,
+    KeyPair, KeySetState, MinTimestamp, PassThroughMode, SignerError, ZoneSigner, faketime_or_now,
+    load_keys,
 };
 use crate::zone::{HistoricalEvent, Zone};
 

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -19,17 +19,17 @@
 
 use std::{
     ops::{BitOr, BitOrAssign},
-    sync::Arc,
+    sync::{Arc, RwLock},
 };
 
 use cascade_zonedata::SignedZoneBuilder;
 use tracing::{debug, error};
 
-use crate::units::zone_signer::SignerError;
 use crate::{
     center::Center,
     zone::{HistoricalEvent, Zone},
 };
+use crate::{signer::status::SigningStatusPerZone, units::zone_signer::SignerError};
 
 pub mod incremental;
 pub mod status;
@@ -58,8 +58,9 @@ async fn sign(
     zone: Arc<Zone>,
     mut builder: SignedZoneBuilder,
     trigger: SigningTrigger,
+    status: Arc<RwLock<SigningStatusPerZone>>,
 ) {
-    let (status, _permits) = center.signer.wait_to_sign(&zone).await;
+    let (_status, _permits) = center.signer.wait_to_sign(&zone).await;
 
     let (result, builder) = tokio::task::spawn_blocking({
         let center = center.clone();
@@ -78,6 +79,7 @@ async fn sign(
     let mut status = status.write().unwrap();
     let mut handle = zone.write_handle(&center);
     handle.state.signer.ongoing.finish();
+    // TODO: Remove `status` from `handle.state.signer.active_signing_status`?
 
     match result {
         Ok(()) => {

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -32,6 +32,7 @@ use crate::{
 };
 
 pub mod incremental;
+pub mod status;
 pub mod zone;
 
 //----------- sign() -----------------------------------------------------------

--- a/src/signer/status.rs
+++ b/src/signer/status.rs
@@ -9,13 +9,14 @@ use crate::util::{
     serialize_duration_as_secs, serialize_instant_as_duration_secs, serialize_opt_duration_as_secs,
 };
 
+#[derive(Debug)]
 pub struct SigningStatusPerZone {
     pub current_action: String,
     pub status: ZoneSigningStatus,
 }
 
 // TODO: Why does this need to be serialized?
-#[derive(Copy, Clone, Serialize)]
+#[derive(Copy, Clone, Debug, Serialize)]
 pub enum ZoneSigningStatus {
     Requested(RequestedStatus),
 
@@ -69,7 +70,7 @@ impl std::fmt::Display for ZoneSigningStatus {
     }
 }
 
-#[derive(Copy, Clone, Serialize)]
+#[derive(Copy, Clone, Debug, Serialize)]
 pub struct RequestedStatus {
     #[serde(serialize_with = "serialize_instant_as_duration_secs")]
     pub requested_at: tokio::time::Instant,
@@ -84,7 +85,7 @@ impl RequestedStatus {
     }
 }
 
-#[derive(Copy, Clone, Serialize)]
+#[derive(Copy, Clone, Debug, Serialize)]
 pub struct InProgressStatus {
     #[serde(serialize_with = "serialize_instant_as_duration_secs")]
     pub requested_at: tokio::time::Instant,
@@ -128,7 +129,7 @@ impl InProgressStatus {
     }
 }
 
-#[derive(Copy, Clone, Serialize)]
+#[derive(Copy, Clone, Debug, Serialize)]
 pub struct FinishedStatus {
     #[serde(serialize_with = "serialize_instant_as_duration_secs")]
     pub requested_at: tokio::time::Instant,

--- a/src/signer/status.rs
+++ b/src/signer/status.rs
@@ -1,0 +1,180 @@
+//! Tracking the status of zone signing.
+
+use std::{sync::Arc, time::Duration};
+
+use serde::Serialize;
+use tokio::time::Instant;
+
+use crate::util::{
+    serialize_duration_as_secs, serialize_instant_as_duration_secs, serialize_opt_duration_as_secs,
+};
+use crate::zone::Zone;
+
+pub struct SigningStatusPerZone {
+    pub zone: Arc<Zone>,
+    pub current_action: String,
+    pub status: ZoneSigningStatus,
+}
+
+// TODO: Why does this need to be serialized?
+#[derive(Copy, Clone, Serialize)]
+pub enum ZoneSigningStatus {
+    Requested(RequestedStatus),
+
+    InProgress(InProgressStatus),
+
+    Finished(FinishedStatus),
+
+    Aborted,
+}
+
+impl ZoneSigningStatus {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self::Requested(RequestedStatus::new())
+    }
+
+    #[allow(clippy::result_unit_err)] // TODO
+    pub fn start(&mut self, zone_serial: domain::new::base::Serial) -> Result<(), ()> {
+        match *self {
+            ZoneSigningStatus::Requested(s) => {
+                *self = Self::InProgress(InProgressStatus::new(s, zone_serial));
+                Ok(())
+            }
+            ZoneSigningStatus::Aborted
+            | ZoneSigningStatus::InProgress(_)
+            | ZoneSigningStatus::Finished(_) => Err(()),
+        }
+    }
+
+    pub fn finish(&mut self, succeeded: bool) {
+        match *self {
+            ZoneSigningStatus::Requested(_) => {
+                *self = Self::Aborted;
+            }
+            ZoneSigningStatus::InProgress(status) => {
+                *self = Self::Finished(FinishedStatus::new(status, succeeded))
+            }
+            ZoneSigningStatus::Finished(_) | ZoneSigningStatus::Aborted => { /* Nothing to do */ }
+        }
+    }
+}
+
+impl std::fmt::Display for ZoneSigningStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ZoneSigningStatus::Requested(_) => f.write_str("Requested"),
+            ZoneSigningStatus::InProgress(_) => f.write_str("InProgress"),
+            ZoneSigningStatus::Finished(_) => f.write_str("Finished"),
+            ZoneSigningStatus::Aborted => f.write_str("Aborted"),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Serialize)]
+pub struct RequestedStatus {
+    #[serde(serialize_with = "serialize_instant_as_duration_secs")]
+    pub requested_at: tokio::time::Instant,
+}
+
+impl RequestedStatus {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            requested_at: Instant::now(),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Serialize)]
+pub struct InProgressStatus {
+    #[serde(serialize_with = "serialize_instant_as_duration_secs")]
+    pub requested_at: tokio::time::Instant,
+    pub zone_serial: domain::base::Serial,
+    #[serde(serialize_with = "serialize_instant_as_duration_secs")]
+    pub started_at: tokio::time::Instant,
+    pub unsigned_rr_count: Option<usize>,
+    #[serde(serialize_with = "serialize_opt_duration_as_secs")]
+    pub walk_time: Option<Duration>,
+    #[serde(serialize_with = "serialize_opt_duration_as_secs")]
+    pub sort_time: Option<Duration>,
+    pub denial_rr_count: Option<usize>,
+    #[serde(serialize_with = "serialize_opt_duration_as_secs")]
+    pub denial_time: Option<Duration>,
+    pub rrsig_count: Option<usize>,
+    pub rrsig_reused_count: Option<usize>,
+    #[serde(serialize_with = "serialize_opt_duration_as_secs")]
+    pub rrsig_time: Option<Duration>,
+    #[serde(serialize_with = "serialize_opt_duration_as_secs")]
+    pub total_time: Option<Duration>,
+    pub threads_used: Option<usize>,
+}
+
+impl InProgressStatus {
+    pub fn new(requested_status: RequestedStatus, zone_serial: domain::new::base::Serial) -> Self {
+        Self {
+            requested_at: requested_status.requested_at,
+            zone_serial: domain::base::Serial(zone_serial.into()),
+            started_at: Instant::now(),
+            unsigned_rr_count: None,
+            walk_time: None,
+            sort_time: None,
+            denial_rr_count: None,
+            denial_time: None,
+            rrsig_count: None,
+            rrsig_reused_count: None,
+            rrsig_time: None,
+            total_time: None,
+            threads_used: None,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Serialize)]
+pub struct FinishedStatus {
+    #[serde(serialize_with = "serialize_instant_as_duration_secs")]
+    pub requested_at: tokio::time::Instant,
+    #[serde(serialize_with = "serialize_instant_as_duration_secs")]
+    pub started_at: tokio::time::Instant,
+    pub zone_serial: domain::base::Serial,
+    pub unsigned_rr_count: usize,
+    #[serde(serialize_with = "serialize_duration_as_secs")]
+    pub walk_time: Duration,
+    #[serde(serialize_with = "serialize_duration_as_secs")]
+    pub sort_time: Duration,
+    pub denial_rr_count: usize,
+    #[serde(serialize_with = "serialize_duration_as_secs")]
+    pub denial_time: Duration,
+    pub rrsig_count: usize,
+    pub rrsig_reused_count: usize,
+    #[serde(serialize_with = "serialize_duration_as_secs")]
+    pub rrsig_time: Duration,
+    #[serde(serialize_with = "serialize_duration_as_secs")]
+    pub total_time: Duration,
+    pub threads_used: usize,
+    #[serde(serialize_with = "serialize_instant_as_duration_secs")]
+    pub finished_at: tokio::time::Instant,
+    pub succeeded: bool,
+}
+
+impl FinishedStatus {
+    fn new(in_progress_status: InProgressStatus, succeeded: bool) -> Self {
+        Self {
+            requested_at: in_progress_status.requested_at,
+            zone_serial: in_progress_status.zone_serial,
+            started_at: Instant::now(),
+            unsigned_rr_count: in_progress_status.unsigned_rr_count.unwrap_or_default(),
+            walk_time: in_progress_status.walk_time.unwrap_or_default(),
+            sort_time: in_progress_status.sort_time.unwrap_or_default(),
+            denial_rr_count: in_progress_status.denial_rr_count.unwrap_or_default(),
+            denial_time: in_progress_status.denial_time.unwrap_or_default(),
+            rrsig_count: in_progress_status.rrsig_count.unwrap_or_default(),
+            rrsig_reused_count: in_progress_status.rrsig_reused_count.unwrap_or_default(),
+            rrsig_time: in_progress_status.rrsig_time.unwrap_or_default(),
+            total_time: in_progress_status.total_time.unwrap_or_default(),
+            threads_used: in_progress_status.threads_used.unwrap_or_default(),
+            finished_at: Instant::now(),
+            succeeded,
+        }
+    }
+}

--- a/src/signer/status.rs
+++ b/src/signer/status.rs
@@ -1,7 +1,11 @@
 //! Tracking the status of zone signing.
 
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
+use cascade_api::{
+    SigningFinishedReport, SigningInProgressReport, SigningReport, SigningRequestedReport,
+    SigningStageReport,
+};
 use serde::Serialize;
 use tokio::time::Instant;
 
@@ -13,6 +17,62 @@ use crate::util::{
 pub struct SigningStatusPerZone {
     pub current_action: String,
     pub status: ZoneSigningStatus,
+}
+
+impl SigningStatusPerZone {
+    pub fn mk_signing_report(&self) -> Option<SigningReport> {
+        let now = Instant::now();
+        let now_t = SystemTime::now();
+        let stage_report = match self.status {
+            ZoneSigningStatus::Requested(s) => {
+                Some(SigningStageReport::Requested(SigningRequestedReport {
+                    requested_at: now_t.checked_sub(now.duration_since(s.requested_at))?,
+                }))
+            }
+            ZoneSigningStatus::InProgress(s) => {
+                Some(SigningStageReport::InProgress(SigningInProgressReport {
+                    requested_at: now_t.checked_sub(now.duration_since(s.requested_at))?,
+                    zone_serial: domain::base::Serial(s.zone_serial.into()),
+                    started_at: now_t.checked_sub(now.duration_since(s.started_at))?,
+                    unsigned_rr_count: s.unsigned_rr_count,
+                    walk_time: s.walk_time,
+                    sort_time: s.sort_time,
+                    denial_rr_count: s.denial_rr_count,
+                    denial_time: s.denial_time,
+                    rrsig_count: s.rrsig_count,
+                    rrsig_reused_count: s.rrsig_reused_count,
+                    rrsig_time: s.rrsig_time,
+                    total_time: s.total_time,
+                    threads_used: s.threads_used,
+                }))
+            }
+            ZoneSigningStatus::Finished(s) => {
+                Some(SigningStageReport::Finished(SigningFinishedReport {
+                    requested_at: now_t.checked_sub(now.duration_since(s.requested_at))?,
+                    zone_serial: domain::base::Serial(s.zone_serial.into()),
+                    started_at: now_t.checked_sub(now.duration_since(s.started_at))?,
+                    unsigned_rr_count: s.unsigned_rr_count,
+                    walk_time: s.walk_time,
+                    sort_time: s.sort_time,
+                    denial_rr_count: s.denial_rr_count,
+                    denial_time: s.denial_time,
+                    rrsig_count: s.rrsig_count,
+                    rrsig_reused_count: s.rrsig_reused_count,
+                    rrsig_time: s.rrsig_time,
+                    total_time: s.total_time,
+                    threads_used: s.threads_used,
+                    finished_at: now_t.checked_sub(now.duration_since(s.finished_at))?,
+                    succeeded: s.succeeded,
+                }))
+            }
+            ZoneSigningStatus::Aborted => None,
+        };
+
+        stage_report.map(|stage_report| SigningReport {
+            current_action: self.current_action.clone(),
+            stage_report,
+        })
+    }
 }
 
 // TODO: Why does this need to be serialized?

--- a/src/signer/status.rs
+++ b/src/signer/status.rs
@@ -1,6 +1,6 @@
 //! Tracking the status of zone signing.
 
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 use serde::Serialize;
 use tokio::time::Instant;
@@ -8,10 +8,8 @@ use tokio::time::Instant;
 use crate::util::{
     serialize_duration_as_secs, serialize_instant_as_duration_secs, serialize_opt_duration_as_secs,
 };
-use crate::zone::Zone;
 
 pub struct SigningStatusPerZone {
-    pub zone: Arc<Zone>,
     pub current_action: String,
     pub status: ZoneSigningStatus,
 }

--- a/src/signer/zone.rs
+++ b/src/signer/zone.rs
@@ -1,13 +1,19 @@
 //! Zone-specific signing state.
 
-use std::{sync::Arc, time::SystemTime};
+use std::{
+    sync::{Arc, RwLock},
+    time::SystemTime,
+};
 
 use cascade_zonedata::SignedZoneBuilder;
 use tracing::{debug, info};
 
 use crate::{
     center::Center,
-    signer::{ResigningTrigger, SigningTrigger},
+    signer::{
+        ResigningTrigger, SigningTrigger,
+        status::{SigningStatusPerZone, ZoneSigningStatus},
+    },
     util::BackgroundTasks,
     zone::{Zone, ZoneHandle, ZoneState},
 };
@@ -213,14 +219,26 @@ impl SignerZoneHandle<'_> {
 
     /// Start a signing operation immediately.
     fn start_op(&mut self, builder: SignedZoneBuilder, trigger: SigningTrigger) {
+        let status = Arc::new(RwLock::new(SigningStatusPerZone {
+            current_action: "Initiating signing".into(),
+            status: ZoneSigningStatus::new(),
+        }));
+
         // The current logging span is nested fairly deep within the logic for
         // initiating signing operations, and does not really matter for the
         // actual signing function. Start with an empty logging context.
         let span = tracing::Span::none();
         self.state.signer.ongoing.spawn(
             span,
-            super::sign(self.center.clone(), self.zone.clone(), builder, trigger),
+            super::sign(
+                self.center.clone(),
+                self.zone.clone(),
+                builder,
+                trigger,
+                status.clone(),
+            ),
         );
+        self.state.signer.active_signing_status = Some(status);
     }
 }
 
@@ -237,6 +255,11 @@ pub struct SignerState {
 
     /// An enqueued re-signing operation, if any.
     pub enqueued_resign: Option<EnqueuedResign>,
+
+    /// Status for an active signing operation, if any.
+    //
+    // TODO: Embed in a state machine.
+    pub active_signing_status: Option<Arc<RwLock<SigningStatusPerZone>>>,
 }
 
 impl SignerState {

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -361,6 +361,7 @@ impl HttpServer {
         let zone;
         let halted_reason;
         let progress;
+        let signing_report;
         let unsigned_serial;
         let signed_serial;
         let published_serial;
@@ -477,6 +478,17 @@ impl HttpServer {
                 ZoneStateMachine::SignedReview(..) => Progress::SignedReview,
                 ZoneStateMachine::HaltSigned(..) => Progress::HaltSigned,
                 ZoneStateMachine::Poisoned => unreachable!(),
+            };
+
+            // Query signing status
+            signing_report = if progress >= Progress::SignedReview {
+                zone_state
+                    .signer
+                    .active_signing_status
+                    .as_ref()
+                    .and_then(|s| s.read().unwrap().mk_signing_report())
+            } else {
+                None
             };
 
             last_published = zone_state
@@ -602,14 +614,6 @@ impl HttpServer {
                 );
             }
         }
-
-        // Query signing status
-        let signing_report = if progress >= Progress::SignedReview {
-            let center = &state.center;
-            center.signer.on_signing_report(&zone)
-        } else {
-            None
-        };
 
         // TODO: Report separate information for ongoing and completed loads.
         let receipt_report = {

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -45,7 +45,7 @@ use tokio::time::Instant;
 use tracing::{Level, debug, error, info, trace, warn};
 use url::Url;
 
-use crate::api::{SigningQueueReport, SigningReport};
+use crate::api::SigningQueueReport;
 use crate::center::Center;
 use crate::manager::{Terminated, record_zone_event};
 use crate::policy::{PolicyVersion, SignerDenialPolicy, SignerSerialPolicy};
@@ -188,18 +188,15 @@ impl ZoneSigner {
         Ok(public_key_info)
     }
 
-    pub fn on_signing_report(&self, zone: &Arc<Zone>) -> Option<SigningReport> {
-        self.signer_status
-            .get(zone)
-            .and_then(|status| status.read().unwrap().mk_signing_report())
-    }
-
     pub fn on_queue_report(&self, _center: &Arc<Center>) -> Vec<SigningQueueReport> {
         let mut report = vec![];
         let zone_signer_status = &self.signer_status;
         let q = zone_signer_status.zones_being_signed.read().unwrap();
-        for (zone, q_item) in q.iter().rev() {
-            if let Some(stage_report) = q_item.read().unwrap().mk_signing_report() {
+        for (zone, _q_item) in q.iter().rev() {
+            let zone_state = zone.read();
+            if let Some(status) = &zone_state.signer.active_signing_status
+                && let Some(stage_report) = status.read().unwrap().mk_signing_report()
+            {
                 report.push(SigningQueueReport {
                     zone_name: zone.name.clone(),
                     signing_report: stage_report,
@@ -961,21 +958,6 @@ impl ZoneSignerStatus {
             zone_semaphores: Default::default(),
             queue_semaphore: Arc::new(Semaphore::new(SIGNING_QUEUE_SIZE)),
         }
-    }
-
-    pub fn get(&self, wanted_zone: &Arc<Zone>) -> Option<Arc<RwLock<SigningStatusPerZone>>> {
-        self.dump_queue();
-
-        let zones_being_signed = self.zones_being_signed.read().unwrap();
-        for (zone, q_item) in zones_being_signed.iter().rev() {
-            let readable_q_item = q_item.read().unwrap();
-            if Arc::ptr_eq(zone, wanted_zone)
-                && !matches!(readable_q_item.status, ZoneSigningStatus::Aborted)
-            {
-                return Some(q_item.clone());
-            }
-        }
-        None
     }
 
     fn dump_queue(&self) {

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -53,15 +53,13 @@ use crate::center::Center;
 use crate::manager::{Terminated, record_zone_event};
 use crate::policy::{PolicyVersion, SignerDenialPolicy, SignerSerialPolicy};
 use crate::signer::incremental::{LocalState, sign_incrementally};
+use crate::signer::status::{SigningStatusPerZone, ZoneSigningStatus};
 use crate::signer::{ResigningTrigger, SigningTrigger};
 use crate::units::http_server::KmipServerState;
 use crate::units::key_manager::{
     KmipClientCredentialsFile, KmipServerCredentialsFileMode, mk_dnst_keyset_state_file_path,
 };
-use crate::util::{
-    AbortOnDrop, serialize_duration_as_secs, serialize_instant_as_duration_secs,
-    serialize_opt_duration_as_secs,
-};
+use crate::util::AbortOnDrop;
 use crate::zone::{HistoricalEvent, Zone, ZoneByName};
 
 // Re-signing zones before signatures expire works as follows:
@@ -995,176 +993,9 @@ impl std::fmt::Debug for ZoneSigner {
     }
 }
 
-//------------ ZoneSigningStatus ---------------------------------------------
-
-#[derive(Copy, Clone, Serialize)]
-pub struct RequestedStatus {
-    #[serde(serialize_with = "serialize_instant_as_duration_secs")]
-    requested_at: tokio::time::Instant,
-}
-
-impl RequestedStatus {
-    fn new() -> Self {
-        Self {
-            requested_at: Instant::now(),
-        }
-    }
-}
-
-#[derive(Copy, Clone, Serialize)]
-pub struct InProgressStatus {
-    #[serde(serialize_with = "serialize_instant_as_duration_secs")]
-    requested_at: tokio::time::Instant,
-    zone_serial: domain::base::Serial,
-    #[serde(serialize_with = "serialize_instant_as_duration_secs")]
-    started_at: tokio::time::Instant,
-    unsigned_rr_count: Option<usize>,
-    #[serde(serialize_with = "serialize_opt_duration_as_secs")]
-    walk_time: Option<Duration>,
-    #[serde(serialize_with = "serialize_opt_duration_as_secs")]
-    sort_time: Option<Duration>,
-    denial_rr_count: Option<usize>,
-    #[serde(serialize_with = "serialize_opt_duration_as_secs")]
-    denial_time: Option<Duration>,
-    rrsig_count: Option<usize>,
-    rrsig_reused_count: Option<usize>,
-    #[serde(serialize_with = "serialize_opt_duration_as_secs")]
-    rrsig_time: Option<Duration>,
-    #[serde(serialize_with = "serialize_opt_duration_as_secs")]
-    total_time: Option<Duration>,
-    threads_used: Option<usize>,
-}
-
-impl InProgressStatus {
-    fn new(requested_status: RequestedStatus, zone_serial: NewBaseSerial) -> Self {
-        Self {
-            requested_at: requested_status.requested_at,
-            zone_serial: domain::base::Serial(zone_serial.into()),
-            started_at: Instant::now(),
-            unsigned_rr_count: None,
-            walk_time: None,
-            sort_time: None,
-            denial_rr_count: None,
-            denial_time: None,
-            rrsig_count: None,
-            rrsig_reused_count: None,
-            rrsig_time: None,
-            total_time: None,
-            threads_used: None,
-        }
-    }
-}
-
-#[derive(Copy, Clone, Serialize)]
-pub struct FinishedStatus {
-    #[serde(serialize_with = "serialize_instant_as_duration_secs")]
-    requested_at: tokio::time::Instant,
-    #[serde(serialize_with = "serialize_instant_as_duration_secs")]
-    started_at: tokio::time::Instant,
-    zone_serial: domain::base::Serial,
-    unsigned_rr_count: usize,
-    #[serde(serialize_with = "serialize_duration_as_secs")]
-    walk_time: Duration,
-    #[serde(serialize_with = "serialize_duration_as_secs")]
-    sort_time: Duration,
-    denial_rr_count: usize,
-    #[serde(serialize_with = "serialize_duration_as_secs")]
-    denial_time: Duration,
-    rrsig_count: usize,
-    rrsig_reused_count: usize,
-    #[serde(serialize_with = "serialize_duration_as_secs")]
-    rrsig_time: Duration,
-    #[serde(serialize_with = "serialize_duration_as_secs")]
-    total_time: Duration,
-    threads_used: usize,
-    #[serde(serialize_with = "serialize_instant_as_duration_secs")]
-    finished_at: tokio::time::Instant,
-    succeeded: bool,
-}
-
-impl FinishedStatus {
-    fn new(in_progress_status: InProgressStatus, succeeded: bool) -> Self {
-        Self {
-            requested_at: in_progress_status.requested_at,
-            zone_serial: in_progress_status.zone_serial,
-            started_at: Instant::now(),
-            unsigned_rr_count: in_progress_status.unsigned_rr_count.unwrap_or_default(),
-            walk_time: in_progress_status.walk_time.unwrap_or_default(),
-            sort_time: in_progress_status.sort_time.unwrap_or_default(),
-            denial_rr_count: in_progress_status.denial_rr_count.unwrap_or_default(),
-            denial_time: in_progress_status.denial_time.unwrap_or_default(),
-            rrsig_count: in_progress_status.rrsig_count.unwrap_or_default(),
-            rrsig_reused_count: in_progress_status.rrsig_reused_count.unwrap_or_default(),
-            rrsig_time: in_progress_status.rrsig_time.unwrap_or_default(),
-            total_time: in_progress_status.total_time.unwrap_or_default(),
-            threads_used: in_progress_status.threads_used.unwrap_or_default(),
-            finished_at: Instant::now(),
-            succeeded,
-        }
-    }
-}
-
-#[derive(Copy, Clone, Serialize)]
-pub enum ZoneSigningStatus {
-    Requested(RequestedStatus),
-
-    InProgress(InProgressStatus),
-
-    Finished(FinishedStatus),
-
-    Aborted,
-}
-
-impl ZoneSigningStatus {
-    fn new() -> Self {
-        Self::Requested(RequestedStatus::new())
-    }
-
-    fn start(&mut self, zone_serial: NewBaseSerial) -> Result<(), ()> {
-        match *self {
-            ZoneSigningStatus::Requested(s) => {
-                *self = Self::InProgress(InProgressStatus::new(s, zone_serial));
-                Ok(())
-            }
-            ZoneSigningStatus::Aborted
-            | ZoneSigningStatus::InProgress(_)
-            | ZoneSigningStatus::Finished(_) => Err(()),
-        }
-    }
-
-    pub fn finish(&mut self, succeeded: bool) {
-        match *self {
-            ZoneSigningStatus::Requested(_) => {
-                *self = Self::Aborted;
-            }
-            ZoneSigningStatus::InProgress(status) => {
-                *self = Self::Finished(FinishedStatus::new(status, succeeded))
-            }
-            ZoneSigningStatus::Finished(_) | ZoneSigningStatus::Aborted => { /* Nothing to do */ }
-        }
-    }
-}
-
-impl std::fmt::Display for ZoneSigningStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ZoneSigningStatus::Requested(_) => f.write_str("Requested"),
-            ZoneSigningStatus::InProgress(_) => f.write_str("InProgress"),
-            ZoneSigningStatus::Finished(_) => f.write_str("Finished"),
-            ZoneSigningStatus::Aborted => f.write_str("Aborted"),
-        }
-    }
-}
-
 //------------ ZoneSignerStatus ----------------------------------------------
 
 const SIGNING_QUEUE_SIZE: usize = 100;
-
-pub struct SigningStatusPerZone {
-    pub zone: Arc<Zone>,
-    pub current_action: String,
-    pub status: ZoneSigningStatus,
-}
 
 struct ZoneSignerStatus {
     // Maps zone names to signing status, keeping records of previous signing.

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -45,10 +45,7 @@ use tokio::time::Instant;
 use tracing::{Level, debug, error, info, trace, warn};
 use url::Url;
 
-use crate::api::{
-    SigningFinishedReport, SigningInProgressReport, SigningQueueReport, SigningReport,
-    SigningRequestedReport, SigningStageReport,
-};
+use crate::api::{SigningQueueReport, SigningReport};
 use crate::center::Center;
 use crate::manager::{Terminated, record_zone_event};
 use crate::policy::{PolicyVersion, SignerDenialPolicy, SignerSerialPolicy};
@@ -191,68 +188,10 @@ impl ZoneSigner {
         Ok(public_key_info)
     }
 
-    fn mk_signing_report(
-        &self,
-        status: Arc<RwLock<SigningStatusPerZone>>,
-    ) -> Option<SigningReport> {
-        let status = status.read().unwrap();
-        let now = Instant::now();
-        let now_t = SystemTime::now();
-        let stage_report = match status.status {
-            ZoneSigningStatus::Requested(s) => {
-                Some(SigningStageReport::Requested(SigningRequestedReport {
-                    requested_at: now_t.checked_sub(now.duration_since(s.requested_at))?,
-                }))
-            }
-            ZoneSigningStatus::InProgress(s) => {
-                Some(SigningStageReport::InProgress(SigningInProgressReport {
-                    requested_at: now_t.checked_sub(now.duration_since(s.requested_at))?,
-                    zone_serial: domain::base::Serial(s.zone_serial.into()),
-                    started_at: now_t.checked_sub(now.duration_since(s.started_at))?,
-                    unsigned_rr_count: s.unsigned_rr_count,
-                    walk_time: s.walk_time,
-                    sort_time: s.sort_time,
-                    denial_rr_count: s.denial_rr_count,
-                    denial_time: s.denial_time,
-                    rrsig_count: s.rrsig_count,
-                    rrsig_reused_count: s.rrsig_reused_count,
-                    rrsig_time: s.rrsig_time,
-                    total_time: s.total_time,
-                    threads_used: s.threads_used,
-                }))
-            }
-            ZoneSigningStatus::Finished(s) => {
-                Some(SigningStageReport::Finished(SigningFinishedReport {
-                    requested_at: now_t.checked_sub(now.duration_since(s.requested_at))?,
-                    zone_serial: domain::base::Serial(s.zone_serial.into()),
-                    started_at: now_t.checked_sub(now.duration_since(s.started_at))?,
-                    unsigned_rr_count: s.unsigned_rr_count,
-                    walk_time: s.walk_time,
-                    sort_time: s.sort_time,
-                    denial_rr_count: s.denial_rr_count,
-                    denial_time: s.denial_time,
-                    rrsig_count: s.rrsig_count,
-                    rrsig_reused_count: s.rrsig_reused_count,
-                    rrsig_time: s.rrsig_time,
-                    total_time: s.total_time,
-                    threads_used: s.threads_used,
-                    finished_at: now_t.checked_sub(now.duration_since(s.finished_at))?,
-                    succeeded: s.succeeded,
-                }))
-            }
-            ZoneSigningStatus::Aborted => None,
-        };
-
-        stage_report.map(|stage_report| SigningReport {
-            current_action: status.current_action.clone(),
-            stage_report,
-        })
-    }
-
     pub fn on_signing_report(&self, zone: &Arc<Zone>) -> Option<SigningReport> {
         self.signer_status
             .get(zone)
-            .and_then(|status| self.mk_signing_report(status))
+            .and_then(|status| status.read().unwrap().mk_signing_report())
     }
 
     pub fn on_queue_report(&self, _center: &Arc<Center>) -> Vec<SigningQueueReport> {
@@ -260,7 +199,7 @@ impl ZoneSigner {
         let zone_signer_status = &self.signer_status;
         let q = zone_signer_status.zones_being_signed.read().unwrap();
         for (zone, q_item) in q.iter().rev() {
-            if let Some(stage_report) = self.mk_signing_report(q_item.clone()) {
+            if let Some(stage_report) = q_item.read().unwrap().mk_signing_report() {
                 report.push(SigningQueueReport {
                     zone_name: zone.name.clone(),
                     signing_report: stage_report,

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -259,10 +259,10 @@ impl ZoneSigner {
         let mut report = vec![];
         let zone_signer_status = &self.signer_status;
         let q = zone_signer_status.zones_being_signed.read().unwrap();
-        for q_item in q.iter().rev() {
+        for (zone, q_item) in q.iter().rev() {
             if let Some(stage_report) = self.mk_signing_report(q_item.clone()) {
                 report.push(SigningQueueReport {
-                    zone_name: q_item.read().unwrap().zone.name.clone(),
+                    zone_name: zone.name.clone(),
                     signing_report: stage_report,
                 });
             }
@@ -1004,7 +1004,8 @@ struct ZoneSignerStatus {
     //
     // TODO: Separate out signing request queuing from signing statistics
     // tracking.
-    zones_being_signed: Arc<RwLock<VecDeque<Arc<RwLock<SigningStatusPerZone>>>>>,
+    #[allow(clippy::type_complexity)] // TODO: Finish removing `ZoneSignerStatus`
+    zones_being_signed: Arc<RwLock<VecDeque<(Arc<Zone>, Arc<RwLock<SigningStatusPerZone>>)>>>,
 
     // Sign each zone only once at a time.
     zone_semaphores: Arc<RwLock<HashMap<Name<Bytes>, Arc<Semaphore>>>>,
@@ -1027,9 +1028,9 @@ impl ZoneSignerStatus {
         self.dump_queue();
 
         let zones_being_signed = self.zones_being_signed.read().unwrap();
-        for q_item in zones_being_signed.iter().rev() {
+        for (zone, q_item) in zones_being_signed.iter().rev() {
             let readable_q_item = q_item.read().unwrap();
-            if Arc::ptr_eq(&readable_q_item.zone, wanted_zone)
+            if Arc::ptr_eq(zone, wanted_zone)
                 && !matches!(readable_q_item.status, ZoneSigningStatus::Aborted)
             {
                 return Some(q_item.clone());
@@ -1041,20 +1042,20 @@ impl ZoneSignerStatus {
     fn dump_queue(&self) {
         if tracing::event_enabled!(Level::DEBUG) {
             let zones_being_signed = self.zones_being_signed.read().unwrap();
-            for q_item in zones_being_signed.iter().rev() {
+            for (zone, q_item) in zones_being_signed.iter().rev() {
                 let q_item = q_item.read().unwrap();
                 match q_item.status {
                     ZoneSigningStatus::Requested(_) => {
-                        debug!("[ZS]: Queue item: {} => requested", q_item.zone.name)
+                        debug!("[ZS]: Queue item: {} => requested", zone.name)
                     }
                     ZoneSigningStatus::InProgress(_) => {
-                        debug!("[ZS]: Queue item: {} => in-progress", q_item.zone.name)
+                        debug!("[ZS]: Queue item: {} => in-progress", zone.name)
                     }
                     ZoneSigningStatus::Finished(_) => {
-                        debug!("[ZS]: Queue item: {} => finished", q_item.zone.name)
+                        debug!("[ZS]: Queue item: {} => finished", zone.name)
                     }
                     ZoneSigningStatus::Aborted => {
-                        debug!("[ZS]: Queue item: {} => aborted", q_item.zone.name)
+                        debug!("[ZS]: Queue item: {} => aborted", zone.name)
                     }
                 };
             }
@@ -1077,14 +1078,13 @@ impl ZoneSignerStatus {
         let zone_name = &zone.name;
         debug!("SIGNER[{zone_name}]: Adding to the queue");
         let status = Arc::new(RwLock::new(SigningStatusPerZone {
-            zone: zone.clone(),
             current_action: "Waiting for any existing signing operation for this zone to finish"
                 .to_string(),
             status: ZoneSigningStatus::new(),
         }));
         {
             let mut zones_being_signed = self.zones_being_signed.write().unwrap();
-            zones_being_signed.push_back(status.clone());
+            zones_being_signed.push_back((zone.clone(), status.clone()));
         }
 
         let approx_q_size = SIGNING_QUEUE_SIZE - self.queue_semaphore.available_permits() + 1;
@@ -1120,7 +1120,7 @@ impl ZoneSignerStatus {
         if zones_being_signed.len() == zones_being_signed.capacity() {
             // Discard oldest.
             let signing_status = zones_being_signed.pop_front();
-            if let Some(signing_status) = signing_status {
+            if let Some((_zone, signing_status)) = signing_status {
                 // Old items in the queue should have reached a final state,
                 // either finished or aborted. If not, something is wrong with
                 // the queueing logic.


### PR DESCRIPTION
This PR unblocks #789 by separating the zone signing status from the zone signer's queue. The status has been moved into `ZoneState`, making it easier to access (as seen in `http_server.rs`).

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?