### PR TITLE
add the word client to --version

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -9,8 +9,25 @@ use super::client::CascadeApiClient;
 use super::commands::Command;
 
 #[derive(Clone, Debug, Parser)]
-#[command(version = env!("CASCADE_BUILD_VERSION"), disable_help_subcommand = true)]
+#[command(
+    version = env!("CASCADE_BUILD_VERSION"),
+    disable_help_subcommand = true,
+    disable_version_flag = true,
+)]
 pub struct Args {
+    /// Print client version
+    #[arg(
+        short = 'V',
+        long = "version",
+        // This doesn't need to be global, because that might lead to confusion
+        // about whether the version is for the client or the server.
+        global = false,
+        action = clap::ArgAction::Version,
+        // Display it at the end of the help
+        display_order = 100,
+    )]
+    pub version: (),
+
     /// The cascade server instance to connect to
     #[arg(
         short = 's',


### PR DESCRIPTION
Before:
```
-V, --version            Print version
```

After:
```
-V, --version            Print client version
```

The new argument is not global so that you can't write `cascade zone --version` or `cascade status --version` or something like that. I tried setting [exclusive](https://docs.rs/clap/latest/clap/struct.Arg.html#method.exclusive) too but that didn't seem to work.