### PR TITLE
Make logging during zone restoration consistent.

### DIFF
--- a/src/persistence/restore.rs
+++ b/src/persistence/restore.rs
@@ -45,7 +45,10 @@ pub fn restore_loaded(
         return io::Result::Ok(false);
     }
 
-    info!("Restoring loaded zone from persisted data");
+    info!(
+        "Restoring loaded records for zone '{}' from persisted data",
+        zone.name
+    );
     state.storage.diffs.clear();
 
     // Determine the paths to read from. Each zone is persisted as an AXFR
@@ -79,6 +82,7 @@ pub fn restore_loaded(
     );
 
     if count == 1 {
+        info!("Restored loaded snapshot for zone '{}'", zone.name);
         return io::Result::Ok(true);
     }
 
@@ -128,7 +132,11 @@ pub fn restore_loaded(
         soa.rdata.serial, zone.name
     );
 
-    info!("Restored loaded zone snapshot and {} diffs", count - 1);
+    info!(
+        "Restored loaded snapshot and {} diffs for zone '{}'",
+        count - 1,
+        zone.name
+    );
     io::Result::Ok(true)
 }
 
@@ -150,6 +158,11 @@ pub fn restore_signed(
     if state.persisted_signed_diff_paths.is_empty() {
         return io::Result::Ok(false);
     }
+
+    info!(
+        "Restoring signed records for zone '{}' from persisted data",
+        zone.name
+    );
 
     // Determine the paths to read from. Each zone is persisted as an AXFR
     // plus zero or more IXFRs. The restorer takes a base path ending in an
@@ -184,6 +197,7 @@ pub fn restore_signed(
     );
 
     if count == 1 {
+        info!("Restored signed snapshot for zone '{}'", zone.name);
         return io::Result::Ok(true);
     }
 
@@ -286,7 +300,11 @@ pub fn restore_signed(
         soa.rdata.serial, zone.name
     );
 
-    info!("Restored signed zone snapshot and {} diffs", count - 1);
+    info!(
+        "Restored signed snapshot and {} diffs for zone '{}'",
+        count - 1,
+        zone.name
+    );
     io::Result::Ok(true)
 }
 


### PR DESCRIPTION
- Log start of restoration of signed data as well as loaded data.
- Log end of restoration of snapshot only, not just when there are also diffs.
- Include the zone name in log messages.
