### PR TITLE
Use `Scheduler` for re-signing timers

### DIFF
--- a/src/persistence/zone.rs
+++ b/src/persistence/zone.rs
@@ -111,6 +111,8 @@ impl ZonePersistenceHandle<'_> {
                 let (loaded_reviewer, signed_reviewer, viewer) =
                     handle.storage().finish_signed_restoration(restored);
 
+                handle.signer().on_restoration();
+
                 // Register the zone against the zone servers.
                 LoadedReviewServer::add_zone(handle.center, handle.zone.clone(), loaded_reviewer);
                 SignedReviewServer::add_zone(handle.center, handle.zone.clone(), signed_reviewer);

--- a/src/signer/zone.rs
+++ b/src/signer/zone.rs
@@ -2,7 +2,7 @@
 
 use std::{
     sync::{Arc, RwLock},
-    time::SystemTime,
+    time::{Duration, SystemTime},
 };
 
 use tracing::{debug, info};
@@ -433,4 +433,24 @@ pub struct EnqueuedResign {
     // TODO:
     // - The ID of the signed instance to re-sign.
     //   Panic if the actual obtained instance does not match this.
+}
+
+//------------------------------------------------------------------------------
+
+/// Compute when a zone should be re-signed.
+///
+/// Returns [`None`] if the zone does not need re-signing.
+pub fn resign_time(state: &ZoneState) -> Option<SystemTime> {
+    let policy = state.policy.as_ref()?;
+
+    let last_refresh_time =
+        SystemTime::UNIX_EPOCH + Duration::from(state.last_signature_refresh.clone());
+    let refresh_interval = Duration::from_secs(policy.signer.signature_refresh_interval as u64);
+    let min_expiration = state.min_expiration?.to_system_time(last_refresh_time);
+    let remain_time = Duration::from_secs(policy.signer.sig_remain_time as u64);
+
+    Some(Ord::min(
+        last_refresh_time + refresh_interval,
+        min_expiration - remain_time,
+    ))
 }

--- a/src/signer/zone.rs
+++ b/src/signer/zone.rs
@@ -375,6 +375,12 @@ pub struct SignerState {
     /// An enqueued re-signing operation, if any.
     pub enqueued_resign: Option<EnqueuedResign>,
 
+    /// When a zone is scheduled to be re-signed.
+    ///
+    /// If this is [`Some`], the zone is currently scheduled for re-signing, at
+    /// the specified time.
+    pub scheduled_resign_time: Option<SystemTime>,
+
     /// Status for an active signing operation, if any.
     //
     // TODO: Embed in a state machine.

--- a/src/signer/zone.rs
+++ b/src/signer/zone.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use tracing::{debug, info};
+use tracing::{debug, info, trace};
 
 use crate::{
     center::Center,
@@ -15,7 +15,7 @@ use crate::{
         status::{SigningStatusPerZone, ZoneSigningStatus},
     },
     util::BackgroundTasks,
-    zone::{Zone, ZoneHandle, ZoneState},
+    zone::{Zone, ZoneByPtr, ZoneHandle, ZoneState},
     zonedata::SignedZoneBuilder,
 };
 
@@ -86,16 +86,36 @@ impl SignerZoneHandle<'_> {
     ///
     /// This will recompute when the zone should be scheduled (if at all) and
     /// update its schedule in the global state.
+    #[tracing::instrument(
+        level = "trace",
+        skip_all,
+        fields(%zone = self.zone.name),
+    )]
     fn reschedule_resigning(&mut self) {
+        // TODO: Make `Scheduler` work with `SystemTime` directly.
+        fn to_instant(time: SystemTime) -> std::time::Instant {
+            // We are computing a timeout value. If the timeout is in the
+            // past then we can just as well use zero.
+            let since_now = time
+                .duration_since(SystemTime::now())
+                .unwrap_or(Duration::ZERO);
+
+            std::time::Instant::now() + since_now
+        }
+
         let new_time = resign_time(self.state);
+        let old_time = self.state.signer.scheduled_resign_time;
+
+        trace!(?new_time, ?old_time, "Rescheduling re-signing");
+
+        let zone = ZoneByPtr(self.zone.clone());
+        self.center.signer.resign_scheduler.update(
+            &zone,
+            old_time.map(to_instant),
+            new_time.map(to_instant),
+        );
 
         self.state.signer.scheduled_resign_time = new_time;
-
-        let _ = self
-            .center
-            .signer
-            .next_resign_time_tx
-            .send(Some(tokio::time::Instant::now()));
     }
 }
 

--- a/src/signer/zone.rs
+++ b/src/signer/zone.rs
@@ -42,7 +42,65 @@ impl SignerZoneHandle<'_> {
             center: self.center,
         }
     }
+}
 
+/// # Reacting to changes
+impl SignerZoneHandle<'_> {
+    /// React to a change in the zone's policy.
+    pub fn after_policy_change(&mut self) {
+        // TODO: Try to reschedule re-signing in fewer cases.
+        self.reschedule_resigning();
+    }
+
+    /// React to the zone being restored from disk.
+    ///
+    /// This is called upon startup when a loaded+signed instance of the zone is
+    /// successfully restored from disk. It schedules the zone for re-signing.
+    pub fn on_restoration(&mut self) {
+        assert!(
+            self.state.signer.scheduled_resign_time.is_none(),
+            "A zone cannot be scheduled for re-signing until restoration completes"
+        );
+
+        self.reschedule_resigning();
+    }
+
+    /// React to the upcoming (signed) instance of the zone being published.
+    ///
+    /// This schedules the zone for re-signing as needed.
+    pub fn on_publication(&mut self) {
+        self.reschedule_resigning();
+    }
+
+    /// React to a signed instance of the zone being abandoned.
+    pub fn before_signed_abandonment(&mut self) {
+        // TODO: Make the caller pass in the right `SigningTrigger`.
+        // TODO: Only enqueue a re-sign if a re-sign was abandoned.
+        //
+        // TODO: Decide what the semantically correct thing to do is. For now,
+        // we just try to re-sign again, in an infinite loop.
+        self.enqueue_resign(ResigningTrigger::SIGS_NEED_REFRESH);
+    }
+
+    /// (Re-)schedule a zone for re-signing.
+    ///
+    /// This will recompute when the zone should be scheduled (if at all) and
+    /// update its schedule in the global state.
+    fn reschedule_resigning(&mut self) {
+        let new_time = resign_time(self.state);
+
+        self.state.signer.scheduled_resign_time = new_time;
+
+        let _ = self
+            .center
+            .signer
+            .next_resign_time_tx
+            .send(Some(tokio::time::Instant::now()));
+    }
+}
+
+/// # Initiating signing
+impl SignerZoneHandle<'_> {
     /// Enqueue a new-signing operation.
     ///
     /// When a new instance of the zone is loaded, reviewed, and approved, this
@@ -446,7 +504,7 @@ pub struct EnqueuedResign {
 /// Compute when a zone should be re-signed.
 ///
 /// Returns [`None`] if the zone does not need re-signing.
-pub fn resign_time(state: &ZoneState) -> Option<SystemTime> {
+fn resign_time(state: &ZoneState) -> Option<SystemTime> {
     let policy = state.policy.as_ref()?;
 
     let last_refresh_time =

--- a/src/signer/zone.rs
+++ b/src/signer/zone.rs
@@ -530,11 +530,6 @@ fn resign_time(state: &ZoneState) -> Option<SystemTime> {
     let last_refresh_time =
         SystemTime::UNIX_EPOCH + Duration::from(state.last_signature_refresh.clone());
     let refresh_interval = Duration::from_secs(policy.signer.signature_refresh_interval as u64);
-    let min_expiration = state.min_expiration?.to_system_time(last_refresh_time);
-    let remain_time = Duration::from_secs(policy.signer.sig_remain_time as u64);
 
-    Some(Ord::min(
-        last_refresh_time + refresh_interval,
-        min_expiration - remain_time,
-    ))
+    Some(last_refresh_time + refresh_interval)
 }

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -946,17 +946,17 @@ impl HttpServer {
                     .get(zone_name)
                     .expect("zones and policies are consistent");
 
-                zone.write(center).policy = Some(pol.latest.clone());
+                {
+                    let mut handle = zone.write_handle(center);
+                    handle.state.policy = Some(pol.latest.clone());
+                    handle.signer().after_policy_change();
+                }
 
                 center
                     .key_manager
                     .on_zone_policy_changed(center, zone, old.clone(), new.clone());
             }
         }
-
-        // We should have an on_zone_policy_changed per zone. For now, just
-        // call it once.
-        center.signer.on_zone_policy_changed();
 
         let mut changes: Vec<(String, _)> =
             changes.into_iter().map(|(p, c)| (p.into(), c)).collect();

--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -502,10 +502,6 @@ impl ZoneServer {
             zone.write_handle(center).get().approve_signed();
         }
 
-        // Send a message to the zone signer to trigger a re-scan of
-        // when to re-sign next.
-        center.signer.on_publish_signed_zone(center);
-
         info!("[CC]: Instructing publication server to publish the signed zone");
         PublicationServer::publish(center, zone, zone_serial);
     }

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::env::{self, VarError};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use domain::base::Rtype;
 use domain::dnssec::sign::keys::keyset::{KeySet, UnixTime};
@@ -10,16 +10,14 @@ use domain::rdata::dnssec::Timestamp;
 use domain_kmip::dep::kmip::client::pool::SyncConnPool;
 use domain_kmip::{self, ClientCertificate, ConnectionSettings};
 use serde::{Deserialize, Serialize};
-use tokio::sync::watch;
-use tokio::time::Instant;
-use tracing::trace;
 
 use crate::center::Center;
+use crate::common::scheduler::Scheduler;
 use crate::signer::ResigningTrigger;
 use crate::signer::keys::LoadError;
 use crate::signer::queue::SigningQueue;
 use crate::util::AbortOnDrop;
-use crate::zone::ZoneByName;
+use crate::zone::ZoneByPtr;
 
 // Re-signing zones before signatures expire works as follows:
 // - compute when the first zone needs to be re-signed. Loop over unsigned
@@ -40,9 +38,8 @@ use crate::zone::ZoneByName;
 pub struct ZoneSigner {
     pub kmip_servers: Arc<Mutex<HashMap<String, SyncConnPool>>>,
 
-    /// A live view of the next scheduled global resigning time.
-    pub next_resign_time_tx: watch::Sender<Option<tokio::time::Instant>>,
-    next_resign_time_rx: watch::Receiver<Option<tokio::time::Instant>>,
+    /// The re-signing scheduler.
+    pub resign_scheduler: Scheduler<ZoneByPtr>,
 
     /// The signing queue.
     pub queue: SigningQueue,
@@ -51,113 +48,35 @@ pub struct ZoneSigner {
 impl ZoneSigner {
     pub fn new() -> Self {
         let max_concurrent_operations = 1;
-        let (next_resign_time_tx, next_resign_time_rx) = watch::channel(None);
+        let resign_scheduler = Scheduler::new();
         let queue = SigningQueue::new(max_concurrent_operations.try_into().unwrap());
 
         Self {
             kmip_servers: Default::default(),
-            next_resign_time_tx,
-            next_resign_time_rx,
+            resign_scheduler,
             queue,
         }
     }
 
     /// Launch the zone signer.
     pub fn run(center: Arc<Center>) -> AbortOnDrop {
-        let this = &center.signer;
-        let resign_time = this.next_resign_time(&center);
-        this.next_resign_time_tx.send(resign_time).unwrap();
+        AbortOnDrop::from(tokio::spawn(async move {
+            center
+                .signer
+                .resign_scheduler
+                .run(|_time, ZoneByPtr(zone)| {
+                    let mut handle = zone.write_handle(&center);
 
-        AbortOnDrop::from(tokio::spawn({
-            let mut next_resign_time = this.next_resign_time_rx.clone();
-            let mut resign_time = resign_time;
-            async move {
-                async fn sleep_until(time: Option<tokio::time::Instant>) {
-                    if let Some(time) = time {
-                        tokio::time::sleep_until(time).await
-                    } else {
-                        std::future::pending().await
-                    }
-                }
+                    // The zone has been removed from the schedule, so update
+                    // its state.
+                    handle.state.signer.scheduled_resign_time = None;
 
-                // Sleep until the resign time and then resign, but also watch
-                // for changes to the resign time.
-                loop {
-                    tokio::select! {
-                        _ = next_resign_time.changed() => {
-                            // Update the resign time and keep going.
-                            resign_time = *next_resign_time.borrow_and_update();
-                        }
-
-                        _ = sleep_until(resign_time) => {
-                            // It's time to resign.
-                            center.signer.resign_zones(&center);
-
-                            // TODO: Should 'resign_zones()' do this?
-                            center.signer.next_resign_time_tx.send(center.signer.next_resign_time(&center)).unwrap();
-                        }
-                    }
-                }
-            }
+                    handle
+                        .signer()
+                        .enqueue_resign(ResigningTrigger::SIGS_NEED_REFRESH);
+                })
+                .await
         }))
-    }
-
-    fn next_resign_time(&self, center: &Arc<Center>) -> Option<Instant> {
-        #[allow(clippy::mutable_key_type)]
-        let zones = {
-            let state = center.state.lock().unwrap();
-            state.zones.clone()
-        };
-
-        // Compute when to incrementally sign a zone again to refresh
-        // signatures.
-        zones
-            .into_iter()
-            // Load the scheduled re-signing time for each zone.
-            .filter_map(|ZoneByName(zone)| {
-                let zone_state = zone.read();
-                zone_state.signer.scheduled_resign_time
-            })
-            .min()
-            .map(|t| {
-                // We need to go from SystemTime to Tokio Instant, is there a
-                // better way?
-
-                // We are computing a timeout value. If the timeout is in the
-                // past then we can just as well use zero.
-                let since_now = t
-                    .duration_since(SystemTime::now())
-                    .unwrap_or(Duration::ZERO);
-
-                Instant::now() + since_now
-            })
-    }
-
-    fn resign_zones(&self, center: &Arc<Center>) {
-        let now = SystemTime::now();
-
-        #[allow(clippy::mutable_key_type)]
-        let zones = {
-            let state = center.state.lock().unwrap();
-            state.zones.clone()
-        };
-
-        for ZoneByName(zone) in zones {
-            let zone_name = &zone.name;
-            let mut handle = zone.write_handle(center);
-
-            let Some(resign_time) = handle.state.signer.scheduled_resign_time.take() else {
-                continue;
-            };
-
-            if resign_time < now {
-                trace!("[ZS]: re-signing: request signing of zone {zone_name}");
-
-                handle
-                    .signer()
-                    .enqueue_resign(ResigningTrigger::SIGS_NEED_REFRESH);
-            }
-        }
     }
 }
 

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -1,9 +1,8 @@
-use std::cmp::min;
 use std::collections::{HashMap, HashSet};
 use std::env::{self, VarError};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime};
 
 use domain::base::Rtype;
 use domain::dnssec::sign::keys::keyset::{KeySet, UnixTime};
@@ -19,6 +18,7 @@ use crate::center::Center;
 use crate::signer::ResigningTrigger;
 use crate::signer::keys::LoadError;
 use crate::signer::queue::SigningQueue;
+use crate::signer::zone::resign_time;
 use crate::util::AbortOnDrop;
 use crate::zone::ZoneByName;
 
@@ -116,8 +116,6 @@ impl ZoneSigner {
     }
 
     fn next_resign_time(&self, center: &Arc<Center>) -> Option<Instant> {
-        let mut min_time = None;
-
         #[allow(clippy::mutable_key_type)]
         let zones = {
             let state = center.state.lock().unwrap();
@@ -126,65 +124,27 @@ impl ZoneSigner {
 
         // Compute when to incrementally sign a zone again to refresh
         // signatures.
-        for ZoneByName(zone) in zones {
-            let zone_name = &zone.name;
-
-            let last_signature_refresh;
-            let signature_refresh_interval;
-            {
-                // Use a block to make sure that the lock is clearly dropped.
+        zones
+            .into_iter()
+            // Compute the ideal re-sign time for each zone, filtering out zones
+            // that don't need re-signing.
+            .filter_map(|ZoneByName(zone)| {
                 let zone_state = zone.read();
+                resign_time(&zone_state)
+            })
+            .min()
+            .map(|t| {
+                // We need to go from SystemTime to Tokio Instant, is there a
+                // better way?
 
-                last_signature_refresh = zone_state.last_signature_refresh.clone();
+                // We are computing a timeout value. If the timeout is in the
+                // past then we can just as well use zero.
+                let since_now = t
+                    .duration_since(SystemTime::now())
+                    .unwrap_or(Duration::ZERO);
 
-                // TODO: what if there is no policy?
-                signature_refresh_interval = zone_state
-                    .policy
-                    .as_ref()
-                    .unwrap()
-                    .signer
-                    .signature_refresh_interval;
-            }
-
-            let curr_refresh_time = last_signature_refresh.clone()
-                + Duration::from_secs(signature_refresh_interval as u64);
-
-            // Start a new block to make sure the mutex is released.
-            {
-                let mut resign_busy = center.resign_busy.lock().expect("should not fail");
-                let opt_refresh_time = resign_busy.get(zone_name);
-                if let Some(saved_refresh_time) = opt_refresh_time {
-                    if *saved_refresh_time == curr_refresh_time {
-                        // This zone is busy.
-                        trace!("[ZS]: resign: zone {zone_name} is busy");
-                        continue;
-                    }
-
-                    // Zone has been resigned. Remove this entry.
-                    resign_busy.remove(zone_name);
-                }
-            }
-
-            let refresh_time = UNIX_EPOCH + Duration::from(curr_refresh_time);
-
-            min_time = if let Some(time) = min_time {
-                Some(min(time, refresh_time))
-            } else {
-                Some(refresh_time)
-            };
-        }
-        min_time.map(|t| {
-            // We need to go from SystemTime to Tokio Instant, is there a
-            // better way?
-
-            // We are computing a timeout value. If the timeout is in the
-            // past then we can just as well use zero.
-            let since_now = t
-                .duration_since(SystemTime::now())
-                .unwrap_or(Duration::ZERO);
-
-            Instant::now() + since_now
-        })
+                Instant::now() + since_now
+            })
     }
 
     fn resign_zones(&self, center: &Arc<Center>) {
@@ -196,29 +156,17 @@ impl ZoneSigner {
             state.zones.clone()
         };
 
-        for zone in zones {
-            let zone = &zone.0;
+        for ZoneByName(zone) in zones {
             let zone_name = &zone.name;
 
-            let last_signature_refresh;
-            let signature_refresh_interval;
-            {
-                // Use a block to make sure that the lock is clearly dropped.
+            let Some(resign_time) = ({
                 let zone_state = zone.read();
+                resign_time(&zone_state)
+            }) else {
+                continue;
+            };
 
-                last_signature_refresh = zone_state.last_signature_refresh.clone();
-
-                // TODO: what if there is no policy?
-                signature_refresh_interval = zone_state
-                    .policy
-                    .as_ref()
-                    .unwrap()
-                    .signer
-                    .signature_refresh_interval;
-            }
-
-            let curr_refresh_time = last_signature_refresh.clone()
-                + Duration::from_secs(signature_refresh_interval as u64);
+            let curr_refresh_time = UnixTime::try_from(resign_time).unwrap();
 
             // Start a new block to make sure the mutex is released.
             {
@@ -232,9 +180,7 @@ impl ZoneSigner {
                 }
             }
 
-            let refresh_time = UNIX_EPOCH + Duration::from(curr_refresh_time.clone());
-
-            if refresh_time < now {
+            if resign_time < now {
                 trace!("[ZS]: re-signing: request signing of zone {zone_name}");
 
                 // Start a new block to make sure the mutex is released.

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -18,7 +18,6 @@ use crate::center::Center;
 use crate::signer::ResigningTrigger;
 use crate::signer::keys::LoadError;
 use crate::signer::queue::SigningQueue;
-use crate::signer::zone::resign_time;
 use crate::util::AbortOnDrop;
 use crate::zone::ZoneByName;
 
@@ -42,7 +41,7 @@ pub struct ZoneSigner {
     pub kmip_servers: Arc<Mutex<HashMap<String, SyncConnPool>>>,
 
     /// A live view of the next scheduled global resigning time.
-    next_resign_time_tx: watch::Sender<Option<tokio::time::Instant>>,
+    pub next_resign_time_tx: watch::Sender<Option<tokio::time::Instant>>,
     next_resign_time_rx: watch::Receiver<Option<tokio::time::Instant>>,
 
     /// The signing queue.
@@ -103,18 +102,6 @@ impl ZoneSigner {
         }))
     }
 
-    pub fn on_publish_signed_zone(&self, center: &Arc<Center>) {
-        trace!("[ZS]: a zone is published, recompute next time to re-sign");
-        let _ = self.next_resign_time_tx.send(self.next_resign_time(center));
-    }
-
-    pub fn on_zone_policy_changed(&self) {
-        // Just recompute the resign timer. In the future we may want to
-        // react to changes in policy, for example, whether NSEC is used
-        // or NSEC3.
-        let _ = self.next_resign_time_tx.send(Some(Instant::now()));
-    }
-
     fn next_resign_time(&self, center: &Arc<Center>) -> Option<Instant> {
         #[allow(clippy::mutable_key_type)]
         let zones = {
@@ -128,10 +115,8 @@ impl ZoneSigner {
             .into_iter()
             // Load the scheduled re-signing time for each zone.
             .filter_map(|ZoneByName(zone)| {
-                let mut zone_state = zone.write(center);
-                let resign_time = resign_time(&zone_state);
-                zone_state.signer.scheduled_resign_time = resign_time;
-                resign_time
+                let zone_state = zone.read();
+                zone_state.signer.scheduled_resign_time
             })
             .min()
             .map(|t| {

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -126,11 +126,12 @@ impl ZoneSigner {
         // signatures.
         zones
             .into_iter()
-            // Compute the ideal re-sign time for each zone, filtering out zones
-            // that don't need re-signing.
+            // Load the scheduled re-signing time for each zone.
             .filter_map(|ZoneByName(zone)| {
-                let zone_state = zone.read();
-                resign_time(&zone_state)
+                let mut zone_state = zone.write(center);
+                let resign_time = resign_time(&zone_state);
+                zone_state.signer.scheduled_resign_time = resign_time;
+                resign_time
             })
             .min()
             .map(|t| {
@@ -158,37 +159,16 @@ impl ZoneSigner {
 
         for ZoneByName(zone) in zones {
             let zone_name = &zone.name;
+            let mut handle = zone.write_handle(center);
 
-            let Some(resign_time) = ({
-                let zone_state = zone.read();
-                resign_time(&zone_state)
-            }) else {
+            let Some(resign_time) = handle.state.signer.scheduled_resign_time.take() else {
                 continue;
             };
-
-            let curr_refresh_time = UnixTime::try_from(resign_time).unwrap();
-
-            // Start a new block to make sure the mutex is released.
-            {
-                let resign_busy = center.resign_busy.lock().expect("should not fail");
-                let opt_refresh_time = resign_busy.get(zone_name);
-                if let Some(saved_refresh_time) = opt_refresh_time
-                    && *saved_refresh_time == curr_refresh_time
-                {
-                    // This zone is busy.
-                    continue;
-                }
-            }
 
             if resign_time < now {
                 trace!("[ZS]: re-signing: request signing of zone {zone_name}");
 
-                // Start a new block to make sure the mutex is released.
-                {
-                    let mut resign_busy = center.resign_busy.lock().expect("should not fail");
-                    resign_busy.insert(zone_name.clone(), curr_refresh_time);
-                }
-                zone.write_handle(center)
+                handle
                     .signer()
                     .enqueue_resign(ResigningTrigger::SIGS_NEED_REFRESH);
             }

--- a/src/zone/machine.rs
+++ b/src/zone/machine.rs
@@ -321,6 +321,8 @@ impl<'a> ZoneHandle<'a> {
     }
 
     pub(crate) fn signing_failed(&mut self, builder: SignedZoneBuilder, err: SignerError) {
+        self.signer().before_signed_abandonment();
+
         let (transition, state) = self.state.machine.transition();
 
         let ZoneStateMachine::Signing(signing) = state else {
@@ -370,6 +372,8 @@ impl<'a> ZoneHandle<'a> {
             },
             None, // TODO
         );
+
+        self.signer().before_signed_abandonment();
 
         let (transition, state) = self.state.machine.transition();
 
@@ -451,6 +455,8 @@ impl<'a> ZoneHandle<'a> {
             num_records,
         });
 
+        self.signer().on_publication();
+
         self.storage().start_publishing(viewer);
     }
 }
@@ -474,6 +480,7 @@ impl<'a> ZoneHandle<'a> {
                 let waiting = halt_signed.reset();
                 transition.move_to(ZoneStateMachine::Waiting(waiting));
 
+                self.signer().before_signed_abandonment();
                 // TODO: This should be handled by 'Instances'.
                 self.state.next_min_expiration = None;
 


### PR DESCRIPTION
This PR changes the zone signer to use shared scheduler infrastructure (provided by `scheduler.rs`, already used by the zone loader for zone refresh timers) for managing re-signing. It also removes the `resign_busy` field from `Center` in favor of explicit data in `ZoneState`.

Solves #740. Solves #730 (avoids panicking if a zone has no policy).

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
