### PR TITLE
Print a message in list commands when no items can be shown

### DIFF
--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -8,7 +8,7 @@ use crate::{
         SignerSerialPolicyInfo,
     },
     client::CascadeApiClient,
-    println,
+    eprintln, println,
 };
 
 #[derive(Clone, Debug, clap::Args)]
@@ -37,6 +37,10 @@ impl Policy {
         match self.command {
             PolicyCommand::List => {
                 let res: PolicyListResult = client.get_json("policy/").await?;
+
+                if res.policies.is_empty() {
+                    eprintln!("No policies to show");
+                }
 
                 for policy in res.policies {
                     println!("{policy}");

--- a/crates/cli/src/commands/tsig.rs
+++ b/crates/cli/src/commands/tsig.rs
@@ -6,7 +6,7 @@ use cascade_api::{
 };
 
 use crate::client::CascadeApiClient;
-use crate::println;
+use crate::{eprintln, println};
 
 #[derive(Clone, Debug, clap::Args)]
 pub struct Tsig {
@@ -169,6 +169,10 @@ impl Tsig {
             // List the set of TSIG keys known to Cascade.
             TsigCommand::List => {
                 let response: TsigListResult = client.get_json("tsig/").await?;
+
+                if response.tsig_key_info.is_empty() {
+                    eprintln!("No TSIG keys to show");
+                }
 
                 for (tsig_key_name, key_info) in response.tsig_key_info {
                     // For each TSIG key also list the zones and policies that

--- a/crates/cli/src/commands/zone.rs
+++ b/crates/cli/src/commands/zone.rs
@@ -7,7 +7,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use crate::ansi;
 use crate::api::*;
 use crate::client::CascadeApiClient;
-use crate::println;
+use crate::{eprintln, println};
 
 #[derive(Clone, Debug, clap::Args)]
 pub struct Zone {
@@ -270,6 +270,10 @@ impl Zone {
             }
             ZoneCommand::List => {
                 let response: ZonesListResult = client.get_json("zone/").await?;
+
+                if response.zones.is_empty() {
+                    eprintln!("No zones to show");
+                }
 
                 for zone_name in response.zones {
                     println!("{}", zone_name);


### PR DESCRIPTION
I chose to use `eprintln` because I don't want this to be filtered out with tracing levels. I think we should probably make it so that the CLIs error printing does not rely on tracing, that feels kind of wrong.

This PR is related to https://github.com/NLnetLabs/cascade/issues/514