### PR TITLE
[zone/machine] Check more state before starting a new operation

### DIFF
--- a/src/zone/machine.rs
+++ b/src/zone/machine.rs
@@ -405,11 +405,16 @@ impl<'a> ZoneHandle<'a> {
             }
             ZoneStateMachine::SigningFailed(signing_failed) => {
                 let waiting = signing_failed.reset();
+                transition.move_to(ZoneStateMachine::Waiting(waiting));
 
                 // TODO: This should be handled by 'Instances'.
                 self.state.next_min_expiration = None;
 
-                transition.move_to(ZoneStateMachine::Waiting(waiting));
+                // The signing operation has already been abandoned, so the zone
+                // data storage is already passive. Its call to `on_passive()`
+                // was ignored because the zone state machine was busy at the
+                // time. Call it again now.
+                self.storage().on_passive();
             }
             _ => {
                 transition.move_to(state);

--- a/src/zone/machine.rs
+++ b/src/zone/machine.rs
@@ -106,11 +106,14 @@ impl<'a> ZoneHandle<'a> {
             return None;
         }
 
-        // It's important that we first check the storage here instead of the
-        // zone state machine. The reason is that while the zone state machine
-        // is in the waiting state, the storage might still be persisting or
-        // cleaning the zone and we shouldn't start a new operation if that's
-        // the case.
+        let ZoneStateMachine::Waiting(_) = &self.state.machine else {
+            info!("Could not start load since an operation is in progress on the zone.");
+            return None;
+        };
+
+        // The zone state machine may be in the waiting state, but the storage
+        // might still be persisting or cleaning the zone, and we shouldn't
+        // start a new operation if that's the case.
         let Some(builder) = self.storage().start_load() else {
             info!("Could not start load since an operation is in progress on the zone.");
             return None;
@@ -118,9 +121,7 @@ impl<'a> ZoneHandle<'a> {
 
         let (transition, state) = self.state.machine.transition();
         let ZoneStateMachine::Waiting(waiting) = state else {
-            panic!(
-                "The storage was in the passive state but the state machine wasn't in the waiting state"
-            );
+            unreachable!("already checked that the state machine is `Waiting`")
         };
 
         transition.move_to(ZoneStateMachine::Loading(waiting.start_load()));
@@ -137,11 +138,14 @@ impl<'a> ZoneHandle<'a> {
             return None;
         }
 
-        // It's important that we first check the storage here instead of the
-        // zone state machine. The reason is that while the zone state machine
-        // is in the waiting state, the storage might still be persisting or
-        // cleaning the zone and we shouldn't start a new operation if that's
-        // the case.
+        let ZoneStateMachine::Waiting(_) = &self.state.machine else {
+            info!("Could not start load since an operation is in progress on the zone.");
+            return None;
+        };
+
+        // The zone state machine may be in the waiting state, but the storage
+        // might still be persisting or cleaning the zone, and we shouldn't
+        // start a new operation if that's the case.
         let Some(builder) = self.storage().start_resign() else {
             info!("Could not start resign since an operation is in progress on the zone.");
             return None;

--- a/src/zone/storage.rs
+++ b/src/zone/storage.rs
@@ -38,7 +38,9 @@ use crate::{
     center::Center,
     server::{LoadedReviewServer, PublicationServer, SignedReviewServer},
     util::BackgroundTasks,
-    zone::{HistoricalEvent, LastPublished, Zone, ZoneHandle, ZoneState},
+    zone::{
+        HistoricalEvent, LastPublished, Zone, ZoneHandle, ZoneState, machine::ZoneStateMachine,
+    },
 };
 
 //----------- StorageZoneHandle ------------------------------------------------
@@ -860,6 +862,12 @@ impl StorageZoneHandle<'_> {
         // TODO: Check whether resigning is needed. It has higher priority than
         // loading a new instance.
 
+        // Ensure a new operation can be started.
+        let ZoneStateMachine::Waiting(_) = &self.state.machine else {
+            trace!("Ignoring `on_passive()` because the pipeline is busy");
+            return;
+        };
+
         if self.zone().loader().start_pending() {
             // The zone is no longer passive.
             return;
@@ -867,7 +875,7 @@ impl StorageZoneHandle<'_> {
 
         if self.zone().signer().start_pending() {
             // The zone is no longer passive.
-            // return;
+            //return;
         }
     }
 }


### PR DESCRIPTION
If the zone is in `SigningFailed` state due to a re-signing failure, the zone data storage state machine is `Passive`. This breaks an assumption made in `try_start_{load,resign}()`. This commit adds a check that the zone is in `Waiting` state before trying the zone data storage state machine.

Should help with #786.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?