### PR TITLE
Fix wrongly succeeding test (fixes #862).

### DIFF
--- a/integration-tests/multipart-axfr/example.test.zone
+++ b/integration-tests/multipart-axfr/example.test.zone
@@ -6,7 +6,7 @@ example.test.   IN SOA ns1.example.test. mail.example.test. (
                    3600          ; expire (1 hour)
                       5          ; minimum (5 seconds)
                     )
-@           ZONEMD  2 1 2 7404f50a5a44f4ac577c1821ad86a0722ca2d47ed74ed70903a61cedda9e133015d334b89de86ab8a727fdc9e2513199581242f32738116865e048897cfd1153
+@           ZONEMD  2 1 2 d0c203b291a34bbd6cd6ba3210cf63aa4770b33d46e3a470553dc746a9c336de12d25760932ca0ee92c99154bdcaea87088ec28fba75202cb40d516472597ffc
 @           NS  example.test.
 @           NS  ns1.example.test.
 @           A   127.0.0.1

--- a/integration-tests/tests/multipart-axfr/action.yml
+++ b/integration-tests/tests/multipart-axfr/action.yml
@@ -74,10 +74,7 @@ runs:
 
         # Check that the received zone matches the included ZONEMD RR.
         # FYI the ZONEMD RR was generated using ldns-signzone -z sha512 -Z example.test.zone
-        if ! ldns-verify-zone -Z example.test.zone.log 2>&1 | tee ldns-verify-unsigned-review-zone.log; then
-          echo "::error:: the unsigned review zone failed the ldns-verify-zone check"
-          exit 1
-        fi
+        ldns-verify-zone -Z example.test.zone.log >ldns-verify-unsigned-review-zone.log
 
         NUM_RRS=$(cat example.test.zone.log | wc -l)
         if [[ ${NUM_RRS} -ne 506 ]]; then


### PR DESCRIPTION
- Update the ZONEMD to match the changes made to the zone for review feedback on PR #505.
- Remove the pipe to 'tee' which is unecessary and for some reason causing the exit code 112 to be suppressed (perhaps nektos/act doesn't set the shell invoked to be the one we define to use pipefail?).

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
