### PR TITLE
Ignore re-signing without a published signed instance

### DIFF
--- a/src/signer/zone.rs
+++ b/src/signer/zone.rs
@@ -96,32 +96,34 @@ impl SignerZoneHandle<'_> {
     )]
     pub fn enqueue_resign(&mut self, trigger: ResigningTrigger) {
         // TODO: The key manager can call 'enqueue_resign()' even when the zone
-        // has not been signed. The re-signing request is ignored if no previous
-        // signed instance of the zone seems to exist. Ideally, the key manager
-        // would check the current signed instance of the zone itself, and check
-        // that it really needs re-signing (i.e. that the signing keys used for
-        // building that instance are different from the latest ones).
+        // has not been signed. So we need to ignore some (but not all) calls
+        // to 'enqueue_resign()'. Ideally, the key manager would check the
+        // current signed instance of the zone itself, and check that it really
+        // needs re-signing (i.e. that the signing keys used for building that
+        // instance are different from the latest ones).
         //
-        // TODO: Explicitly track whether a signed instance exists. Maybe the
-        // zone data storage can report it via a method on 'PassiveStorage'? Or
-        // track instances of zones more explicitly in 'ZoneState' (the latter
-        // will happen / has happened when integrating the zone server with the
-        // zone data storage).
+        // TODO: Stop relying on `{next_,}min_expiration` to tell us about the
+        // published and upcoming instances of the zone.
         //
-        // TODO: Check if this comment is correct. The key manager triggers
-        // resigning the zone when the state of the key manager has changed.
-        // That does imply that resigning is needed. The incremental signer
-        // checks if something needs to be done. For this reason, ignore the
-        // re-signing request if no previous instance of the zone seems to
-        // exist. This can also be trigger by re-signing timers if no
-        // persistent state is available.
+        // TODO: Verify that `min_expiration` is set to `None` when Cascade is
+        // starting up and trying to restoring zones from the disk.
+        //
+        // If a published instance of the zone exists, we definitely want to
+        // re-sign it. If a published instance of the zone does not exist, but
+        // an upcoming signed instance does, we should try re-signing it too.
+        // But before re-signing is actually initiated, we will verify that
+        // the upcoming instance was accepted and published (and ignore the
+        // re-signing request otherwise).
         if self
             .state
-            .next_min_expiration
-            .or(self.state.min_expiration)
+            .min_expiration
+            .or(self.state.next_min_expiration)
             .is_none()
         {
-            debug!("Ignoring re-signing request; the zone has not been signed yet");
+            debug!(
+                "Ignoring re-signing request; \
+                there is no published or upcoming signed instance to re-sign"
+            );
             return;
         }
 
@@ -133,8 +135,13 @@ impl SignerZoneHandle<'_> {
             return;
         }
 
-        // Try to obtain a 'SignedZoneBuilder' so building can begin.
-        let builder = self.zone().try_start_resign();
+        // TODO: Track expiration time in 'SignerState'.
+        let expiration_time = self
+            .state
+            .next_min_expiration
+            .or(self.state.min_expiration)
+            .expect("checked for a published/upcoming signed instance")
+            .to_system_time(SystemTime::now());
 
         // TODO: Keep state for a queue of pending (re-)signing operations, so
         // that the number of simultaneous operations can be limited. At the
@@ -142,7 +149,9 @@ impl SignerZoneHandle<'_> {
         // task.
 
         // Try to initiate the re-sign immediately.
-        if let Some(builder) = builder {
+        if self.state.min_expiration.is_some()
+            && let Some(builder) = self.zone().try_start_resign()
+        {
             // A zone can have at most one 'SignedZoneBuilder' at a time.
             // Because we have 'builder', we are guaranteed that no other
             // signing operations are ongoing right now.
@@ -151,14 +160,6 @@ impl SignerZoneHandle<'_> {
 
             self.start_op(builder, SigningTrigger::Resign(trigger));
         } else {
-            // TODO: Track expiration time in 'SignerState'.
-            let expiration_time = self
-                .state
-                .next_min_expiration
-                .or(self.state.min_expiration)
-                .unwrap_or_else(|| panic!("re-sign enqueued but the zone has not been signed"))
-                .to_system_time(SystemTime::now());
-
             self.state.signer.enqueued_resign = Some(EnqueuedResign {
                 builder: None,
                 trigger,
@@ -201,6 +202,20 @@ impl SignerZoneHandle<'_> {
         // As mentioned above, 'SignedZoneBuilder' cannot exist when the zone
         // data storage is in the passive state.
         assert!(builder.is_none());
+
+        // Since the zone data storage is passive, there is no upcoming instance
+        // of the zone. If a published signed instance does not exist either,
+        // there is nothing to re-sign, and we should just abandon the existing
+        // re-signing operation.
+        if self.state.min_expiration.is_none() {
+            debug!(
+                ?trigger,
+                "Dropping previously enqueued re-signing request; \
+                there is no published or upcoming signed instance of the zone"
+            );
+
+            return false;
+        }
 
         let builder = self
             .zone()


### PR DESCRIPTION
Following a discussion with @Philip-NLnetLabs. Appears to resolve intermittent failures with the `signed-review-zone` integration test.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
