### PR TITLE
Return some proper JSON for the health api endpoint

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -759,6 +759,11 @@ impl fmt::Display for ZoneReloadError {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct Health {
+    pub healthy: bool,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct ServerStatusResult {
     pub halted_zones: Vec<(ZoneName, String)>,
     pub signing_queue: Vec<SigningQueueReport>,

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -71,7 +71,7 @@ impl Command {
                     println!("Ok");
                 } else {
                     // This path is unreachable in practice at the moment.
-                    println!("Something's wrong!")
+                    println!("The Cascade daemon is reachable but reports itself as unhealthy.");
                 }
                 Ok(())
             }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -66,8 +66,13 @@ impl Command {
         match self {
             Self::Debug(cmd) => cmd.execute(client).await,
             Self::Health => {
-                client.get_json::<()>("health").await?;
-                println!("Ok");
+                let health = client.get_json::<cascade_api::Health>("health").await?;
+                if health.healthy {
+                    println!("Ok");
+                } else {
+                    // This path is unreachable in practice at the moment.
+                    println!("Something's wrong!")
+                }
                 Ok(())
             }
             Self::Zone(zone) => zone.execute(client).await,

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -189,8 +189,8 @@ impl HttpServer {
     }
 
     /// If this endpoint responds, the daemon is considered healthy.
-    async fn health() -> Json<()> {
-        Json(())
+    async fn health() -> Json<api::Health> {
+        Json(Health { healthy: true })
     }
 
     async fn metrics(State(state): State<Arc<HttpServer>>) -> impl IntoResponse {


### PR DESCRIPTION
Closes #375

Instead of returning `null`/`()` we now return `{ healthy: true }`. This makes it a bit clearer what the response means and allows us to extend it with more information in the future (e.g. maybe check for dnst keyset and stuff like that).