### PR TITLE
Refactor metrics to be more centralized in metrics.rs

### DIFF
--- a/src/center.rs
+++ b/src/center.rs
@@ -17,6 +17,7 @@ use crate::api::KeyImport;
 use crate::config::RuntimeConfig;
 use crate::loader::Loader;
 use crate::loader::zone::LoaderZoneHandle;
+use crate::metrics::Metrics;
 use crate::persistence::{Persister, Restorer};
 use crate::server::{LoadedReviewServer, PublicationServer, SignedReviewServer};
 use crate::state::PolicySpec;
@@ -40,6 +41,9 @@ use crate::{
 pub struct Center {
     /// Global state.
     pub state: Mutex<State>,
+
+    // The Prometheus metrics
+    pub metrics: Metrics,
 
     /// The configuration.
     pub config: Config,
@@ -110,7 +114,7 @@ pub async fn add_zone(
         }
 
         // Create the zone and initialize its state.
-        zone = Arc::new(Zone::new(name));
+        zone = Arc::new(Zone::new(name, &center.metrics));
 
         source = match api_source {
             cascade_api::ZoneSource::None => crate::loader::Source::None,

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -18,17 +18,12 @@ use camino::Utf8Path;
 use cascade_api::ZoneReloadError;
 use cascade_zonedata::LoadedZoneBuilder;
 use domain::{new::base::Serial, tsig};
-use prometheus_client::{
-    metrics::{counter::Counter, family::Family, gauge::Gauge},
-    registry::Unit,
-};
 use tracing::{debug, error, info};
 
 use crate::{
     center::{Center, State},
     common::scheduler::Scheduler,
     loader::zone::EnqueuedRefresh,
-    metrics::{MetricsCollection, XfrLabels, ZoneLabel},
     util::AbortOnDrop,
     zone::{HistoricalEvent, Zone, ZoneByName, ZoneByPtr},
 };
@@ -40,60 +35,16 @@ mod zonefile;
 //----------- Loader -----------------------------------------------------------
 
 /// The zone loader.
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct Loader {
     /// A scheduler for SOA timer based zone refreshes.
     refresh_scheduler: Scheduler<ZoneByPtr>,
-    prometheus_metrics: LoaderPrometheusMetrics,
 }
 
 impl Loader {
     /// Construct a new [`Loader`].
-    pub fn new(metrics: &mut MetricsCollection) -> Self {
-        let loader_metrics = LoaderPrometheusMetrics::default();
-
-        metrics.register(
-            "xfr_requests_to_upstream_attempted",
-            "Number of zone transfers attempted by Cascade towards the upstream primary",
-            loader_metrics.xfr_requests_to_upstream_attempted.clone(),
-        );
-
-        metrics.register(
-            "xfr_requests_to_upstream_succeeded",
-            "Number of succesful zone transfers by Cascade towards the upstream primary",
-            loader_metrics.xfr_requests_to_upstream_succeeded.clone(),
-        );
-
-        metrics.register(
-            "zone_loaded_last_successful_records",
-            "Number of records loaded in last successful zone transfer or zonefile load",
-            loader_metrics.zone_loaded_last_successful_records.clone(),
-        );
-
-        metrics.register_with_unit(
-            "zone_loaded_last_successful_size",
-            "Number of bytes loaded in last successful zone transfer or zonefile load",
-            Unit::Bytes,
-            loader_metrics.zone_loaded_last_successful_bytes.clone(),
-        );
-
-        metrics.register(
-            "zone_loaded_last_records",
-            "Number of records loaded in last attempted zone transfer or zonefile load",
-            loader_metrics.zone_loaded_last_records.clone(),
-        );
-
-        metrics.register_with_unit(
-            "zone_loaded_last_size",
-            "Number of bytes loaded in last attempted zone transfer or zonefile load",
-            Unit::Bytes,
-            loader_metrics.zone_loaded_last_bytes.clone(),
-        );
-
-        Self {
-            refresh_scheduler: Scheduler::new(),
-            prometheus_metrics: loader_metrics,
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Initialize the loader, synchronously.
@@ -169,7 +120,6 @@ async fn refresh(
 ) {
     info!("Refreshing {:?}", zone.name);
     let force = refresh == EnqueuedRefresh::Reload;
-    let prometheus_metrics = &center.loader.prometheus_metrics;
 
     // Perform the source-specific reload into the zone contents.
     let result = match source {
@@ -191,29 +141,14 @@ async fn refresh(
         }
         Source::Server { addr, tsig_key } if force => {
             let tsig_key = tsig_key.as_deref().cloned();
-            server::axfr(
-                &zone,
-                &addr,
-                tsig_key,
-                &mut builder,
-                &metrics,
-                prometheus_metrics,
-            )
-            .await
-            .map(|()| true)
-            .map_err(Into::into)
+            server::axfr(&zone, &addr, tsig_key, &mut builder, &metrics)
+                .await
+                .map(|()| true)
+                .map_err(Into::into)
         }
         Source::Server { addr, tsig_key } => {
             let tsig_key = tsig_key.as_deref().cloned();
-            server::refresh(
-                &zone,
-                &addr,
-                tsig_key,
-                &mut builder,
-                &metrics,
-                prometheus_metrics,
-            )
-            .await
+            server::refresh(&zone, &addr, tsig_key, &mut builder, &metrics).await
         }
     };
 
@@ -224,20 +159,13 @@ async fn refresh(
     handle.state.loader.active_load_metrics = None;
     handle.state.loader.last_load_metrics = Some(metrics.finish());
 
-    let zone_label = ZoneLabel {
-        zone: zone.name.clone().into(),
-    };
     {
         let loader_metrics = handle.state.loader.last_load_metrics.as_ref().unwrap();
         // Copy generated loader metrics to prometheus metrics
-        prometheus_metrics
-            .zone_loaded_last_bytes
-            .get_or_create(&zone_label)
-            .set(loader_metrics.num_loaded_bytes as i64);
-        prometheus_metrics
-            .zone_loaded_last_records
-            .get_or_create(&zone_label)
-            .set(loader_metrics.num_loaded_records as i64);
+        zone.metrics
+            .zone_loaded_last_bytes(loader_metrics.num_loaded_bytes as i64);
+        zone.metrics
+            .zone_loaded_last_records(loader_metrics.num_loaded_records as i64);
     }
 
     // Update the SOA refresh timer state.
@@ -299,14 +227,10 @@ async fn refresh(
             let loader_metrics = handle.state.loader.last_load_metrics.as_ref().unwrap();
 
             // Copy generated loader metrics to prometheus metrics
-            prometheus_metrics
-                .zone_loaded_last_successful_bytes
-                .get_or_create(&zone_label)
-                .set(loader_metrics.num_loaded_bytes as i64);
-            prometheus_metrics
-                .zone_loaded_last_successful_records
-                .get_or_create(&zone_label)
-                .set(loader_metrics.num_loaded_records as i64);
+            zone.metrics
+                .zone_loaded_last_successful_bytes(loader_metrics.num_loaded_bytes as i64);
+            zone.metrics
+                .zone_loaded_last_successful_records(loader_metrics.num_loaded_records as i64);
 
             // Inform the zone storage of completion; it will initiate unsigned
             // review automatically.
@@ -511,27 +435,6 @@ impl ActiveLoadMetrics {
             num_loaded_records: self.num_loaded_records.load(atomic::Ordering::Relaxed),
         }
     }
-}
-
-//----------- LoaderPrometheusMetrics ----------------------------------------
-
-/// Prometheus metrics for the zone loader.
-#[derive(Debug, Default)]
-struct LoaderPrometheusMetrics {
-    /// The number of zone transfers attempted by Cascade to the upstream
-    xfr_requests_to_upstream_attempted: Family<XfrLabels, Counter>,
-    /// The number of zone transfers succeeded by Cascade to the upstream
-    xfr_requests_to_upstream_succeeded: Family<XfrLabels, Counter>,
-    /// The number of records loaded in the last successful load (file or transfer)
-    zone_loaded_last_successful_records: Family<ZoneLabel, Gauge>,
-    /// The number of bytes loaded in the last successful load (file or transfer)
-    zone_loaded_last_successful_bytes: Family<ZoneLabel, Gauge>,
-    /// The number of records loaded in the last load (file or transfer),
-    /// regardless of wether it was successful or aborted due to failure
-    zone_loaded_last_records: Family<ZoneLabel, Gauge>,
-    /// The number of bytes loaded in the last load (file or transfer),
-    /// regardless of wether it was successful or aborted due to failure
-    zone_loaded_last_bytes: Family<ZoneLabel, Gauge>,
 }
 
 //============ Errors ==========================================================

--- a/src/loader/server.rs
+++ b/src/loader/server.rs
@@ -44,8 +44,8 @@ use tokio::net::TcpStream;
 use tracing::{debug, trace};
 
 use crate::{
-    loader::{ActiveLoadMetrics, LoaderPrometheusMetrics},
-    metrics::{XfrLabels, XfrTransport, XfrType},
+    loader::ActiveLoadMetrics,
+    metrics::{XfrTransport, XfrType},
     zone::Zone,
 };
 
@@ -72,7 +72,6 @@ pub async fn refresh(
     tsig_key: Option<tsig::Key>,
     builder: &mut LoadedZoneBuilder,
     metrics: &ActiveLoadMetrics,
-    prometheus_metrics: &LoaderPrometheusMetrics,
 ) -> Result<bool, RefreshError> {
     debug!("Refreshing {:?} from server {addr:?}", zone.name);
 
@@ -88,13 +87,13 @@ pub async fn refresh(
 
     if builder.curr().is_none() {
         // Fetch the whole zone.
-        axfr(zone, addr, tsig_key, builder, metrics, prometheus_metrics).await?;
+        axfr(zone, addr, tsig_key, builder, metrics).await?;
 
         return Ok(true);
     };
 
     // Fetch the zone relative to the latest local copy.
-    Ok(ixfr(zone, addr, tsig_key, builder, metrics, prometheus_metrics).await?)
+    Ok(ixfr(zone, addr, tsig_key, builder, metrics).await?)
 }
 
 //----------- ixfr() -----------------------------------------------------------
@@ -118,7 +117,6 @@ pub async fn ixfr(
     tsig_key: Option<tsig::Key>,
     builder: &mut LoadedZoneBuilder,
     metrics: &ActiveLoadMetrics,
-    prometheus_metrics: &LoaderPrometheusMetrics,
 ) -> Result<bool, IxfrError> {
     debug!("Attempting an IXFR");
 
@@ -184,14 +182,8 @@ pub async fn ixfr(
     let mut response = SendRequestMulti::send_request(&*client, request);
     let mut interpreter = XfrResponseInterpreter::new();
 
-    prometheus_metrics
-        .xfr_requests_to_upstream_attempted
-        .get_or_create(&XfrLabels {
-            zone: zone.name.clone().into(),
-            r#type: XfrType::IXFR,
-            transport: XfrTransport::TCP,
-        })
-        .inc();
+    zone.metrics
+        .inc_xfr_requests_to_upstream_attempted(XfrType::IXFR, XfrTransport::TCP);
 
     // Process the first message.
     let initial = response
@@ -203,7 +195,7 @@ pub async fn ixfr(
     if initial.header().rcode() == Rcode::NOTIMP {
         trace!("The server does not support IXFR, falling back to AXFR");
 
-        axfr(zone, addr, tsig_key, builder, metrics, prometheus_metrics).await?;
+        axfr(zone, addr, tsig_key, builder, metrics).await?;
         return Ok(true);
     }
 
@@ -268,14 +260,8 @@ pub async fn ixfr(
             writer.apply()?;
             metrics.num_loaded_bytes.fetch_add(bytes, Relaxed);
 
-            prometheus_metrics
-                .xfr_requests_to_upstream_succeeded
-                .get_or_create(&XfrLabels {
-                    zone: zone.name.clone().into(),
-                    r#type: XfrType::IXFR,
-                    transport: XfrTransport::TCP,
-                })
-                .inc();
+            zone.metrics
+                .inc_xfr_requests_to_upstream_succeeded(XfrType::IXFR, XfrTransport::TCP);
 
             Ok(true)
         }
@@ -312,14 +298,8 @@ pub async fn ixfr(
 
             writer.apply()?;
 
-            prometheus_metrics
-                .xfr_requests_to_upstream_succeeded
-                .get_or_create(&XfrLabels {
-                    zone: zone.name.clone().into(),
-                    r#type: XfrType::IXFR,
-                    transport: XfrTransport::TCP,
-                })
-                .inc();
+            zone.metrics
+                .inc_xfr_requests_to_upstream_succeeded(XfrType::IXFR, XfrTransport::TCP);
 
             Ok(true)
         }
@@ -384,7 +364,6 @@ pub async fn axfr(
     tsig_key: Option<tsig::Key>,
     builder: &mut LoadedZoneBuilder,
     metrics: &ActiveLoadMetrics,
-    prometheus_metrics: &LoaderPrometheusMetrics,
 ) -> Result<(), AxfrError> {
     debug!("Attempting an AXFR");
 
@@ -433,14 +412,8 @@ pub async fn axfr(
             Box::new(client) as _
         };
 
-    prometheus_metrics
-        .xfr_requests_to_upstream_attempted
-        .get_or_create(&XfrLabels {
-            zone: zone.name.clone().into(),
-            r#type: XfrType::AXFR,
-            transport: XfrTransport::TCP,
-        })
-        .inc();
+    zone.metrics
+        .inc_xfr_requests_to_upstream_attempted(XfrType::AXFR, XfrTransport::TCP);
 
     // Attempt the AXFR.
     let request = RequestMessageMulti::new(message).unwrap();
@@ -483,14 +456,8 @@ pub async fn axfr(
     writer.set_soa(soa)?;
     writer.apply()?;
 
-    prometheus_metrics
-        .xfr_requests_to_upstream_succeeded
-        .get_or_create(&XfrLabels {
-            zone: zone.name.clone().into(),
-            r#type: XfrType::AXFR,
-            transport: XfrTransport::TCP,
-        })
-        .inc();
+    zone.metrics
+        .inc_xfr_requests_to_upstream_succeeded(XfrType::AXFR, XfrTransport::TCP);
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use cascaded::{
     daemon::{PreBindError, SocketProvider, daemonize},
     loader::Loader,
     manager::Manager,
-    metrics::MetricsCollection,
+    metrics::Metrics,
     persistence::{Persister, Restorer},
     policy,
     server::{LoadedReviewServer, PublicationServer, SignedReviewServer},
@@ -77,6 +77,7 @@ fn main() -> ExitCode {
     // Load the global state file or build one from scratch.
     let mut zones = Default::default();
     let mut policies = Default::default();
+    let metrics = Metrics::new();
     let state = match center::State::init_from_file(&config, &mut zones, &mut policies) {
         Ok(mut state) => {
             info!(
@@ -116,11 +117,16 @@ fn main() -> ExitCode {
                     !state.zones.contains(&name),
                     "Zone '{name}' was encountered twice"
                 );
-                let zone =
-                    match Zone::restore(&config, name, &mut state.policies, &state.tsig_store) {
-                        Ok(zone) => zone,
-                        Err(_) => return ExitCode::FAILURE,
-                    };
+                let zone = match Zone::restore(
+                    &config,
+                    name,
+                    &mut state.policies,
+                    &state.tsig_store,
+                    &metrics,
+                ) {
+                    Ok(zone) => zone,
+                    Err(_) => return ExitCode::FAILURE,
+                };
                 state.zones.insert(ZoneByName(Arc::new(zone)));
             }
 
@@ -248,14 +254,13 @@ fn main() -> ExitCode {
         return ExitCode::FAILURE;
     }
 
-    let mut metrics = MetricsCollection::new();
-
     // Prepare Cascade.
     let center = Arc::new(Center {
         state: Mutex::new(state),
         config,
+        metrics,
         logger,
-        loader: Loader::new(&mut metrics),
+        loader: Loader::new(),
         key_manager: KeyManager::new(),
         persister: Persister::new(),
         restorer: Restorer::new(),
@@ -288,7 +293,7 @@ fn main() -> ExitCode {
     // Enter the runtime.
     let result = runtime.block_on(async {
         // Spawn Cascade's units.
-        let manager = match Manager::spawn(center.clone(), socket_provider, metrics) {
+        let manager = match Manager::spawn(center.clone(), socket_provider) {
             Ok(manager) => manager,
             Err(err) => {
                 error!("Failed to spawn units: {err}");

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use crate::center::Center;
 use crate::daemon::SocketProvider;
 use crate::loader::Loader;
-use crate::metrics::MetricsCollection;
 use crate::persistence::Restorer;
 use crate::server::{LoadedReviewServer, PublicationServer, SignedReviewServer};
 use crate::units::http_server::HTTP_UNIT_NAME;
@@ -37,11 +36,7 @@ pub struct Manager {
 
 impl Manager {
     /// Spawn all targets.
-    pub fn spawn(
-        center: Arc<Center>,
-        mut socket_provider: SocketProvider,
-        metrics: MetricsCollection,
-    ) -> Result<Self, Error> {
+    pub fn spawn(center: Arc<Center>, mut socket_provider: SocketProvider) -> Result<Self, Error> {
         // Initialize the components.
         {
             let mut state = center.state.lock().unwrap();
@@ -104,7 +99,7 @@ impl Manager {
 
         // Spawn the remote-control server.
         debug!("Starting the HTTP remote-control server");
-        let http_server = HttpServer::launch(center.clone(), http_sockets, metrics)?;
+        let http_server = HttpServer::launch(center.clone(), http_sockets)?;
 
         Ok(Self {
             center,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -15,10 +15,11 @@ use bytes::Bytes;
 use domain::base::Name;
 use prometheus_client::encoding::text::encode;
 use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue};
+use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
 use prometheus_client::metrics::gauge::Gauge;
 use prometheus_client::metrics::info::Info;
-use prometheus_client::registry::{Metric, Registry, Unit};
+use prometheus_client::registry::{Registry, Unit};
 
 use crate::center::Center;
 use crate::zone::ZoneByName;
@@ -44,29 +45,32 @@ const PROMETHEUS_PREFIX: &str = "cascade";
 
 //------------ MetricsCollection ---------------------------------------------
 
-// TODO: document how to register metrics
 #[derive(Debug)]
-pub struct MetricsCollection {
+pub struct Metrics {
     /// The metrics registry for all metrics in Cascade. Units need to
     /// register their metrics with this registry.
-    pub cascade: Registry,
+    registry: Registry,
+
+    /// Metrics that are available per zone.
+    per_zone_metrics: PerZoneMetrics,
 
     /// The metrics assemble time only relevant for metrics that get collected
     /// on scraping. If we remove all metrics that get built (from state) on
     /// each scrape, then this timer will be useless and should be removed.
-    _assemble_time_metric: Gauge<u64, AtomicU64>,
+    assemble_time_metric: Gauge<u64, AtomicU64>,
 
     /// A collection of metrics that get collected from state on each metrics
     /// scrape.
-    _state_metrics: StateMetrics,
+    state_metrics: StateMetrics,
 }
 
-impl MetricsCollection {
+impl Metrics {
     pub fn new() -> Self {
         let mut col = Self {
-            cascade: Registry::with_prefix(PROMETHEUS_PREFIX),
-            _assemble_time_metric: Default::default(),
-            _state_metrics: Default::default(),
+            registry: Registry::with_prefix(PROMETHEUS_PREFIX),
+            per_zone_metrics: Default::default(),
+            assemble_time_metric: Default::default(),
+            state_metrics: Default::default(),
         };
 
         // This metric is a "fake" metric and only there to expose the
@@ -83,17 +87,18 @@ impl MetricsCollection {
         // for exposing software version information. And `prometheus_client`
         // exposes the `Info` type, which we use here to expose cascade
         // version information just like `cascaded --version`.
-        col.cascade
+        col.registry
             .register("build", "Cascade build information", _cascade_version);
 
-        col.cascade.register_with_unit(
+        col.registry.register_with_unit(
             "metrics_assemble_duration",
             "The time taken in milliseconds to assemble the last metric snapshot",
             Unit::Other("milliseconds".into()),
-            col._assemble_time_metric.clone(),
+            col.assemble_time_metric.clone(),
         );
 
-        col._state_metrics.register_metrics(&mut col.cascade);
+        col.state_metrics.register_metrics(&mut col.registry);
+        col.per_zone_metrics.register_metrics(&mut col.registry);
 
         col
     }
@@ -103,7 +108,7 @@ impl MetricsCollection {
     pub fn assemble(&self, center: Arc<Center>) -> Result<String, fmt::Error> {
         let start_time = Instant::now();
 
-        let metrics = &self._state_metrics;
+        let metrics = &self.state_metrics;
 
         let zones_configured: i64;
         let mut zones_loaded: i64 = 0;
@@ -176,87 +181,29 @@ impl MetricsCollection {
 
         // u64::MAX milliseconds is around 585_000_000 years
         let assemble_ms = start_time.elapsed().as_millis() as u64;
-        self._assemble_time_metric.set(assemble_ms);
+        self.assemble_time_metric.set(assemble_ms);
         String::try_from(self)
     }
 
-    /// Register a metric with the [`Registry`].
-    ///
-    /// Note: In the Open Metrics text exposition format some metric types
-    /// have a special suffix, e.g. the `Counter` metric with `_total`. These
-    /// suffixes are inferred through the metric type and must not be appended
-    /// to the metric name manually by the user.
-    ///
-    /// Note: A full stop punctuation mark (`.`) is automatically added to the
-    /// passed help text.
-    ///
-    /// Use [`Registry::register_with_unit`] whenever a unit for the given
-    /// metric is known.
-    ///
-    /// ```
-    /// # use prometheus_client::metrics::counter::{Atomic as _, Counter};
-    /// # use prometheus_client::registry::{Registry, Unit};
-    /// # let mut metrics = Registry::default();
-    /// let counter: Counter = Counter::default();
-    ///
-    /// metrics.register("my_counter", "This is my counter", counter.clone());
-    /// ```
-    // This docstring is based on prometheus-client's docstring on the same
-    // method.
-    pub fn register<N: Into<String>, H: Into<String>>(
-        &mut self,
-        name: N,
-        help: H,
-        metric: impl Metric,
-    ) {
-        self.cascade.register(name, help, metric)
-    }
-
-    /// Register a metric with the [`Registry`] specifying the metric's unit.
-    ///
-    /// See [`Registry::register`] for additional documentation.
-    ///
-    /// Note: In the Open Metrics text exposition format units are appended to
-    /// the metric name. This is done automatically. Users must not append the
-    /// unit to the name manually.
-    ///
-    /// ```
-    /// # use prometheus_client::metrics::counter::{Atomic as _, Counter};
-    /// # use prometheus_client::registry::{Registry, Unit};
-    /// # let mut metrics = Registry::default();
-    /// let counter: Counter = Counter::default();
-    ///
-    /// metrics.register_with_unit(
-    ///   "my_counter",
-    ///   "This is my counter",
-    ///   Unit::Seconds,
-    ///   counter.clone(),
-    /// );
-    /// ```
-    // This docstring is based on prometheus-client's docstring on the same
-    // method.
-    pub fn register_with_unit<N: Into<String>, H: Into<String>>(
-        &mut self,
-        name: N,
-        help: H,
-        unit: Unit,
-        metric: impl Metric,
-    ) {
-        self.cascade.register_with_unit(name, help, unit, metric)
+    pub fn get_zone_metrics(&self, name: Name<Bytes>) -> ZoneMetrics {
+        ZoneMetrics {
+            per_zone_metrics: self.per_zone_metrics.clone(),
+            zone_name: name.into(),
+        }
     }
 }
 
-impl TryFrom<&MetricsCollection> for String {
+impl TryFrom<&Metrics> for String {
     type Error = fmt::Error;
 
-    fn try_from(metrics: &MetricsCollection) -> Result<Self, Self::Error> {
+    fn try_from(metrics: &Metrics) -> Result<Self, Self::Error> {
         let mut buffer = String::new();
-        encode(&mut buffer, &metrics.cascade)?;
+        encode(&mut buffer, &metrics.registry)?;
         Ok(buffer)
     }
 }
 
-impl Default for MetricsCollection {
+impl Default for Metrics {
     fn default() -> Self {
         Self::new()
     }
@@ -381,5 +328,141 @@ impl StateMetrics {
             "Number of halted zones",
             self.zones_halted.clone(),
         );
+    }
+}
+
+//------------ PerZoneMetrics ------------------------------------------------
+
+#[derive(Debug, Default, Clone)]
+struct PerZoneMetrics {
+    /// The number of zone transfers attempted by Cascade to the upstream
+    xfr_requests_to_upstream_attempted: Family<XfrLabels, Counter>,
+
+    /// The number of zone transfers succeeded by Cascade to the upstream
+    xfr_requests_to_upstream_succeeded: Family<XfrLabels, Counter>,
+
+    /// The number of records loaded in the last successful load (file or transfer)
+    zone_loaded_last_successful_records: Family<ZoneLabel, Gauge>,
+
+    /// The number of bytes loaded in the last successful load (file or transfer)
+    zone_loaded_last_successful_bytes: Family<ZoneLabel, Gauge>,
+
+    /// The number of records loaded in the last load (file or transfer),
+    /// regardless of wether it was successful or aborted due to failure
+    zone_loaded_last_records: Family<ZoneLabel, Gauge>,
+
+    /// The number of bytes loaded in the last load (file or transfer),
+    /// regardless of wether it was successful or aborted due to failure
+    zone_loaded_last_bytes: Family<ZoneLabel, Gauge>,
+}
+
+impl PerZoneMetrics {
+    fn register_metrics(&self, metrics: &mut Registry) {
+        metrics.register(
+            "xfr_requests_to_upstream_attempted",
+            "Number of zone transfers attempted by Cascade towards the upstream primary",
+            self.xfr_requests_to_upstream_attempted.clone(),
+        );
+
+        metrics.register(
+            "xfr_requests_to_upstream_succeeded",
+            "Number of succesful zone transfers by Cascade towards the upstream primary",
+            self.xfr_requests_to_upstream_succeeded.clone(),
+        );
+
+        metrics.register(
+            "zone_loaded_last_successful_records",
+            "Number of records loaded in last successful zone transfer or zonefile load",
+            self.zone_loaded_last_successful_records.clone(),
+        );
+
+        metrics.register_with_unit(
+            "zone_loaded_last_successful_size",
+            "Number of bytes loaded in last successful zone transfer or zonefile load",
+            Unit::Bytes,
+            self.zone_loaded_last_successful_bytes.clone(),
+        );
+
+        metrics.register(
+            "zone_loaded_last_records",
+            "Number of records loaded in last attempted zone transfer or zonefile load",
+            self.zone_loaded_last_records.clone(),
+        );
+
+        metrics.register_with_unit(
+            "zone_loaded_last_size",
+            "Number of bytes loaded in last attempted zone transfer or zonefile load",
+            Unit::Bytes,
+            self.zone_loaded_last_bytes.clone(),
+        );
+    }
+}
+
+//------------ ZoneMetrics ---------------------------------------------------
+
+/// An instantiation of `PerZoneMetrics` for a zone.
+#[derive(Debug, Clone)]
+pub struct ZoneMetrics {
+    per_zone_metrics: PerZoneMetrics,
+    zone_name: StoredName,
+}
+
+impl ZoneMetrics {
+    pub fn inc_xfr_requests_to_upstream_attempted(&self, ty: XfrType, transport: XfrTransport) {
+        self.per_zone_metrics
+            .xfr_requests_to_upstream_attempted
+            .get_or_create(&XfrLabels {
+                zone: self.zone_name.clone(),
+                r#type: ty,
+                transport,
+            })
+            .inc();
+    }
+
+    pub fn inc_xfr_requests_to_upstream_succeeded(&self, ty: XfrType, transport: XfrTransport) {
+        self.per_zone_metrics
+            .xfr_requests_to_upstream_succeeded
+            .get_or_create(&XfrLabels {
+                zone: self.zone_name.clone(),
+                r#type: ty,
+                transport,
+            })
+            .inc();
+    }
+
+    pub fn zone_loaded_last_successful_records(&self, n: i64) {
+        self.per_zone_metrics
+            .zone_loaded_last_successful_records
+            .get_or_create(&ZoneLabel {
+                zone: self.zone_name.clone(),
+            })
+            .set(n);
+    }
+
+    pub fn zone_loaded_last_records(&self, n: i64) {
+        self.per_zone_metrics
+            .zone_loaded_last_records
+            .get_or_create(&ZoneLabel {
+                zone: self.zone_name.clone(),
+            })
+            .set(n);
+    }
+
+    pub fn zone_loaded_last_successful_bytes(&self, n: i64) {
+        self.per_zone_metrics
+            .zone_loaded_last_successful_bytes
+            .get_or_create(&ZoneLabel {
+                zone: self.zone_name.clone(),
+            })
+            .set(n);
+    }
+
+    pub fn zone_loaded_last_bytes(&self, n: i64) {
+        self.per_zone_metrics
+            .zone_loaded_last_bytes
+            .get_or_create(&ZoneLabel {
+                zone: self.zone_name.clone(),
+            })
+            .set(n);
     }
 }

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -38,7 +38,6 @@ use crate::center::Center;
 use crate::center::get_zone;
 use crate::loader;
 use crate::manager::Terminated;
-use crate::metrics::MetricsCollection;
 use crate::policy::AutoConfig;
 use crate::policy::SignerDenialPolicy;
 use crate::policy::SignerSerialPolicy;
@@ -61,13 +60,6 @@ pub const HTTP_UNIT_NAME: &str = "HS";
 
 pub struct HttpServer {
     pub center: Arc<Center>,
-    pub metrics: Arc<MetricsCollection>,
-    pub http_metrics: HttpMetrics,
-}
-
-#[derive(Default)]
-pub struct HttpMetrics {
-    // http_api_last_connection: Counter,
 }
 
 impl HttpServer {
@@ -75,27 +67,8 @@ impl HttpServer {
     pub fn launch(
         center: Arc<Center>,
         http_sockets: Vec<TcpListener>,
-        /* mut */ metrics: MetricsCollection,
     ) -> Result<Arc<Self>, Terminated> {
-        // TODO: register metrics here
-
-        let http_metrics = HttpMetrics::default();
-
-        // This would require some work in tracking the last API access. I did
-        // not find a way to call something on every route in axum. Maybe we
-        // need a wrapper function that sets the last_connection timestamp.
-        // // - last time a CLI connection was made
-        // metrics.register(
-        //     "http_api_last_connection",
-        //     "The last unix epoch time an API HTTP connection was made (excl. /metrics and /)",
-        //     http_metrics.http_api_last_connection.clone()
-        // );
-
-        let this = Arc::new(Self {
-            center,
-            metrics: Arc::new(metrics),
-            http_metrics,
-        });
+        let this = Arc::new(Self { center });
 
         let app = Router::new()
             .route("/health", get(Self::health))
@@ -203,7 +176,7 @@ impl HttpServer {
     }
 
     async fn metrics(State(state): State<Arc<HttpServer>>) -> impl IntoResponse {
-        match state.metrics.assemble(state.center.clone()) {
+        match state.center.metrics.assemble(state.center.clone()) {
             Ok(b) => Ok((
                 StatusCode::OK,
                 [(

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -19,6 +19,7 @@ use domain::rdata::dnssec::Timestamp;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, trace};
 
+use crate::metrics::{Metrics, ZoneMetrics};
 use crate::{
     api::{self, ZoneReviewStatus},
     center::Center,
@@ -57,6 +58,9 @@ pub struct Zone {
     /// [`ZoneState`].
     pub state: ZoneStateLock,
 
+    /// The metrics for this zone.
+    pub metrics: ZoneMetrics,
+
     /// Whether the zone was restored from the state file.
     ///
     /// This is set if the zone originates from a previous execution of Cascade
@@ -70,10 +74,12 @@ impl Zone {
     ///
     /// The zone is initialized to an empty state, where nothing is known about
     /// it and Cascade won't act on it.
-    pub fn new(name: Name<Bytes>) -> Self {
+    pub fn new(name: Name<Bytes>, metrics: &Metrics) -> Self {
+        let metrics = metrics.get_zone_metrics(name.clone());
         Self {
             name,
             state: ZoneStateLock::new(ZoneState::default()),
+            metrics,
             restored: false,
         }
     }
@@ -100,6 +106,7 @@ impl Zone {
         name: Name<Bytes>,
         policies: &mut foldhash::HashMap<Box<str>, Policy>,
         tsig_store: &TsigStore,
+        metrics: &Metrics,
     ) -> Result<Self, state::LoadError> {
         let path = config.zone_state_dir.join(format!("{name}.db"));
 
@@ -115,10 +122,13 @@ impl Zone {
             }
         };
 
+        let metrics = metrics.get_zone_metrics(name.clone());
+
         debug!("Restored the state of zone '{name}' (from '{path}')");
 
         Ok(Self {
             name,
+            metrics,
             state: ZoneStateLock::new(state),
             restored: true,
         })


### PR DESCRIPTION
This is just a small refactor to move where the metrics are defined. I think we want the metrics to be more centrally defined rather than by each component. Metrics are now in the `Center` and there is also a clone of those in each zone, so that operations on a zone are easily accessible.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [ ] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?