### PR TITLE
add basic info command to get daemon version

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -764,6 +764,11 @@ pub struct Health {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct Info {
+    pub version: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct ServerStatusResult {
     pub halted_zones: Vec<(ZoneName, String)>,
     pub signing_queue: Vec<SigningQueueReport>,

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -23,6 +23,10 @@ pub enum Command {
     #[command(name = "health")]
     Health,
 
+    /// Show daemon information.
+    #[command(name = "info")]
+    Info,
+
     /// Manage zones
     #[command(name = "zone")]
     Zone(self::zone::Zone),
@@ -73,6 +77,11 @@ impl Command {
                     // This path is unreachable in practice at the moment.
                     println!("The Cascade daemon is reachable but reports itself as unhealthy.");
                 }
+                Ok(())
+            }
+            Self::Info => {
+                let info = client.get_json::<cascade_api::Info>("info").await?;
+                println!("Cascade daemon version: {}", info.version);
                 Ok(())
             }
             Self::Zone(zone) => zone.execute(client).await,

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -98,6 +98,7 @@ impl HttpServer {
 
         let app = Router::new()
             .route("/health", get(Self::health))
+            .route("/info", get(Self::info))
             .route("/metrics", get(Self::metrics))
             .route("/status", get(Self::status))
             .route("/status/keys", get(Self::status_keys))
@@ -191,6 +192,13 @@ impl HttpServer {
     /// If this endpoint responds, the daemon is considered healthy.
     async fn health() -> Json<api::Health> {
         Json(Health { healthy: true })
+    }
+
+    /// Get server info
+    async fn info() -> Json<api::Info> {
+        Json(Info {
+            version: env!("CASCADE_BUILD_VERSION").into(),
+        })
     }
 
     async fn metrics(State(state): State<Arc<HttpServer>>) -> impl IntoResponse {


### PR DESCRIPTION
Closes https://github.com/NLnetLabs/cascade/issues/803.

Add an `info` command that prints:
```
Cascade daemon version: 0.1.0-beta3-dev at c9a03b3a11-dirty
```

It uses the same string as `--version` but for the server instead of the client.

Some background on internal discussion:
- `health` should be used for load balancers and monitoring, not for getting the version.
- `status` doesn't feel right either, since that describes more what Cascade is doing.
- Therefore, a new command feels appropriate.
