### PR TITLE
Store a copy of SOA records with regular records

### DIFF
--- a/crates/zonedata/src/data.rs
+++ b/crates/zonedata/src/data.rs
@@ -55,7 +55,7 @@ pub struct InstanceData {
 
     /// All other records.
     ///
-    /// Records are sorted in DNSSEC canonical order. The SOA record is not
+    /// Records are sorted in DNSSEC canonical order. The SOA record **is**
     /// included.
     pub records: Vec<RegularRecord>,
 }

--- a/crates/zonedata/src/diff.rs
+++ b/crates/zonedata/src/diff.rs
@@ -33,14 +33,16 @@ pub struct DiffData {
 
     /// Removed regular records.
     ///
-    /// These records are present in the base, but not in the target. They do
-    /// not include the SOA record. They are sorted in DNSSEC canonical order.
+    /// These records are present in the base, but not in the target. They
+    /// **also** include the removed SOA record. They are sorted in DNSSEC
+    /// canonical order.
     pub removed_records: Vec<RegularRecord>,
 
     /// Added regular records.
     ///
-    /// These records are present in the target, but not in the base. They do
-    /// not include the SOA record. They are sorted in DNSSEC canonical order.
+    /// These records are present in the target, but not in the base. They
+    /// **also** include the added SOA record. They are sorted in DNSSEC
+    /// canonical order.
     pub added_records: Vec<RegularRecord>,
 }
 

--- a/crates/zonedata/src/reader.rs
+++ b/crates/zonedata/src/reader.rs
@@ -54,52 +54,27 @@ impl<'d> LoadedZoneReader<'d> {
 
     /// Regular records in the zone.
     ///
-    /// Records are sorted in DNSSEC canonical order. The SOA record **is not**
+    /// Records are sorted in DNSSEC canonical order. The SOA record **is**
     /// included.
     pub const fn regular_records(&self) -> &'d [RegularRecord] {
         self.instance.records.as_slice()
-    }
-
-    /// All records in the zone.
-    ///
-    /// Records are sorted in DNSSEC canonical order. The SOA record **is**
-    /// included.
-    pub fn all_records(&self) -> impl Iterator<Item = RegularRecord> + Send + use<'d> {
-        let (soa, records) = (self.soa(), self.regular_records());
-        let soa = RegularRecord::from(soa.clone());
-
-        // Find the position to insert the SOA record.
-        let pos = records
-            .iter()
-            .position(|r| soa <= *r)
-            .unwrap_or(records.len());
-
-        records[..pos]
-            .iter()
-            .cloned()
-            .chain([soa])
-            .chain(records[pos..].iter().cloned())
     }
 
     /// The unsigned records in the zone.
     ///
     /// DNSSEC related records that would be produced by Cascade's signer (e.g.
     /// RRSIGs, NSEC/NSEC3, etc.) are stripped. The records are sorted in DNSSEC
-    /// canonical order. The SOA record **is not** included.
-    pub fn unsigned_records(&self) -> impl Iterator<Item = RegularRecord> + Send + use<'d> {
+    /// canonical order. The SOA record **is** included.
+    pub fn unsigned_records(&self) -> impl Iterator<Item = &'d RegularRecord> + Send + use<'d> {
         // Filter out records that would be generated during signing.
         //
         // TODO: 'RType::{CDS, CDNSKEY, ZONEMD}'.
-        self.instance
-            .records
-            .iter()
-            .filter(|r| {
-                !matches!(
-                    r.rtype,
-                    RType::NSEC | RType::NSEC3 | RType::NSEC3PARAM | RType::DNSKEY | RType::RRSIG
-                ) && !matches!(r.rtype.code.get(), 59 | 60 | 63)
-            })
-            .cloned()
+        self.instance.records.iter().filter(|&r| {
+            !matches!(
+                r.rtype,
+                RType::NSEC | RType::NSEC3 | RType::NSEC3PARAM | RType::DNSKEY | RType::RRSIG
+            ) && !matches!(r.rtype.code.get(), 59 | 60 | 63)
+        })
     }
 }
 
@@ -166,7 +141,7 @@ impl<'d> SignedZoneReader<'d> {
 
     /// All records generated during signing.
     ///
-    /// Records are sorted in DNSSEC canonical order. The SOA record is not
+    /// Records are sorted in DNSSEC canonical order. The SOA record **is**
     /// included.
     pub const fn generated_records(&self) -> &'d [RegularRecord] {
         self.signed_instance.records.as_slice()
@@ -182,18 +157,18 @@ impl<'d> SignedZoneReader<'d> {
     /// Records are sorted in DNSSEC canonical order. Only records also present
     /// in the signed instance are included (the loaded SOA record, and loaded
     /// DNSKEY, RRSIG, CDS, CDNSKEY, ZONEMD records are excluded).
-    pub fn loaded_records(&self) -> impl Iterator<Item = RegularRecord> + Send + use<'d> {
-        LoadedZoneReader::new(self.loaded_instance).unsigned_records()
+    pub fn loaded_records(&self) -> impl Iterator<Item = &'d RegularRecord> + Send + use<'d> {
+        let soa = self.soa();
+        LoadedZoneReader::new(self.loaded_instance)
+            .unsigned_records()
+            .filter(|&r| r.rname != soa.rname || r.rtype != soa.rtype)
     }
 
     /// All records in the zone.
     ///
-    /// Records are **unsorted**. The SOA record and records from the loaded
-    /// instance **are** included.
-    pub fn all_records(&self) -> impl Iterator<Item = RegularRecord> + Send + use<'d> {
-        [self.soa().clone().into()]
-            .into_iter()
-            .chain(self.loaded_records())
-            .chain(self.generated_records().iter().cloned())
+    /// Records are **unsorted**. The SOA record (of the signed instance) **is**
+    /// included; unsigned records from the loaded instance **are** included.
+    pub fn all_records(&self) -> impl Iterator<Item = &'d RegularRecord> + Send + use<'d> {
+        self.generated_records().iter().chain(self.loaded_records())
     }
 }

--- a/crates/zonedata/src/writer.rs
+++ b/crates/zonedata/src/writer.rs
@@ -64,6 +64,8 @@ impl<'d> LoadedZoneReplacer<'d> {
     }
 
     /// Set the SOA record.
+    ///
+    /// A copy of the record **must** be added as a regular record too.
     pub fn set_soa(&mut self, soa: SoaRecord) -> Result<(), ReplaceError> {
         if self.next.soa.is_some() {
             return Err(ReplaceError::MultipleSoas);
@@ -81,9 +83,9 @@ impl<'d> LoadedZoneReplacer<'d> {
 
     /// Set all records.
     ///
-    /// The given [`Vec`] will replace all the records in the instance, except
-    /// for the SOA record (which must be set via [`Self::set_soa()`]). The
-    /// records must be sorted.
+    /// The given [`Vec`] will replace all the records in the instance,
+    /// including the SOA record; but a copy of the SOA record **must** be set
+    /// via [`Self::set_soa()`]. The records must be sorted.
     pub fn set_records(&mut self, records: Vec<RegularRecord>) -> Result<(), ReplaceError> {
         self.next.records = records;
         Ok(())
@@ -170,6 +172,8 @@ impl<'d> LoadedZonePatcher<'d> {
     }
 
     /// Remove the previous SOA record.
+    ///
+    /// A copy of the record **must** be removed as a regular record too.
     pub fn remove_soa(&mut self, soa: SoaRecord) -> Result<(), PatchError> {
         if self.immediate.removed_soa.is_some() {
             return Err(PatchError::Inconsistency);
@@ -180,6 +184,8 @@ impl<'d> LoadedZonePatcher<'d> {
     }
 
     /// Add the new SOA record.
+    ///
+    /// A copy of the record **must** be added as a regular record too.
     pub fn add_soa(&mut self, soa: SoaRecord) -> Result<(), PatchError> {
         if self.immediate.added_soa.is_some() {
             return Err(PatchError::MultipleSoasAdded);
@@ -341,6 +347,8 @@ impl<'d> SignedZoneReplacer<'d> {
     }
 
     /// Set the SOA record.
+    ///
+    /// A copy of the record **must** be added as a regular record too.
     pub fn set_soa(&mut self, soa: SoaRecord) -> Result<(), ReplaceError> {
         if self.next.soa.is_some() {
             return Err(ReplaceError::MultipleSoas);
@@ -358,9 +366,9 @@ impl<'d> SignedZoneReplacer<'d> {
 
     /// Set all records.
     ///
-    /// The given [`Vec`] will replace all the records in the instance, except
-    /// for the SOA record (which must be set via [`Self::set_soa()`]). The
-    /// records must be sorted.
+    /// The given [`Vec`] will replace all the records in the instance,
+    /// including the SOA record; but a copy of the SOA record **must** be set
+    /// via [`Self::set_soa()`]. The records must be sorted.
     pub fn set_records(&mut self, records: Vec<RegularRecord>) -> Result<(), ReplaceError> {
         self.next.records = records;
         Ok(())
@@ -538,6 +546,8 @@ impl<'d> SignedZonePatcher<'d> {
     }
 
     /// Remove the previous SOA record.
+    ///
+    /// A copy of the record **must** be removed as a regular record too.
     pub fn remove_soa(&mut self, soa: SoaRecord) -> Result<(), PatchError> {
         if self.immediate.removed_soa.is_some() {
             return Err(PatchError::Inconsistency);
@@ -548,6 +558,8 @@ impl<'d> SignedZonePatcher<'d> {
     }
 
     /// Add the new SOA record.
+    ///
+    /// A copy of the record **must** be added as a regular record too.
     pub fn add_soa(&mut self, soa: SoaRecord) -> Result<(), PatchError> {
         if self.immediate.added_soa.is_some() {
             return Err(PatchError::MultipleSoasAdded);

--- a/src/loader/server.rs
+++ b/src/loader/server.rs
@@ -248,6 +248,7 @@ pub async fn ixfr(
             };
 
             assert!(interpreter.is_finished());
+            writer.add(soa.clone().into())?;
             writer.set_soa(soa)?;
             writer.apply()?;
             metrics.num_loaded_bytes.fetch_add(bytes, Relaxed);
@@ -261,6 +262,7 @@ pub async fn ixfr(
             // Work-around for #493: pre-process the current SOA as
             // process_ixfr() assumes it will receive it when fetching the
             // next record but it has already been consumed.
+            writer.remove(soa.clone().into())?;
             writer.remove_soa(soa.into())?;
 
             // Process the response messages.
@@ -304,6 +306,7 @@ fn process_ixfr(
                 // A previous deletion-addition set (i.e. a complete diff) has
                 // been finished, and a new one is starting.
                 writer.next_patchset()?;
+                writer.remove(soa.clone().into())?;
                 writer.remove_soa(soa.into())?;
             }
 
@@ -312,6 +315,7 @@ fn process_ixfr(
             }
 
             ZoneUpdate::BeginBatchAdd(soa) => {
+                writer.add(soa.clone().into())?;
                 writer.add_soa(soa.into())?;
             }
 
@@ -431,6 +435,7 @@ pub async fn axfr(
     };
 
     assert!(interpreter.is_finished());
+    writer.add(soa.clone().into())?;
     writer.set_soa(soa)?;
     writer.apply()?;
     Ok(())

--- a/src/loader/zonefile.rs
+++ b/src/loader/zonefile.rs
@@ -47,6 +47,7 @@ pub fn load(
 
         match record {
             Parsed::Soa(soa) => {
+                writer.add(soa.clone().into())?;
                 writer.set_soa(soa)?;
             }
             Parsed::Record(record) => writer.add(record)?,

--- a/src/persistence/persist.rs
+++ b/src/persistence/persist.rs
@@ -362,6 +362,10 @@ fn persist_to_file(destination: &Path, diff: Arc<DiffData>) {
 
         // Write the deleted records.
         for r in &diff.removed_records {
+            if r.rname == removed_soa.rname && r.rtype == removed_soa.rtype {
+                continue;
+            }
+
             write_rr(&mut buf, r, &mut f);
         }
 
@@ -371,6 +375,10 @@ fn persist_to_file(destination: &Path, diff: Arc<DiffData>) {
 
     // Write the added records.
     for r in &diff.added_records {
+        if r.rname == added_soa.rname && r.rtype == added_soa.rtype {
+            continue;
+        }
+
         write_rr(&mut buf, r, &mut f);
     }
 
@@ -382,15 +390,7 @@ fn persist_to_file(destination: &Path, diff: Arc<DiffData>) {
         destination.display(),
         diff.removed_soa.as_ref().map(|v| v.rdata.serial),
         diff.added_soa.as_ref().map(|v| v.rdata.serial),
-        if !diff.removed_records.is_empty() {
-            diff.removed_records.len() + 1
-        } else {
-            0
-        },
-        if !diff.added_records.is_empty() {
-            diff.added_records.len() + 1
-        } else {
-            0
-        },
+        diff.removed_records.is_empty(),
+        diff.added_records.len(),
     );
 }

--- a/src/persistence/restore.rs
+++ b/src/persistence/restore.rs
@@ -71,6 +71,7 @@ pub fn restore_loaded(
     ))?;
     loaded_replacer.set_soa(soa.clone()).unwrap();
     loaded_replacer.set_records(records).unwrap();
+    loaded_replacer.add(soa.clone().into()).unwrap();
     loaded_replacer.apply().unwrap();
     trace!(
         "Restored loaded snapshot for SOA serial {} for zone '{}' from file '{loaded_source}'",
@@ -175,6 +176,7 @@ pub fn restore_signed(
     ))?;
     signed_replacer.set_soa(soa.clone()).unwrap();
     signed_replacer.set_records(records).unwrap();
+    signed_replacer.add(soa.clone().into()).unwrap();
     signed_replacer.apply().unwrap();
     trace!(
         "Restored signed snapshot for SOA serial {} for zone '{}' from file '{signed_source}'",
@@ -498,9 +500,15 @@ enum IxfrEvent {
 
 fn apply_ixfr_event_to_loaded_data(patcher: &mut LoadedZonePatcher<'_>, event: IxfrEvent) {
     match event {
-        IxfrEvent::Remove(r) if r.rtype == RType::SOA => patcher.remove_soa(r.into()).unwrap(),
+        IxfrEvent::Remove(r) if r.rtype == RType::SOA => {
+            patcher.remove(r.clone()).unwrap();
+            patcher.remove_soa(r.into()).unwrap();
+        }
         IxfrEvent::Remove(r) => patcher.remove(r).unwrap(),
-        IxfrEvent::Add(r) if r.rtype == RType::SOA => patcher.add_soa(r.into()).unwrap(),
+        IxfrEvent::Add(r) if r.rtype == RType::SOA => {
+            patcher.add(r.clone()).unwrap();
+            patcher.add_soa(r.into()).unwrap()
+        }
         IxfrEvent::Add(r) => patcher.add(r).unwrap(),
         IxfrEvent::EndOfUpdate => patcher.next_patchset().unwrap(),
     }
@@ -508,9 +516,15 @@ fn apply_ixfr_event_to_loaded_data(patcher: &mut LoadedZonePatcher<'_>, event: I
 
 fn apply_ixfr_event_to_signed_data(patcher: &mut SignedZonePatcher<'_>, event: IxfrEvent) {
     match event {
-        IxfrEvent::Remove(r) if r.rtype == RType::SOA => patcher.remove_soa(r.into()).unwrap(),
+        IxfrEvent::Remove(r) if r.rtype == RType::SOA => {
+            patcher.remove(r.clone()).unwrap();
+            patcher.remove_soa(r.into()).unwrap();
+        }
         IxfrEvent::Remove(r) => patcher.remove(r).unwrap(),
-        IxfrEvent::Add(r) if r.rtype == RType::SOA => patcher.add_soa(r.into()).unwrap(),
+        IxfrEvent::Add(r) if r.rtype == RType::SOA => {
+            patcher.add(r.clone()).unwrap();
+            patcher.add_soa(r.into()).unwrap()
+        }
         IxfrEvent::Add(r) => patcher.add(r).unwrap(),
         IxfrEvent::EndOfUpdate => patcher.next_patchset().unwrap(),
     }

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -313,7 +313,7 @@ mod compat {
             let soa = viewer.soa().clone();
             let mut records = [soa.clone().into()]
                 .into_iter()
-                .chain(viewer.non_soa_records())
+                .chain(viewer.non_soa_records().cloned())
                 .chain([soa.into()])
                 .peekable();
 
@@ -613,21 +613,69 @@ mod compat {
                 if mode == ServiceMode::LoadedReview {
                     // Remove old records.
                     rrs.push(removed_soa.clone().into());
-                    rrs.extend(soa_source_diff.removed_records.clone());
+                    rrs.extend(
+                        soa_source_diff
+                            .removed_records
+                            .iter()
+                            .filter(|&r| {
+                                r.rname != removed_soa.rname || r.rtype != removed_soa.rtype
+                            })
+                            .cloned(),
+                    );
 
                     // Add new records.
                     rrs.push(added_soa.clone().into());
-                    rrs.extend(soa_source_diff.added_records.clone());
+                    rrs.extend(
+                        soa_source_diff
+                            .added_records
+                            .iter()
+                            .filter(|&r| {
+                                r.rname != removed_soa.rname || r.rtype != removed_soa.rtype
+                            })
+                            .cloned(),
+                    );
                 } else {
                     // Remove old records.
                     rrs.push(removed_soa.clone().into());
-                    rrs.extend(loaded_diff.removed_records.clone());
-                    rrs.extend(soa_source_diff.removed_records.clone());
+                    rrs.extend(
+                        loaded_diff
+                            .removed_records
+                            .iter()
+                            .filter(|&r| {
+                                r.rname != removed_soa.rname || r.rtype != removed_soa.rtype
+                            })
+                            .cloned(),
+                    );
+                    rrs.extend(
+                        soa_source_diff
+                            .removed_records
+                            .iter()
+                            .filter(|&r| {
+                                r.rname != removed_soa.rname || r.rtype != removed_soa.rtype
+                            })
+                            .cloned(),
+                    );
 
                     // Add new records.
                     rrs.push(added_soa.clone().into());
-                    rrs.extend(loaded_diff.added_records.clone());
-                    rrs.extend(soa_source_diff.added_records.clone());
+                    rrs.extend(
+                        loaded_diff
+                            .added_records
+                            .iter()
+                            .filter(|&r| {
+                                r.rname != removed_soa.rname || r.rtype != removed_soa.rtype
+                            })
+                            .cloned(),
+                    );
+                    rrs.extend(
+                        soa_source_diff
+                            .added_records
+                            .iter()
+                            .filter(|&r| {
+                                r.rname != removed_soa.rname || r.rtype != removed_soa.rtype
+                            })
+                            .cloned(),
+                    );
                 }
 
                 last_removed_soa = Some(removed_soa);
@@ -725,7 +773,9 @@ trait Viewer {
     fn soa(&self) -> &SoaRecord;
 
     /// Return all records in the zone (excluding SOA).
-    fn non_soa_records(&self) -> impl Iterator<Item = RegularRecord> + Send;
+    fn non_soa_records<'d>(
+        &'d self,
+    ) -> impl Iterator<Item = &'d RegularRecord> + Send + use<'d, Self>;
 }
 
 impl Viewer for LoadedZoneReviewer {
@@ -737,8 +787,13 @@ impl Viewer for LoadedZoneReviewer {
         self.read().unwrap().soa()
     }
 
-    fn non_soa_records(&self) -> impl Iterator<Item = RegularRecord> + Send {
-        self.read().unwrap().regular_records().iter().cloned()
+    fn non_soa_records<'d>(&'d self) -> impl Iterator<Item = &'d RegularRecord> + Send + use<'d> {
+        let soa = self.soa();
+        self.read()
+            .unwrap()
+            .regular_records()
+            .iter()
+            .filter(|&r| r.rname != soa.rname || r.rtype != soa.rtype)
     }
 }
 
@@ -751,11 +806,14 @@ impl Viewer for SignedZoneReviewer {
         self.read().unwrap().soa()
     }
 
-    fn non_soa_records(&self) -> impl Iterator<Item = RegularRecord> + Send {
+    fn non_soa_records<'d>(&'d self) -> impl Iterator<Item = &'d RegularRecord> + Send + use<'d> {
+        let soa = self.soa();
         let reader = self.read().unwrap();
         reader
-            .loaded_records()
-            .chain(reader.generated_records().iter().cloned())
+            .generated_records()
+            .iter()
+            .filter(|&r| r.rname != soa.rname || r.rtype != soa.rtype)
+            .chain(reader.loaded_records())
     }
 }
 
@@ -768,11 +826,14 @@ impl Viewer for ZoneViewer {
         self.read().unwrap().soa()
     }
 
-    fn non_soa_records(&self) -> impl Iterator<Item = RegularRecord> + Send {
+    fn non_soa_records<'d>(&'d self) -> impl Iterator<Item = &'d RegularRecord> + Send + use<'d> {
+        let soa = self.soa();
         let reader = self.read().unwrap();
         reader
-            .loaded_records()
-            .chain(reader.generated_records().iter().cloned())
+            .generated_records()
+            .iter()
+            .filter(|&r| r.rname != soa.rname || r.rtype != soa.rtype)
+            .chain(reader.loaded_records())
     }
 }
 

--- a/src/signer/incremental.rs
+++ b/src/signer/incremental.rs
@@ -639,6 +639,9 @@ impl WorkSpace<'_> {
                 // just remove all if there is more than one.
                 for r in old_rrs {
                     let r: SoaRecord = r.clone().into();
+                    self.patch.remove(r.clone().into()).map_err(|e| {
+                        SignerError::PatchFailed(format!("unable to remove soa {r:?}: {e}"))
+                    })?;
                     self.patch.remove_soa(r.clone()).map_err(|e| {
                         SignerError::PatchFailed(format!("unable to remove soa {r:?}: {e}"))
                     })?;
@@ -685,6 +688,9 @@ impl WorkSpace<'_> {
                 // just add all if there is more than one.
                 for r in new_rrs {
                     let r: SoaRecord = r.clone().into();
+                    self.patch.add(r.clone().into()).map_err(|e| {
+                        SignerError::PatchFailed(format!("unable to add soa {r:?}: {e}"))
+                    })?;
                     self.patch.add_soa(r.clone()).map_err(|e| {
                         SignerError::PatchFailed(format!("unable to add soa {r:?}: {e}"))
                     })?;
@@ -1621,8 +1627,6 @@ impl IncrementalSigningState {
         // Collect records for a
         // name/RRtype and store a complete RRset in a btree.
         let mut records = Vec::<Record<Name<Bytes>, ZoneRecordData<Bytes, Name<Bytes>>>>::new();
-
-        records.push(Into::<OldParsedRecord>::into(reader.soa().clone()).flatten_into());
 
         for entry in reader.regular_records() {
             let record: OldParsedRecord = entry.clone().into();

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -344,6 +344,7 @@ impl ZoneSigner {
             soa.rdata.serial = serial;
             soa
         };
+        new_records.push(new_soa.clone().into());
 
         info!(
             "[ZS]: Serials for zone '{zone_name}': last signed={previous_serial:?}, current={loaded_serial}, serial policy={}, new={serial}",
@@ -375,9 +376,10 @@ impl ZoneSigner {
         status.write().unwrap().current_action = "Collecting records to sign".to_string();
         debug!("[ZS]: Collecting records to sign for zone '{zone_name}'.");
         let walk_start = Instant::now();
-        // TODO: Filter out DNSSEC records from the loaded instance.
         let mut records = loaded
             .unsigned_records()
+            .filter(|r| r.rname != new_soa.rname || r.rtype != new_soa.rtype)
+            .cloned()
             .map(OldRecord::from)
             .collect::<Vec<_>>();
         records.push(new_soa.clone().into());

--- a/src/zone/storage.rs
+++ b/src/zone/storage.rs
@@ -730,8 +730,8 @@ impl StorageZoneHandle<'_> {
         // Compute the total number of records
         let reader = viewer.read().unwrap();
         let generated_records = reader.generated_records().len();
-        let loaded_records = reader.loaded().regular_records().len();
-        let num_records = 1 + generated_records + loaded_records;
+        let loaded_records = reader.loaded().regular_records().len() - 1;
+        let num_records = generated_records + loaded_records;
 
         // Spawn a background task to update the publication server.
         let span = trace_span!("switch_publication_server");


### PR DESCRIPTION
For @Philip-NLnetLabs -- makes it easier to access the data within the `zonedata` by reference.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?