### PR TITLE
Support importing keys by private key path as well as public key path (fixes #717).

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -190,7 +190,8 @@ pub enum KeyImport {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct FileKeyImport {
     pub key_type: KeyType,
-    pub path: Utf8PathBuf,
+    pub public_key_path: Utf8PathBuf,
+    pub private_key_path: Utf8PathBuf,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/crates/cli/src/commands/zone.rs
+++ b/crates/cli/src/commands/zone.rs
@@ -1064,9 +1064,9 @@ fn key_file_imports(
     Ok(key_imports)
 }
 
-// This is not done as impl TryFrom<Utf8PathBuf> for FileKeyImport as
-// Utf8PathBuf is not defined in this crate and Rust doesn't allow impl for a
-// type defined in another crate.
+// This is not done as impl TryFrom<Utf8PathBuf> for FileKeyImport as neither
+// Utf8PathBuf nor FileKeyImport are not defined in this crate and Rust
+// doesn't allow impl for a type defined in another crate.
 fn expand_key_path(key_file_path: Utf8PathBuf, key_type: KeyType) -> Result<FileKeyImport, String> {
     // Is the given path to a .key file or a .private file? We need both
     // so generate the other one from the one given. Note that we don't

--- a/crates/cli/src/commands/zone.rs
+++ b/crates/cli/src/commands/zone.rs
@@ -192,24 +192,9 @@ impl Zone {
                 import_csk_kmip,
             } => {
                 let import_public_key = import_public_key.into_iter().map(KeyImport::PublicKey);
-                let import_ksk_file = import_ksk_file.into_iter().map(|p| {
-                    KeyImport::File(FileKeyImport {
-                        key_type: KeyType::Ksk,
-                        path: p,
-                    })
-                });
-                let import_csk_file = import_csk_file.into_iter().map(|p| {
-                    KeyImport::File(FileKeyImport {
-                        key_type: KeyType::Csk,
-                        path: p,
-                    })
-                });
-                let import_zsk_file = import_zsk_file.into_iter().map(|p| {
-                    KeyImport::File(FileKeyImport {
-                        key_type: KeyType::Zsk,
-                        path: p,
-                    })
-                });
+                let import_ksk_file = key_file_imports(import_ksk_file, KeyType::Ksk)?;
+                let import_csk_file = key_file_imports(import_csk_file, KeyType::Csk)?;
+                let import_zsk_file = key_file_imports(import_zsk_file, KeyType::Zsk)?;
                 let import_ksk_kmip = kmip_imports(KeyType::Ksk, &import_ksk_kmip);
                 let import_csk_kmip = kmip_imports(KeyType::Csk, &import_csk_kmip);
                 let import_zsk_kmip = kmip_imports(KeyType::Zsk, &import_zsk_kmip);
@@ -1066,6 +1051,50 @@ fn format_duration(duration: Duration) -> String {
             )
             .unwrap()
     )
+}
+
+fn key_file_imports(
+    key_paths: Vec<Utf8PathBuf>,
+    key_type: KeyType,
+) -> Result<Vec<KeyImport>, String> {
+    let mut key_imports = Vec::with_capacity(key_paths.len());
+    for key_path in key_paths {
+        key_imports.push(KeyImport::File(expand_key_path(key_path, key_type)?));
+    }
+    Ok(key_imports)
+}
+
+// This is not done as impl TryFrom<Utf8PathBuf> for FileKeyImport as
+// Utf8PathBuf is not defined in this crate and Rust doesn't allow impl for a
+// type defined in another crate.
+fn expand_key_path(key_file_path: Utf8PathBuf, key_type: KeyType) -> Result<FileKeyImport, String> {
+    // Is the given path to a .key file or a .private file? We need both
+    // so generate the other one from the one given. Note that we don't
+    // do any actual checking against the filesystem, that is left to the
+    // daemon as the files have to be loaded by the daemon which may have
+    // different access rights (or even be on a different filesystem/host)
+    // than the client.
+    let (public_key_path, private_key_path) = match key_file_path.extension() {
+        Some("key") => {
+            let pri_path = key_file_path.with_extension("private");
+            let pub_path = key_file_path;
+            Ok((pub_path, pri_path))
+        }
+        Some("private") => {
+            let pub_path = key_file_path.with_extension("key");
+            let pri_path = key_file_path;
+            Ok((pub_path, pri_path))
+        }
+        _ => Err(format!(
+            "Key file path '{key_file_path}' does not end in .key or .private"
+        )),
+    }?;
+
+    Ok(FileKeyImport {
+        key_type,
+        public_key_path,
+        private_key_path,
+    })
 }
 
 fn kmip_imports(key_type: KeyType, x: &[String]) -> Vec<KeyImport> {

--- a/doc/manual/build/man/cascade-zone.1
+++ b/doc/manual/build/man/cascade-zone.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "CASCADE-ZONE" "1" "Jan 01, 2026" "0.1.0-beta2" "Cascade"
+.TH "CASCADE-ZONE" "1" "Jan 01, 2026" "0.1.0-beta3-dev" "Cascade"
 .SH NAME
 cascade-zone \- Manage zones
 .SH SYNOPSIS
@@ -183,30 +183,33 @@ This needs to be a file path accessible by the Cascade daemon.
 .B \-\-import\-ksk\-file <IMPORT_KSK_FILE>
 Import a key pair as a KSK.
 .sp
-The file path needs to be the public key file of the KSK. The private key
-file name is derived from the public key file. Key files are not
-actually copied from the specified paths and must remain accessible
-to the server.
+The file path needs to either be a public key file of the KSK with
+extension .key, or a private key file of the KSK with extension .private.
+The path to the other half of the key will be derived by replacing .key
+with .private or vice versa. Key files are not actually copied from the
+specified paths and must remain accessible to the server.
 .UNINDENT
 .INDENT 0.0
 .TP
 .B \-\-import\-zsk\-file <IMPORT_ZSK_FILE>
 Import a key pair as a ZSK.
 .sp
-The file path needs to be the public key file of the ZSK. The private key
-file name is derived from the public key file. Key files are not
-actually copied from the specified paths and must remain accessible
-to the server.
+The file path needs to either be a public key file of the ZSK with
+extension .key, or a private key file of the ZSK with extension .private.
+The path to the other half of the key will be derived by replacing .key
+with .private or vice versa. Key files are not actually copied from the
+specified paths and must remain accessible to the server.
 .UNINDENT
 .INDENT 0.0
 .TP
 .B \-\-import\-csk\-file <IMPORT_CSK_FILE>
 Import a key pair as a CSK.
 .sp
-The file path needs to be the public key file of the CSK. The private key
-file name is derived from the public key file. Key files are not
-actually copied from the specified paths and must remain accessible
-to the server.
+The file path needs to either be a public key file of the CSK with
+extension .key, or a private key file of the CSK with extension .private.
+The path to the other half of the key will be derived by replacing .key
+with .private or vice versa. Key files are not actually copied from the
+specified paths and must remain accessible to the server.
 .UNINDENT
 .INDENT 0.0
 .TP

--- a/doc/manual/source/man/cascade-zone.rst
+++ b/doc/manual/source/man/cascade-zone.rst
@@ -135,28 +135,31 @@ Options for :subcmd:`zone add`
 
    Import a key pair as a KSK.
 
-   The file path needs to be the public key file of the KSK. The private key
-   file name is derived from the public key file. Key files are not
-   actually copied from the specified paths and must remain accessible
-   to the server.
+   The file path needs to either be a public key file of the KSK with
+   extension .key, or a private key file of the KSK with extension .private.
+   The path to the other half of the key will be derived by replacing .key
+   with .private or vice versa. Key files are not actually copied from the
+   specified paths and must remain accessible to the server.
 
 .. option:: --import-zsk-file <IMPORT_ZSK_FILE>
 
    Import a key pair as a ZSK.
 
-   The file path needs to be the public key file of the ZSK. The private key
-   file name is derived from the public key file. Key files are not
-   actually copied from the specified paths and must remain accessible
-   to the server.
+   The file path needs to either be a public key file of the ZSK with
+   extension .key, or a private key file of the ZSK with extension .private.
+   The path to the other half of the key will be derived by replacing .key
+   with .private or vice versa. Key files are not actually copied from the
+   specified paths and must remain accessible to the server.
 
 .. option:: --import-csk-file <IMPORT_CSK_FILE>
 
    Import a key pair as a CSK.
 
-   The file path needs to be the public key file of the CSK. The private key
-   file name is derived from the public key file. Key files are not
-   actually copied from the specified paths and must remain accessible
-   to the server.
+   The file path needs to either be a public key file of the CSK with
+   extension .key, or a private key file of the CSK with extension .private.
+   The path to the other half of the key will be derived by replacing .key
+   with .private or vice versa. Key files are not actually copied from the
+   specified paths and must remain accessible to the server.
 
 .. option:: --import-ksk-kmip <server> <public_id> <private_id> <algorithm> <flags>
 

--- a/src/units/key_manager.rs
+++ b/src/units/key_manager.rs
@@ -1236,8 +1236,19 @@ fn imports_to_commands(key_imports: &[KeyImport]) -> Vec<Vec<String>> {
                     "import", key_type, "kmip", server, public_id, private_id, algorithm, flags
                 ]
             }
-            KeyImport::File(FileKeyImport { key_type, path }) => {
-                strs!["import", key_type, "file", path]
+            KeyImport::File(FileKeyImport {
+                key_type,
+                public_key_path,
+                private_key_path,
+            }) => {
+                strs![
+                    "import",
+                    key_type,
+                    "file",
+                    public_key_path,
+                    "--private-key",
+                    private_key_path
+                ]
             }
         })
         .collect()


### PR DESCRIPTION
Determines the path to the "other" half of the key and passes both public and private paths to `dnst keyset` explicitly, rather than just the public path as the latter can cause `dnst keyset` to produce a confusing error that the user specify `--private-key`, an argument not offered by `cascade zone add`.

Provide your description here

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?

- If you are modifying man pages:
  - [x] Did you commit the updated built man pages?
