### PR TITLE
Speedup zone restore by parallelizing sorting.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,7 @@ version = "0.1.0-beta5-dev"
 dependencies = [
  "bytes",
  "domain",
+ "rayon",
 ]
 
 [[package]]

--- a/crates/zonedata/Cargo.toml
+++ b/crates/zonedata/Cargo.toml
@@ -29,6 +29,7 @@ bytes = ["dep:bytes", "domain/bytes"]
 # --- Dependencies -------------------------------------------------------------
 
 [dependencies]
+rayon = "1.12.0"
 
 # The zone storage needs a way to represent DNS records.  'domain' is a
 # general-purpose library offering those types, that we use across Cascade.

--- a/crates/zonedata/src/writer.rs
+++ b/crates/zonedata/src/writer.rs
@@ -13,6 +13,7 @@
 use std::{fmt, sync::Arc};
 
 use domain::new::base::RType;
+use rayon::slice::ParallelSliceMut;
 
 use crate::{
     DiffData, InstanceData, LoadedZoneReader, RegularRecord, SignedZoneReader, SoaRecord, merge,
@@ -640,7 +641,7 @@ fn apply_replacement(
         return Err(ReplaceError::MissingSoa);
     };
 
-    next.records.sort_unstable();
+    next.records.par_sort_unstable();
 
     if curr.soa.is_some() {
         let mut removed_records = Vec::new();
@@ -689,8 +690,8 @@ fn next_patchset(
         return Err(PatchError::MissingSoaChange);
     };
 
-    immediate.removed_records.sort_unstable();
-    immediate.added_records.sort_unstable();
+    immediate.removed_records.par_sort_unstable();
+    immediate.added_records.par_sort_unstable();
 
     if accumulated.is_empty() {
         // There was no previous patchset; accumulate the current one.


### PR DESCRIPTION
Flame graphs captured using [samply](https://github.com/mstange/samply/) with commands:

```
$ CARGO_PROFILE_RELEASE_STRIP=false CARGO_PROFILE_RELEASE_DEBUG=true cargo build --release
$ sudo /home/ximon/.cargo/bin/samply record target/release/cascaded \
  --config /home/ximon/src/cascade/cascade-tmp/cascade.conf \
  --state /tmp/cascade/state.db
```

Without parallel sorting: 19 seconds

<img width="3773" height="2003" alt="image" src="https://github.com/user-attachments/assets/3f3b5674-abf1-4676-b3ac-d322e2827f08" />

```
2026-07-07T11:21:51.104558Z  INFO cascaded::persistence::restore: Restoring loaded zone from persisted data
2026-07-07T11:22:01.158485Z  INFO cascaded::persistence::restore: Restored loaded snapshot for zone 'nl'
2026-07-07T11:22:10.019750Z  INFO cascaded::persistence::restore: Restored signed snapshot for zone 'nl'
```

With parallel sorting: 9 seconds

<img width="3773" height="2003" alt="image" src="https://github.com/user-attachments/assets/f3ae7286-8869-4abf-a1cd-06fe46b8501a" />

```
2026-07-07T11:20:52.903650Z  INFO cascaded::persistence::restore: Restoring loaded zone from persisted data
2026-07-07T11:20:57.477619Z  INFO cascaded::persistence::restore: Restored loaded snapshot for zone 'nl'
2026-07-07T11:21:01.977370Z  INFO cascaded::persistence::restore: Restored signed snapshot for zone 'nl'
```

The flamegraph showed that sorting during restore as a fraction of the total time spent by the application was more than expected, and that parallelizing that sorting (via the `rayon` crate) reduced makes that fraction smaller.