### PR TITLE
Move pipeline logic out of `zone/storage.rs`

### DIFF
--- a/crates/zonedata/src/builder.rs
+++ b/crates/zonedata/src/builder.rs
@@ -19,6 +19,7 @@ use crate::{
 /// [`LoadedZoneBuilder`] is used to load new instances of a zone from external
 /// sources (e.g. zonefiles and DNS servers). It offers read-only access to the
 /// current loaded instance of the zone, to support incremental loading.
+#[must_use = "Dropping this will lock up the zone data storage"]
 pub struct LoadedZoneBuilder {
     /// The underlying data.
     data: Arc<Data>,
@@ -285,6 +286,7 @@ impl fmt::Debug for LoadedZoneBuilder {
 /// re-sign existing signed instances. It offers read-only access to the current
 /// (loaded and signed) instance of the zone, and (if any) the new loaded
 /// instance of the zone, to support incremental signing.
+#[must_use = "Dropping this will lock up the zone data storage"]
 pub struct SignedZoneBuilder {
     /// The underlying data.
     data: Arc<Data>,
@@ -732,6 +734,7 @@ impl fmt::Debug for SignedZoneBuilder {
 //----------- LoadedZoneBuilt --------------------------------------------------
 
 /// Proof that the loaded component of a zone has been built.
+#[must_use = "Dropping this will lock up the zone data storage"]
 pub struct LoadedZoneBuilt {
     /// The underlying data.
     pub(crate) data: Arc<Data>,
@@ -743,6 +746,7 @@ pub struct LoadedZoneBuilt {
 //----------- SignedZoneBuilt --------------------------------------------------
 
 /// Proof that the signed component of a zone has been built.
+#[must_use = "Dropping this will lock up the zone data storage"]
 pub struct SignedZoneBuilt {
     /// The underlying data.
     pub(crate) data: Arc<Data>,

--- a/crates/zonedata/src/builder.rs
+++ b/crates/zonedata/src/builder.rs
@@ -261,6 +261,7 @@ impl LoadedZoneBuilder {
         if self.built() {
             Ok(LoadedZoneBuilt {
                 data: self.data,
+                index: self.index,
                 diff: Arc::new(*self.diff.unwrap()),
             })
         } else {
@@ -712,6 +713,9 @@ impl SignedZoneBuilder {
         if self.built() {
             Ok(SignedZoneBuilt {
                 data: self.data,
+                loaded_index: self.loaded_index,
+                loaded_diff: self.loaded_diff.clone(),
+                signed_index: self.signed_index,
                 diff: Arc::new(*self.signed_diff.unwrap()),
             })
         } else {
@@ -739,8 +743,35 @@ pub struct LoadedZoneBuilt {
     /// The underlying data.
     pub(crate) data: Arc<Data>,
 
+    /// The index of the new loaded instance.
+    pub(crate) index: bool,
+
     /// The diff.
     pub(crate) diff: Arc<DiffData>,
+}
+
+impl LoadedZoneBuilt {
+    /// The new (loaded) instance.
+    ///
+    /// If a new instance instance has been built, it can be accessed here. Note
+    /// that empty instances cannot be accessed.
+    pub fn next(&self) -> Option<LoadedZoneReader<'_>> {
+        // SAFETY: As per the caller, 'loaded[index]' will not be
+        // accessed elsewhere for the lifetime of 'self', and so is sound to
+        // access immutably.
+        let next = unsafe { &*self.data.loaded[self.index as usize].get() };
+
+        next.soa.as_ref()?;
+
+        // NOTE:
+        // - 'next' is complete, as checked above.
+        Some(LoadedZoneReader::new(next))
+    }
+
+    /// The prepared diff.
+    pub const fn diff(&self) -> &Arc<DiffData> {
+        &self.diff
+    }
 }
 
 //----------- SignedZoneBuilt --------------------------------------------------
@@ -751,6 +782,93 @@ pub struct SignedZoneBuilt {
     /// The underlying data.
     pub(crate) data: Arc<Data>,
 
+    /// The index of the next loaded instance.
+    pub(crate) loaded_index: bool,
+
+    /// The index of the new signed instance.
+    pub(crate) signed_index: bool,
+
+    /// The loaded diff.
+    pub(crate) loaded_diff: Option<Arc<DiffData>>,
+
     /// The diff.
     pub(crate) diff: Arc<DiffData>,
+}
+
+impl SignedZoneBuilt {
+    /// Whether a new loaded instance exists.
+    ///
+    /// If this is true, and the new loaded instance is non-empty,
+    /// [`Self::next_loaded()`] will return `Some` and provide access to it.
+    pub fn have_next_loaded(&self) -> bool {
+        self.loaded_diff.is_some()
+    }
+
+    /// The diff of the built loaded component.
+    ///
+    /// If the loaded component of the zone has been built, and the current
+    /// authoritative instance of the zone has a loaded component, the diff
+    /// between the two (from the old instance to the new one) can be accessed
+    /// here.
+    pub fn loaded_diff(&self) -> Option<&Arc<DiffData>> {
+        self.loaded_diff.as_ref()
+    }
+
+    /// The new loaded instance (if any).
+    ///
+    /// If a new loaded instance has been prepared, and is non-empty, it can be
+    /// accessed here. Check [`Self::have_next_loaded()`] to determine whether
+    /// the new instance exists but is empty. Use [`Self::loaded_diff()`] to
+    /// examine the differences between the current and new instances.
+    pub fn next_loaded(&self) -> Option<LoadedZoneReader<'_>> {
+        if !self.have_next_loaded() {
+            // The loaded component has not been built.
+            return None;
+        }
+
+        // SAFETY: As per the caller, 'loaded[loaded_index]' will not be
+        // accessed elsewhere for the lifetime of 'self', and so is sound to
+        // access immutably.
+        let next = unsafe { &*self.data.loaded[self.loaded_index as usize].get() };
+
+        next.soa.as_ref()?;
+
+        // NOTE:
+        // - 'next' is complete, as checked above.
+        Some(LoadedZoneReader::new(next))
+    }
+
+    /// The newly-built signed instance.
+    ///
+    /// If the instance is non-empty, it can be accessed here.
+    pub fn next_signed(&self) -> Option<SignedZoneReader<'_>> {
+        // SAFETY: As per the caller, 'signed[signed_index]' will not be
+        // accessed elsewhere for the lifetime of 'self', and so is sound to
+        // access immutably.
+        let signed = unsafe { &*self.data.signed[self.signed_index as usize].get() };
+
+        let loaded = if !self.have_next_loaded() {
+            // SAFETY: As per the caller, 'loaded[!loaded_index]' will not be
+            // accessed elsewhere for the lifetime of 'self', and so is sound to
+            // access immutably.
+            unsafe { &*self.data.loaded[!self.loaded_index as usize].get() }
+        } else {
+            // SAFETY: As per the caller, 'loaded[loaded_index]' will not be
+            // accessed elsewhere for the lifetime of 'self', and so is sound to
+            // access immutably.
+            unsafe { &*self.data.loaded[self.loaded_index as usize].get() }
+        };
+
+        signed.soa.as_ref()?;
+
+        // NOTE:
+        // - 'signed' is complete, as checked above.
+        // - Since 'signed' is complete, 'loaded' must be complete.
+        Some(SignedZoneReader::new(loaded, signed))
+    }
+
+    /// The prepared diff.
+    pub const fn diff(&self) -> &Arc<DiffData> {
+        &self.diff
+    }
 }

--- a/crates/zonedata/src/viewer.rs
+++ b/crates/zonedata/src/viewer.rs
@@ -15,6 +15,7 @@ use crate::{Data, DiffData, LoadedZoneReader, SignedZoneReader};
 ///
 /// [`ZoneViewer`] offers complete (read-only) access to the current
 /// authoritative instance of a zone.
+#[must_use = "Dropping this will lock up the zone data storage"]
 pub struct ZoneViewer {
     /// The underlying data.
     data: Arc<Data>,
@@ -117,6 +118,7 @@ impl ZoneViewer {
 /// [`LoadedZoneReviewer`] offers read-only access to the loaded component
 /// of an upcoming instance of a zone, allowing its contents to be reviewed
 /// before it is signed or it becomes authoritative.
+#[must_use = "Dropping this will lock up the zone data storage"]
 pub struct LoadedZoneReviewer {
     /// The underlying data.
     data: Arc<Data>,
@@ -198,6 +200,7 @@ impl LoadedZoneReviewer {
 /// [`SignedZoneReviewer`] offers complete (read-only) access to an upcoming
 /// signed instance of a zone, allowing its contents to be reviewed before it
 /// becomes authoritative.
+#[must_use = "Dropping this will lock up the zone data storage"]
 pub struct SignedZoneReviewer {
     /// The underlying data.
     data: Arc<Data>,

--- a/src/center.rs
+++ b/src/center.rs
@@ -152,15 +152,22 @@ pub async fn add_zone(
 
             // Don't try to restore zone data, since it's a completely new zone.
             //
-            // This will clear the data for the zone and register it against the
-            // zone servers.
-            ZoneHandle {
+            // This will clear the data for the zone.
+            let mut handle = ZoneHandle {
                 zone: &zone,
                 state: &mut zone_state,
                 center,
-            }
-            .storage()
-            .abandon_loaded_restoration(restorer);
+            };
+            let (loaded_reviewer, signed_reviewer, viewer) =
+                handle.storage().abandon_loaded_restoration(restorer);
+
+            // Update the zone servers.
+            LoadedReviewServer::add_zone(handle.center, handle.zone.clone(), loaded_reviewer);
+            SignedReviewServer::add_zone(handle.center, handle.zone.clone(), signed_reviewer);
+            PublicationServer::add_zone(handle.center, handle.zone.clone(), viewer);
+
+            // Send a notification that the state machine is now passive.
+            handle.storage().on_passive();
         }
 
         // Insert the zone in the global set.

--- a/src/persistence/zone.rs
+++ b/src/persistence/zone.rs
@@ -181,7 +181,7 @@ impl ZonePersistenceHandle<'_> {
                 // cannot be taken until the outer function terminates.
                 let mut handle = zone.write_handle(&center);
 
-                handle.get().start_switch(persisted);
+                handle.get().finish_signed_persistence(persisted);
 
                 handle.state.persistence.ongoing.finish();
             });

--- a/src/persistence/zone.rs
+++ b/src/persistence/zone.rs
@@ -9,6 +9,7 @@ use tracing::{debug, info, trace, trace_span, warn};
 
 use crate::{
     center::Center,
+    server::{LoadedReviewServer, PublicationServer, SignedReviewServer},
     util::BackgroundTasks,
     zone::{Zone, ZoneHandle, ZoneState, save_state_now},
 };
@@ -109,7 +110,17 @@ impl ZonePersistenceHandle<'_> {
                     "Restored diffs: {:?}",
                     handle.state.persisted_loaded_diff_paths
                 );
-                handle.storage().finish_signed_restoration(restored);
+                let (loaded_reviewer, signed_reviewer, viewer) =
+                    handle.storage().finish_signed_restoration(restored);
+
+                // Register the zone against the zone servers.
+                LoadedReviewServer::add_zone(handle.center, handle.zone.clone(), loaded_reviewer);
+                SignedReviewServer::add_zone(handle.center, handle.zone.clone(), signed_reviewer);
+                PublicationServer::add_zone(handle.center, handle.zone.clone(), viewer);
+
+                // Send a notification that the state machine is now passive.
+                handle.storage().on_passive();
+
                 handle.state.persistence.ongoing.finish();
             });
     }
@@ -184,7 +195,17 @@ fn abandon_loaded_restoration(
 ) {
     reset_state_due_to_abandoned_restore(center, zone);
     let mut handle = zone.write_handle(center);
-    handle.storage().abandon_loaded_restoration(restorer);
+    let (loaded_reviewer, signed_reviewer, viewer) =
+        handle.storage().abandon_loaded_restoration(restorer);
+
+    // Update the zone servers.
+    LoadedReviewServer::add_zone(handle.center, handle.zone.clone(), loaded_reviewer);
+    SignedReviewServer::add_zone(handle.center, handle.zone.clone(), signed_reviewer);
+    PublicationServer::add_zone(handle.center, handle.zone.clone(), viewer);
+
+    // Send a notification that the state machine is now passive.
+    handle.storage().on_passive();
+
     handle.state.persistence.ongoing.finish();
 }
 
@@ -195,7 +216,17 @@ fn abandon_signed_restoration(
 ) {
     reset_state_due_to_abandoned_restore(center, zone);
     let mut handle = zone.write_handle(center);
-    handle.storage().abandon_signed_restoration(restorer);
+    let (loaded_reviewer, signed_reviewer, viewer) =
+        handle.storage().abandon_signed_restoration(restorer);
+
+    // Update the zone servers.
+    LoadedReviewServer::add_zone(handle.center, handle.zone.clone(), loaded_reviewer);
+    SignedReviewServer::add_zone(handle.center, handle.zone.clone(), signed_reviewer);
+    PublicationServer::add_zone(handle.center, handle.zone.clone(), viewer);
+
+    // Send a notification that the state machine is now passive.
+    handle.storage().on_passive();
+
     handle.state.persistence.ongoing.finish();
 }
 

--- a/src/zone/machine.rs
+++ b/src/zone/machine.rs
@@ -1,9 +1,12 @@
+use std::time::SystemTime;
+
 use cascade_api::ZoneReviewStatus;
+use domain::base::Serial;
 use tracing::{info, trace};
 
 use crate::{
     units::zone_signer::SignerError,
-    zone::{HistoricalEvent, ZoneHandle},
+    zone::{HistoricalEvent, LastPublished, ZoneHandle},
 };
 
 /// State machine for a particular zone
@@ -407,14 +410,51 @@ impl<'a> ZoneHandle<'a> {
 
 /// # Switching operations
 impl<'a> ZoneHandle<'a> {
-    /// Begin switching to an approved instance of the zone.
-    pub(crate) fn start_switch(&mut self, persisted: cascade_zonedata::SignedZonePersisted) {
-        self.storage().start_switch(persisted);
-    }
+    /// Finish persisting an approved signed instance.
+    pub(crate) fn finish_signed_persistence(
+        &mut self,
+        persisted: cascade_zonedata::SignedZonePersisted,
+    ) {
+        let viewer = self.storage().finish_signed_persistence(persisted);
 
-    /// Finish switching to a new instance of the zone.
-    pub(crate) fn finish_switch(&mut self, cleaner: cascade_zonedata::ZoneCleaner) {
-        self.storage().start_cleanup(cleaner);
+        self.state.storage.published_soa = viewer.read().map(|r| r.soa().clone());
+        self.state.storage.published_loaded_soa = viewer.read().map(|r| r.loaded().soa().clone());
+
+        // Compute the total number of records
+        let reader = viewer.read().unwrap();
+        let generated_records = reader.generated_records().len();
+        let loaded_records = reader.loaded().regular_records().len() - 1;
+        let num_records = generated_records + loaded_records;
+
+        let loaded_serial = Serial(
+            self.state
+                .storage
+                .published_loaded_soa
+                .as_ref()
+                .unwrap()
+                .rdata
+                .serial
+                .into(),
+        );
+        let signed_serial = Serial(
+            self.state
+                .storage
+                .published_soa
+                .as_ref()
+                .unwrap()
+                .rdata
+                .serial
+                .into(),
+        );
+        let timestamp = SystemTime::now();
+        self.state.last_published = Some(LastPublished {
+            loaded_serial,
+            signed_serial,
+            timestamp,
+            num_records,
+        });
+
+        self.storage().start_publishing(viewer);
     }
 }
 

--- a/src/zone/machine.rs
+++ b/src/zone/machine.rs
@@ -190,7 +190,17 @@ impl<'a> ZoneHandle<'a> {
 
         transition.move_to(ZoneStateMachine::LoadedReview(loaded.finish_load()));
 
-        self.storage().finish_load(built);
+        let loaded_reviewer = self.storage().finish_load(built);
+
+        // TODO: Use the instance ID here, which will not require
+        // examining the zone contents.
+        let serial = loaded_reviewer.read().unwrap().soa().rdata.serial;
+        self.state.record_event(
+            HistoricalEvent::NewVersionReceived,
+            Some(domain::base::Serial(serial.into())),
+        );
+
+        self.storage().start_loaded_review(loaded_reviewer);
     }
 }
 
@@ -234,7 +244,10 @@ impl<'a> ZoneHandle<'a> {
         };
 
         transition.move_to(ZoneStateMachine::Waiting(loaded.soft_reject()));
-        self.storage().abandon_loaded_review();
+        let loaded_reviewer = self.storage().abandon_loaded_review();
+        // Stop serving the abandoned instance.
+        self.storage()
+            .start_rewinding_loaded_review(loaded_reviewer);
     }
 
     pub(crate) fn hard_reject_loaded(&mut self) {
@@ -272,7 +285,9 @@ impl<'a> ZoneHandle<'a> {
 
         transition.move_to(ZoneStateMachine::SignedReview(signing.finish_signing()));
 
-        self.storage().finish_sign(built);
+        let signed_reviewer = self.storage().finish_sign(built);
+        // Begin reviewing the prepared instance.
+        self.storage().start_signed_review(signed_reviewer);
     }
 
     // Abandon the ongoing signing operation (but not due to failure).
@@ -287,7 +302,10 @@ impl<'a> ZoneHandle<'a> {
 
         transition.move_to(ZoneStateMachine::Waiting(signing.abandon()));
 
-        self.storage().abandon_sign(builder);
+        let loaded_reviewer = self.storage().abandon_sign(builder);
+        // Stop serving the abandoned instance.
+        self.storage()
+            .start_rewinding_loaded_review(loaded_reviewer);
     }
 
     pub(crate) fn signing_failed(
@@ -303,7 +321,10 @@ impl<'a> ZoneHandle<'a> {
 
         transition.move_to(ZoneStateMachine::SigningFailed(signing.signing_failed(err)));
 
-        self.storage().abandon_sign(builder);
+        let loaded_reviewer = self.storage().abandon_sign(builder);
+        // Stop serving the abandoned instance.
+        self.storage()
+            .start_rewinding_loaded_review(loaded_reviewer);
     }
 }
 
@@ -349,10 +370,15 @@ impl<'a> ZoneHandle<'a> {
 
         transition.move_to(ZoneStateMachine::Waiting(signed.soft_reject()));
 
+        let (loaded_reviewer, signed_reviewer) = self.storage().abandon_signed_review();
+
         // TODO: This should be handled by 'Instances'.
         self.state.next_min_expiration = None;
+        self.state.storage.loaded_review_soa = loaded_reviewer.read().map(|r| r.soa().clone());
+        self.state.storage.signed_review_soa = signed_reviewer.read().map(|r| r.soa().clone());
 
-        self.storage().abandon_signed_review();
+        self.storage()
+            .start_rewinding_review(loaded_reviewer, signed_reviewer);
     }
 
     pub(crate) fn hard_reject_signed(&mut self) {
@@ -395,7 +421,9 @@ impl<'a> ZoneHandle<'a> {
             ZoneStateMachine::HaltLoaded(halt_loaded) => {
                 let waiting = halt_loaded.reset();
                 transition.move_to(ZoneStateMachine::Waiting(waiting));
-                self.storage().abandon_loaded_review();
+                let loaded_reviewer = self.storage().abandon_loaded_review();
+                self.storage()
+                    .start_rewinding_loaded_review(loaded_reviewer);
             }
             ZoneStateMachine::HaltSigned(halt_signed) => {
                 let waiting = halt_signed.reset();
@@ -404,7 +432,9 @@ impl<'a> ZoneHandle<'a> {
                 // TODO: This should be handled by 'Instances'.
                 self.state.next_min_expiration = None;
 
-                self.storage().abandon_signed_review();
+                let (loaded_reviewer, signed_reviewer) = self.storage().abandon_signed_review();
+                self.storage()
+                    .start_rewinding_review(loaded_reviewer, signed_reviewer);
             }
             ZoneStateMachine::SigningFailed(signing_failed) => {
                 let waiting = signing_failed.reset();

--- a/src/zone/machine.rs
+++ b/src/zone/machine.rs
@@ -1,5 +1,4 @@
 use cascade_api::ZoneReviewStatus;
-use cascade_zonedata::{LoadedZoneBuilder, LoadedZoneBuilt, SignedZoneBuilder};
 use tracing::{info, trace};
 
 use crate::{
@@ -99,7 +98,7 @@ impl ZoneStateMachine {
 
 /// # Initiating operations
 impl<'a> ZoneHandle<'a> {
-    pub(crate) fn try_start_load(&mut self) -> Option<LoadedZoneBuilder> {
+    pub(crate) fn try_start_load(&mut self) -> Option<cascade_zonedata::LoadedZoneBuilder> {
         // If we're in maintenance mode, then we don't start this operation.
         // TODO: distinguish between a manual load and an automatic one.
         if self.state.maintenance_mode {
@@ -131,7 +130,7 @@ impl<'a> ZoneHandle<'a> {
         Some(builder)
     }
 
-    pub(crate) fn try_start_resign(&mut self) -> Option<SignedZoneBuilder> {
+    pub(crate) fn try_start_resign(&mut self) -> Option<cascade_zonedata::SignedZoneBuilder> {
         // If we're in maintenance mode, then we don't start this operation.
         // TODO: distinguish between a manual resign and an automatic one.
         if self.state.maintenance_mode {
@@ -170,7 +169,7 @@ impl<'a> ZoneHandle<'a> {
 
 /// # Loading operations
 impl<'a> ZoneHandle<'a> {
-    pub(crate) fn abandon_load(&mut self, builder: LoadedZoneBuilder) {
+    pub(crate) fn abandon_load(&mut self, builder: cascade_zonedata::LoadedZoneBuilder) {
         let (transition, state) = self.state.machine.transition();
 
         let ZoneStateMachine::Loading(loaded) = state else {
@@ -182,7 +181,7 @@ impl<'a> ZoneHandle<'a> {
         self.storage().abandon_load(builder);
     }
 
-    pub(crate) fn finish_load(&mut self, built: LoadedZoneBuilt) {
+    pub(crate) fn finish_load(&mut self, built: cascade_zonedata::LoadedZoneBuilt) {
         let (transition, state) = self.state.machine.transition();
 
         let ZoneStateMachine::Loading(loaded) = state else {
@@ -277,7 +276,7 @@ impl<'a> ZoneHandle<'a> {
     }
 
     // Abandon the ongoing signing operation (but not due to failure).
-    pub(crate) fn abandon_signing(&mut self, builder: SignedZoneBuilder) {
+    pub(crate) fn abandon_signing(&mut self, builder: cascade_zonedata::SignedZoneBuilder) {
         let (transition, state) = self.state.machine.transition();
 
         let ZoneStateMachine::Signing(signing) = state else {
@@ -291,7 +290,11 @@ impl<'a> ZoneHandle<'a> {
         self.storage().abandon_sign(builder);
     }
 
-    pub(crate) fn signing_failed(&mut self, builder: SignedZoneBuilder, err: SignerError) {
+    pub(crate) fn signing_failed(
+        &mut self,
+        builder: cascade_zonedata::SignedZoneBuilder,
+        err: SignerError,
+    ) {
         let (transition, state) = self.state.machine.transition();
 
         let ZoneStateMachine::Signing(signing) = state else {

--- a/src/zone/machine.rs
+++ b/src/zone/machine.rs
@@ -200,6 +200,8 @@ impl<'a> ZoneHandle<'a> {
             Some(domain::base::Serial(serial.into())),
         );
 
+        self.state.storage.loaded_review_soa = loaded_reviewer.read().map(|r| r.soa().clone());
+
         self.storage().start_loaded_review(loaded_reviewer);
     }
 }
@@ -246,6 +248,7 @@ impl<'a> ZoneHandle<'a> {
         transition.move_to(ZoneStateMachine::Waiting(loaded.soft_reject()));
         let loaded_reviewer = self.storage().abandon_loaded_review();
         // Stop serving the abandoned instance.
+        self.state.storage.loaded_review_soa = loaded_reviewer.read().map(|r| r.soa().clone());
         self.storage()
             .start_rewinding_loaded_review(loaded_reviewer);
     }
@@ -287,6 +290,7 @@ impl<'a> ZoneHandle<'a> {
 
         let signed_reviewer = self.storage().finish_sign(built);
         // Begin reviewing the prepared instance.
+        self.state.storage.signed_review_soa = signed_reviewer.read().map(|r| r.soa().clone());
         self.storage().start_signed_review(signed_reviewer);
     }
 
@@ -304,6 +308,7 @@ impl<'a> ZoneHandle<'a> {
 
         let loaded_reviewer = self.storage().abandon_sign(builder);
         // Stop serving the abandoned instance.
+        self.state.storage.loaded_review_soa = loaded_reviewer.read().map(|r| r.soa().clone());
         self.storage()
             .start_rewinding_loaded_review(loaded_reviewer);
     }
@@ -323,6 +328,7 @@ impl<'a> ZoneHandle<'a> {
 
         let loaded_reviewer = self.storage().abandon_sign(builder);
         // Stop serving the abandoned instance.
+        self.state.storage.loaded_review_soa = loaded_reviewer.read().map(|r| r.soa().clone());
         self.storage()
             .start_rewinding_loaded_review(loaded_reviewer);
     }
@@ -422,6 +428,8 @@ impl<'a> ZoneHandle<'a> {
                 let waiting = halt_loaded.reset();
                 transition.move_to(ZoneStateMachine::Waiting(waiting));
                 let loaded_reviewer = self.storage().abandon_loaded_review();
+                self.state.storage.loaded_review_soa =
+                    loaded_reviewer.read().map(|r| r.soa().clone());
                 self.storage()
                     .start_rewinding_loaded_review(loaded_reviewer);
             }

--- a/src/zone/storage.rs
+++ b/src/zone/storage.rs
@@ -176,8 +176,6 @@ impl StorageZoneHandle<'_> {
         fields(zone = %self.zone.name),
     )]
     pub fn start_loaded_review(&mut self, loaded_reviewer: LoadedZoneReviewer) {
-        self.state.storage.loaded_review_soa = loaded_reviewer.read().map(|r| r.soa().clone());
-
         let zone = self.zone.clone();
         let center = self.center.clone();
         let span = trace_span!("start_loaded_review");
@@ -260,8 +258,6 @@ impl StorageZoneHandle<'_> {
                 info!("The loaded instance has been rejected; cleaning it up");
 
                 let (s, loaded_reviewer) = s.give_up();
-                self.state.storage.loaded_review_soa =
-                    loaded_reviewer.read().map(|r| r.soa().clone());
                 transition.move_to(ZoneDataStorage::CleanLoadedPending(s));
                 loaded_reviewer
             }
@@ -383,8 +379,6 @@ impl StorageZoneHandle<'_> {
                 trace!("Abandoning the ongoing sign operation");
 
                 let (s, loaded_reviewer) = s.give_up(builder);
-                self.state.storage.loaded_review_soa =
-                    loaded_reviewer.read().map(|r| r.soa().clone());
                 transition.move_to(ZoneDataStorage::CleanLoadedPending(s));
                 loaded_reviewer
             }
@@ -405,8 +399,6 @@ impl StorageZoneHandle<'_> {
         fields(zone = %self.zone.name),
     )]
     pub fn start_signed_review(&mut self, signed_reviewer: SignedZoneReviewer) {
-        self.state.storage.signed_review_soa = signed_reviewer.read().map(|r| r.soa().clone());
-
         let zone = self.zone.clone();
         let center = self.center.clone();
         let span = trace_span!("start_signed_review");

--- a/src/zone/storage.rs
+++ b/src/zone/storage.rs
@@ -515,36 +515,7 @@ impl StorageZoneHandle<'_> {
             _ => panic!("The zone is not undergoing signer review"),
         };
 
-        let span = trace_span!("reset_review_servers");
-        let zone = self.zone.clone();
-        let center = self.center.clone();
-        self.state.storage.background_tasks.spawn(span, async move {
-            trace!("Resetting the signed review server");
-            let old_signed_reviewer =
-                SignedReviewServer::update_viewer(&center, &zone, signed_reviewer).await;
-
-            trace!("Resetting the loaded review server");
-            let old_loaded_reviewer =
-                LoadedReviewServer::update_viewer(&center, &zone, loaded_reviewer).await;
-
-            // Examine the current state.
-            let mut handle = zone.write_handle(&center);
-            let cleaner = match transition(&mut handle.state.storage.machine) {
-                (transition, ZoneDataStorage::CleanWholePending(s)) => {
-                    let (s, cleaner) = s
-                        .stop_review(old_signed_reviewer)
-                        .stop_review(old_loaded_reviewer);
-                    transition.move_to(ZoneDataStorage::Cleaning(s));
-                    cleaner
-                }
-
-                _ => unreachable!("The zone was left in 'CleanWholePending' state"),
-            };
-
-            handle.storage().start_cleanup(cleaner);
-
-            handle.state.storage.background_tasks.finish();
-        });
+        self.start_rewinding_review(loaded_reviewer, signed_reviewer);
     }
 }
 
@@ -841,6 +812,57 @@ impl StorageZoneHandle<'_> {
             };
 
             // Initiate cleanup of the abandoned instance.
+            handle.storage().start_cleanup(cleaner);
+
+            handle.state.storage.background_tasks.finish();
+        });
+    }
+
+    /// Rewind the loaded and signed review servers.
+    ///
+    /// When an upcoming loaded+signed instance is under review and is
+    /// abandoned, the review servers must be updated to stop serving it. A
+    /// background task will be started to achieve this.
+    ///
+    /// The loaded and signed reviewer objects for the current instance (not the
+    /// one being abandoned) are received. The old reviewers will be returned to
+    /// the state machine and the old instance will be cleaned up.
+    #[tracing::instrument(
+        level = "trace",
+        skip_all,
+        fields(zone = %self.zone.name),
+    )]
+    fn start_rewinding_review(
+        &mut self,
+        loaded_reviewer: LoadedZoneReviewer,
+        signed_reviewer: SignedZoneReviewer,
+    ) {
+        let span = trace_span!("reset_review_servers");
+        let zone = self.zone.clone();
+        let center = self.center.clone();
+        self.state.storage.background_tasks.spawn(span, async move {
+            trace!("Resetting the signed review server");
+            let old_signed_reviewer =
+                SignedReviewServer::update_viewer(&center, &zone, signed_reviewer).await;
+
+            trace!("Resetting the loaded review server");
+            let old_loaded_reviewer =
+                LoadedReviewServer::update_viewer(&center, &zone, loaded_reviewer).await;
+
+            // Examine the current state.
+            let mut handle = zone.write_handle(&center);
+            let cleaner = match transition(&mut handle.state.storage.machine) {
+                (transition, ZoneDataStorage::CleanWholePending(s)) => {
+                    let (s, cleaner) = s
+                        .stop_review(old_signed_reviewer)
+                        .stop_review(old_loaded_reviewer);
+                    transition.move_to(ZoneDataStorage::Cleaning(s));
+                    cleaner
+                }
+
+                _ => unreachable!("The zone was left in 'CleanWholePending' state"),
+            };
+
             handle.storage().start_cleanup(cleaner);
 
             handle.state.storage.background_tasks.finish();

--- a/src/zone/storage.rs
+++ b/src/zone/storage.rs
@@ -23,7 +23,7 @@
 //! such operations must wait. When the data storage becomes passive, it will
 //! call [`StorageZoneHandle::on_passive()`] to initiate enqueued operations.
 
-use std::{fmt, sync::Arc, time::SystemTime};
+use std::{fmt, sync::Arc};
 
 use cascade_zonedata::{
     DiffData, LoadedZoneBuilder, LoadedZoneBuilt, LoadedZonePersisted, LoadedZonePersister,
@@ -31,14 +31,13 @@ use cascade_zonedata::{
     SignedZonePersisted, SignedZonePersister, SignedZoneRestored, SignedZoneRestorer,
     SignedZoneReviewer, SoaRecord, ZoneCleaner, ZoneDataStorage, ZoneViewer,
 };
-use domain::base::Serial;
 use tracing::{info, trace, trace_span, warn};
 
 use crate::{
     center::Center,
     server::{LoadedReviewServer, PublicationServer, SignedReviewServer},
     util::BackgroundTasks,
-    zone::{LastPublished, Zone, ZoneHandle, ZoneState, machine::ZoneStateMachine},
+    zone::{Zone, ZoneHandle, ZoneState, machine::ZoneStateMachine},
 };
 
 //----------- StorageZoneHandle ------------------------------------------------
@@ -575,6 +574,22 @@ impl StorageZoneHandle<'_> {
             ),
         }
     }
+
+    /// Finish the ongoing signed-instance persistence.
+    pub fn finish_signed_persistence(&mut self, persisted: SignedZonePersisted) -> ZoneViewer {
+        // Examine the current state.
+        match transition(&mut self.state.storage.machine) {
+            (transition, ZoneDataStorage::PersistingSigned(s)) => {
+                let (s, viewer) = s.mark_complete(persisted);
+                transition.move_to(ZoneDataStorage::Switching(s));
+                viewer
+            }
+
+            _ => unreachable!(
+                "'ZoneDataStorage::PersistingSigned' is the only state where a 'SignedZonePersisted' is available"
+            ),
+        }
+    }
 }
 
 /// # Background Tasks
@@ -623,38 +638,16 @@ impl StorageZoneHandle<'_> {
         });
     }
 
-    /// Start switching to an approved and persisted signed instance.
+    /// Start publishing a new instance.
     ///
     /// A background task will be spawned to switch the publication server to
-    /// the newly persisted instance and transition to the next state.
+    /// the new instance and transition to the next state.
     #[tracing::instrument(
         level = "trace",
         skip_all,
         fields(zone = %self.zone.name),
     )]
-    pub fn start_switch(&mut self, persisted: SignedZonePersisted) {
-        // Examine the current state.
-        let viewer = match transition(&mut self.state.storage.machine) {
-            (transition, ZoneDataStorage::PersistingSigned(s)) => {
-                let (s, viewer) = s.mark_complete(persisted);
-                transition.move_to(ZoneDataStorage::Switching(s));
-                viewer
-            }
-
-            _ => unreachable!(
-                "'ZoneDataStorage::PersistingSigned' is the only state where a 'SignedZonePersisted' is available"
-            ),
-        };
-
-        self.state.storage.published_soa = viewer.read().map(|r| r.soa().clone());
-        self.state.storage.published_loaded_soa = viewer.read().map(|r| r.loaded().soa().clone());
-
-        // Compute the total number of records
-        let reader = viewer.read().unwrap();
-        let generated_records = reader.generated_records().len();
-        let loaded_records = reader.loaded().regular_records().len() - 1;
-        let num_records = generated_records + loaded_records;
-
+    pub fn start_publishing(&mut self, viewer: ZoneViewer) {
         // Spawn a background task to update the publication server.
         let span = trace_span!("switch_publication_server");
         let zone = self.zone.clone();
@@ -679,37 +672,7 @@ impl StorageZoneHandle<'_> {
                 _ => unreachable!("just transitioned to 'Switching'"),
             };
 
-            let loaded_serial = Serial(
-                handle
-                    .state
-                    .storage
-                    .published_loaded_soa
-                    .as_ref()
-                    .unwrap()
-                    .rdata
-                    .serial
-                    .into(),
-            );
-            let signed_serial = Serial(
-                handle
-                    .state
-                    .storage
-                    .published_soa
-                    .as_ref()
-                    .unwrap()
-                    .rdata
-                    .serial
-                    .into(),
-            );
-            let timestamp = SystemTime::now();
-            handle.state.last_published = Some(LastPublished {
-                loaded_serial,
-                signed_serial,
-                timestamp,
-                num_records,
-            });
-
-            handle.get().finish_switch(cleaner);
+            handle.storage().start_cleanup(cleaner);
 
             handle.state.storage.background_tasks.finish();
         });

--- a/src/zone/storage.rs
+++ b/src/zone/storage.rs
@@ -29,7 +29,7 @@ use cascade_zonedata::{
     DiffData, LoadedZoneBuilder, LoadedZoneBuilt, LoadedZonePersisted, LoadedZonePersister,
     LoadedZoneRestored, LoadedZoneRestorer, LoadedZoneReviewer, SignedZoneBuilder, SignedZoneBuilt,
     SignedZonePersisted, SignedZonePersister, SignedZoneRestored, SignedZoneRestorer,
-    SignedZoneReviewer, SoaRecord, ZoneCleaner, ZoneDataStorage,
+    SignedZoneReviewer, SoaRecord, ZoneCleaner, ZoneDataStorage, ZoneViewer,
 };
 use domain::base::Serial;
 use tracing::{info, trace, trace_span, warn};
@@ -38,9 +38,7 @@ use crate::{
     center::Center,
     server::{LoadedReviewServer, PublicationServer, SignedReviewServer},
     util::BackgroundTasks,
-    zone::{
-        HistoricalEvent, LastPublished, Zone, ZoneHandle, ZoneState, machine::ZoneStateMachine,
-    },
+    zone::{LastPublished, Zone, ZoneHandle, ZoneState, machine::ZoneStateMachine},
 };
 
 //----------- StorageZoneHandle ------------------------------------------------
@@ -120,7 +118,7 @@ impl StorageZoneHandle<'_> {
         skip_all,
         fields(zone = %self.zone.name),
     )]
-    pub fn finish_load(&mut self, built: LoadedZoneBuilt) {
+    pub fn finish_load(&mut self, built: LoadedZoneBuilt) -> LoadedZoneReviewer {
         // Examine the current state.
         let (transition, state) = transition(&mut self.state.storage.machine);
         match state {
@@ -129,16 +127,7 @@ impl StorageZoneHandle<'_> {
 
                 let (s, loaded_reviewer) = s.finish(built);
                 transition.move_to(ZoneDataStorage::ReviewLoadedPending(s));
-
-                // TODO: Use the instance ID here, which will not require
-                // examining the zone contents.
-                let serial = loaded_reviewer.read().unwrap().soa().rdata.serial;
-                self.state.record_event(
-                    HistoricalEvent::NewVersionReceived,
-                    Some(domain::base::Serial(serial.into())),
-                );
-
-                self.start_loaded_review(loaded_reviewer);
+                loaded_reviewer
             }
 
             _ => unreachable!(
@@ -186,7 +175,7 @@ impl StorageZoneHandle<'_> {
         skip_all,
         fields(zone = %self.zone.name),
     )]
-    fn start_loaded_review(&mut self, loaded_reviewer: LoadedZoneReviewer) {
+    pub fn start_loaded_review(&mut self, loaded_reviewer: LoadedZoneReviewer) {
         self.state.storage.loaded_review_soa = loaded_reviewer.read().map(|r| r.soa().clone());
 
         let zone = self.zone.clone();
@@ -263,9 +252,9 @@ impl StorageZoneHandle<'_> {
         skip_all,
         fields(zone = %self.zone.name),
     )]
-    pub fn abandon_loaded_review(&mut self) {
+    pub fn abandon_loaded_review(&mut self) -> LoadedZoneReviewer {
         // Examine the current state.
-        let loaded_reviewer = match transition(&mut self.state.storage.machine) {
+        match transition(&mut self.state.storage.machine) {
             (transition, ZoneDataStorage::ReviewingLoaded(s)) => {
                 // TODO: Specify the instance ID.
                 info!("The loaded instance has been rejected; cleaning it up");
@@ -278,10 +267,7 @@ impl StorageZoneHandle<'_> {
             }
 
             _ => panic!("The zone is not undergoing loader review"),
-        };
-
-        // Stop serving the abandoned instance.
-        self.start_rewinding_loaded_review(loaded_reviewer);
+        }
     }
 }
 
@@ -358,7 +344,7 @@ impl StorageZoneHandle<'_> {
         skip_all,
         fields(zone = %self.zone.name),
     )]
-    pub fn finish_sign(&mut self, built: SignedZoneBuilt) {
+    pub fn finish_sign(&mut self, built: SignedZoneBuilt) -> SignedZoneReviewer {
         // Examine the current state.
         let (transition, state) = transition(&mut self.state.storage.machine);
         match state {
@@ -367,8 +353,7 @@ impl StorageZoneHandle<'_> {
 
                 let (s, signed_reviewer) = s.finish(built);
                 transition.move_to(ZoneDataStorage::ReviewSignedPending(s));
-
-                self.start_signed_review(signed_reviewer);
+                signed_reviewer
             }
 
             _ => unreachable!(
@@ -391,9 +376,9 @@ impl StorageZoneHandle<'_> {
         skip_all,
         fields(zone = %self.zone.name),
     )]
-    pub fn abandon_sign(&mut self, builder: SignedZoneBuilder) {
+    pub fn abandon_sign(&mut self, builder: SignedZoneBuilder) -> LoadedZoneReviewer {
         // Examine the current state.
-        let loaded_reviewer = match transition(&mut self.state.storage.machine) {
+        match transition(&mut self.state.storage.machine) {
             (transition, ZoneDataStorage::Signing(s)) => {
                 trace!("Abandoning the ongoing sign operation");
 
@@ -407,10 +392,7 @@ impl StorageZoneHandle<'_> {
             _ => unreachable!(
                 "'ZoneDataStorage::Signing' is the only state where a 'SignedZoneBuilder' is available"
             ),
-        };
-
-        // Stop serving the abandoned instance.
-        self.start_rewinding_loaded_review(loaded_reviewer);
+        }
     }
 }
 
@@ -422,7 +404,7 @@ impl StorageZoneHandle<'_> {
         skip_all,
         fields(zone = %self.zone.name),
     )]
-    fn start_signed_review(&mut self, signed_reviewer: SignedZoneReviewer) {
+    pub fn start_signed_review(&mut self, signed_reviewer: SignedZoneReviewer) {
         self.state.storage.signed_review_soa = signed_reviewer.read().map(|r| r.soa().clone());
 
         let zone = self.zone.clone();
@@ -495,27 +477,20 @@ impl StorageZoneHandle<'_> {
         skip_all,
         fields(zone = %self.zone.name),
     )]
-    pub fn abandon_signed_review(&mut self) {
+    pub fn abandon_signed_review(&mut self) -> (LoadedZoneReviewer, SignedZoneReviewer) {
         // Examine the current state.
-        let (loaded_reviewer, signed_reviewer);
         match transition(&mut self.state.storage.machine) {
             (transition, ZoneDataStorage::ReviewingSigned(s)) => {
                 // TODO: Specify the instance ID.
                 info!("The signed instance has been rejected; cleaning it up");
 
-                let new_s;
-                (new_s, loaded_reviewer, signed_reviewer) = s.give_up();
+                let (new_s, loaded_reviewer, signed_reviewer) = s.give_up();
                 transition.move_to(ZoneDataStorage::CleanWholePending(new_s));
-                self.state.storage.loaded_review_soa =
-                    loaded_reviewer.read().map(|r| r.soa().clone());
-                self.state.storage.signed_review_soa =
-                    signed_reviewer.read().map(|r| r.soa().clone());
+                (loaded_reviewer, signed_reviewer)
             }
 
             _ => panic!("The zone is not undergoing signer review"),
-        };
-
-        self.start_rewinding_review(loaded_reviewer, signed_reviewer);
+        }
     }
 }
 
@@ -547,84 +522,66 @@ impl StorageZoneHandle<'_> {
     ///
     /// The zone is moved to the passive state, and it is registered against
     /// Cascade's zone servers.
-    pub fn finish_signed_restoration(&mut self, restored: SignedZoneRestored) {
+    pub fn finish_signed_restoration(
+        &mut self,
+        restored: SignedZoneRestored,
+    ) -> (LoadedZoneReviewer, SignedZoneReviewer, ZoneViewer) {
         // Examine the current state.
-        let (loaded_reviewer, signed_reviewer, viewer);
         match transition(&mut self.state.storage.machine) {
             (transition, ZoneDataStorage::RestoringSigned(s)) => {
-                let new_s;
-                (loaded_reviewer, signed_reviewer, viewer, new_s) = s.finish(restored);
+                let (loaded_reviewer, signed_reviewer, viewer, new_s) = s.finish(restored);
                 transition.move_to(ZoneDataStorage::Passive(new_s));
+                (loaded_reviewer, signed_reviewer, viewer)
             }
 
             _ => unreachable!(
                 "A 'SignedZoneRestored' is only available in the 'RestoringSigned' state"
             ),
         }
-
-        // Register the zone against the zone servers.
-        LoadedReviewServer::add_zone(self.center, self.zone.clone(), loaded_reviewer);
-        SignedReviewServer::add_zone(self.center, self.zone.clone(), signed_reviewer);
-        PublicationServer::add_zone(self.center, self.zone.clone(), viewer);
-
-        // Send a notification that the state machine is now passive.
-        self.on_passive();
     }
 
     /// Abandon the ongoing loaded-instance restore.
     ///
     /// Any intermediate zone data is cleared and the zone is moved to the
     /// passive state. It is registered against Cascade's zone servers.
-    pub fn abandon_loaded_restoration(&mut self, restorer: LoadedZoneRestorer) {
+    pub fn abandon_loaded_restoration(
+        &mut self,
+        restorer: LoadedZoneRestorer,
+    ) -> (LoadedZoneReviewer, SignedZoneReviewer, ZoneViewer) {
         // Examine the current state.
-        let (loaded_reviewer, signed_reviewer, viewer);
         match transition(&mut self.state.storage.machine) {
             (transition, ZoneDataStorage::RestoringLoaded(s)) => {
-                let new_s;
-                (loaded_reviewer, signed_reviewer, viewer, new_s) = s.abandon(restorer);
+                let (loaded_reviewer, signed_reviewer, viewer, new_s) = s.abandon(restorer);
                 transition.move_to(ZoneDataStorage::Passive(new_s));
+                (loaded_reviewer, signed_reviewer, viewer)
             }
 
             _ => unreachable!(
                 "A 'LoadedZoneRestorer' is only available in the 'RestoringLoaded' state"
             ),
-        };
-
-        // Update the zone servers.
-        LoadedReviewServer::add_zone(self.center, self.zone.clone(), loaded_reviewer);
-        SignedReviewServer::add_zone(self.center, self.zone.clone(), signed_reviewer);
-        PublicationServer::add_zone(self.center, self.zone.clone(), viewer);
-
-        // Send a notification that the state machine is now passive.
-        self.on_passive();
+        }
     }
 
     /// Abandon the ongoing signed-instance restore.
     ///
     /// Any intermediate zone data is cleared and the zone is moved to the
     /// passive state. It is registered against Cascade's zone servers.
-    pub fn abandon_signed_restoration(&mut self, restorer: SignedZoneRestorer) {
+    pub fn abandon_signed_restoration(
+        &mut self,
+        restorer: SignedZoneRestorer,
+    ) -> (LoadedZoneReviewer, SignedZoneReviewer, ZoneViewer) {
         // Examine the current state.
-        let (loaded_reviewer, signed_reviewer, viewer);
         match transition(&mut self.state.storage.machine) {
             (transition, ZoneDataStorage::RestoringSigned(s)) => {
-                let new_s;
-                (loaded_reviewer, signed_reviewer, viewer, new_s) = s.abandon(restorer);
+                let (loaded_reviewer, signed_reviewer, viewer, new_s) = s.abandon(restorer);
                 transition.move_to(ZoneDataStorage::Passive(new_s));
+                (loaded_reviewer, signed_reviewer, viewer)
             }
 
             _ => unreachable!(
                 "A 'SignedZoneRestorer' is only available in the 'RestoringSigned' state"
             ),
-        };
-
-        // Update the zone servers.
-        LoadedReviewServer::add_zone(self.center, self.zone.clone(), loaded_reviewer);
-        SignedReviewServer::add_zone(self.center, self.zone.clone(), signed_reviewer);
-        PublicationServer::add_zone(self.center, self.zone.clone(), viewer);
-
-        // Send a notification that the state machine is now passive.
-        self.on_passive();
+        }
     }
 }
 
@@ -780,7 +737,7 @@ impl StorageZoneHandle<'_> {
         skip_all,
         fields(zone = %self.zone.name),
     )]
-    fn start_rewinding_loaded_review(&mut self, loaded_reviewer: LoadedZoneReviewer) {
+    pub fn start_rewinding_loaded_review(&mut self, loaded_reviewer: LoadedZoneReviewer) {
         assert!(
             matches!(
                 self.state.storage.machine,
@@ -832,7 +789,7 @@ impl StorageZoneHandle<'_> {
         skip_all,
         fields(zone = %self.zone.name),
     )]
-    fn start_rewinding_review(
+    pub fn start_rewinding_review(
         &mut self,
         loaded_reviewer: LoadedZoneReviewer,
         signed_reviewer: SignedZoneReviewer,


### PR DESCRIPTION
Before `zone/machine.rs` was introduced, `zone/storage.rs` served as Cascade's de facto state machine, and accumulated important logic and control flow. This PR moves it into `zone/machine.rs` so that it is in the right place. These changes should not affect Cascade's behavior whatsoever.

This PR moves the management of the `*_soa` fields to `zone/machine.rs`. These will be replaced by #617, which now depends on this PR.

Solves #764. There is still important work happening in `zone/storage.rs` that should happen elsewhere (specifically communication with review servers), but that needs to be factored out separately.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?