### PR TITLE
Add metrics for the duration of the last loading and signing operations

### DIFF
--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -121,6 +121,8 @@ async fn refresh(
     info!("Refreshing {:?}", zone.name);
     let force = refresh == EnqueuedRefresh::Reload;
 
+    let start = Instant::now();
+
     // Perform the source-specific reload into the zone contents.
     let result = match source {
         Source::None => Ok(false),
@@ -151,6 +153,10 @@ async fn refresh(
             server::refresh(&zone, &addr, tsig_key, &mut builder, &metrics).await
         }
     };
+
+    let end = Instant::now();
+    let duration = (end - start).as_secs_f64();
+    zone.metrics.last_load_duration(duration);
 
     let mut handle = zone.write_handle(&center);
 
@@ -216,6 +222,8 @@ async fn refresh(
         }
 
         Ok(true) => {
+            zone.metrics.last_successful_load_duration(duration);
+
             let soa = builder.next().unwrap().soa().clone();
 
             debug!(

--- a/src/loader/server.rs
+++ b/src/loader/server.rs
@@ -41,7 +41,7 @@ use tracing::{debug, trace};
 
 use crate::{
     loader::ActiveLoadMetrics,
-    metrics::{XfrTransport, XfrType},
+    metrics::XfrType,
     zone::Zone,
     zonedata::{
         LoadedZoneBuilder, LoadedZonePatcher, LoadedZoneReplacer, OldRecord, PatchError,
@@ -183,7 +183,7 @@ pub async fn ixfr(
     let mut interpreter = XfrResponseInterpreter::new();
 
     zone.metrics
-        .inc_xfr_requests_to_upstream_attempted(XfrType::Ixfr, XfrTransport::Tcp);
+        .inc_xfr_requests_to_upstream_attempted(XfrType::Ixfr);
 
     // Process the first message.
     let initial = response
@@ -261,7 +261,7 @@ pub async fn ixfr(
             metrics.num_loaded_bytes.fetch_add(bytes, Relaxed);
 
             zone.metrics
-                .inc_xfr_requests_to_upstream_succeeded(XfrType::Ixfr, XfrTransport::Tcp);
+                .inc_xfr_requests_to_upstream_succeeded(XfrType::Ixfr);
 
             Ok(true)
         }
@@ -299,7 +299,7 @@ pub async fn ixfr(
             writer.apply()?;
 
             zone.metrics
-                .inc_xfr_requests_to_upstream_succeeded(XfrType::Ixfr, XfrTransport::Tcp);
+                .inc_xfr_requests_to_upstream_succeeded(XfrType::Ixfr);
 
             Ok(true)
         }
@@ -413,7 +413,7 @@ pub async fn axfr(
         };
 
     zone.metrics
-        .inc_xfr_requests_to_upstream_attempted(XfrType::Axfr, XfrTransport::Tcp);
+        .inc_xfr_requests_to_upstream_attempted(XfrType::Axfr);
 
     // Attempt the AXFR.
     let request = RequestMessageMulti::new(message).unwrap();
@@ -457,7 +457,7 @@ pub async fn axfr(
     writer.apply()?;
 
     zone.metrics
-        .inc_xfr_requests_to_upstream_succeeded(XfrType::Axfr, XfrTransport::Tcp);
+        .inc_xfr_requests_to_upstream_succeeded(XfrType::Axfr);
 
     Ok(())
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -354,6 +354,18 @@ struct PerZoneMetrics {
     /// The number of bytes loaded in the last load (file or transfer),
     /// regardless of wether it was successful or aborted due to failure
     zone_loaded_last_bytes: Family<ZoneLabel, Gauge>,
+
+    /// Duration of the last load for this zone.
+    zone_last_load_duration: Family<ZoneLabel, Gauge<f64, AtomicU64>>,
+
+    /// Duration of the last load for this zone.
+    zone_last_successful_load_duration: Family<ZoneLabel, Gauge<f64, AtomicU64>>,
+
+    /// Duration of the last successful signing operation for this zone.
+    zone_last_sign_duration: Family<ZoneLabel, Gauge<f64, AtomicU64>>,
+
+    /// Duration of the last signing operations for this zone.
+    zone_last_successful_sign_duration: Family<ZoneLabel, Gauge<f64, AtomicU64>>,
 }
 
 impl PerZoneMetrics {
@@ -394,6 +406,34 @@ impl PerZoneMetrics {
             "Number of bytes loaded in last attempted zone transfer or zonefile load",
             Unit::Bytes,
             self.zone_loaded_last_bytes.clone(),
+        );
+
+        metrics.register_with_unit(
+            "zone_last_load_duration",
+            "Duration of the last load for this zone",
+            Unit::Seconds,
+            self.zone_last_load_duration.clone(),
+        );
+
+        metrics.register_with_unit(
+            "zone_last_successful_load_duration",
+            "Duration of the last successful load for this zone",
+            Unit::Seconds,
+            self.zone_last_successful_load_duration.clone(),
+        );
+
+        metrics.register_with_unit(
+            "zone_last_sign_duration",
+            "Duration of the last signing operation for this zone",
+            Unit::Seconds,
+            self.zone_last_sign_duration.clone(),
+        );
+
+        metrics.register_with_unit(
+            "zone_last_successful_sign_duration",
+            "Duration of the last successful signing operation for this zone",
+            Unit::Seconds,
+            self.zone_last_successful_sign_duration.clone(),
         );
     }
 }
@@ -460,6 +500,42 @@ impl ZoneMetrics {
     pub fn zone_loaded_last_bytes(&self, n: i64) {
         self.per_zone_metrics
             .zone_loaded_last_bytes
+            .get_or_create(&ZoneLabel {
+                zone: self.zone_name.clone(),
+            })
+            .set(n);
+    }
+
+    pub fn last_load_duration(&self, n: f64) {
+        self.per_zone_metrics
+            .zone_last_load_duration
+            .get_or_create(&ZoneLabel {
+                zone: self.zone_name.clone(),
+            })
+            .set(n);
+    }
+
+    pub fn last_successful_load_duration(&self, n: f64) {
+        self.per_zone_metrics
+            .zone_last_successful_load_duration
+            .get_or_create(&ZoneLabel {
+                zone: self.zone_name.clone(),
+            })
+            .set(n);
+    }
+
+    pub fn last_sign_duration(&self, n: f64) {
+        self.per_zone_metrics
+            .zone_last_sign_duration
+            .get_or_create(&ZoneLabel {
+                zone: self.zone_name.clone(),
+            })
+            .set(n);
+    }
+
+    pub fn last_successful_sign_duration(&self, n: f64) {
+        self.per_zone_metrics
+            .zone_last_successful_sign_duration
             .get_or_create(&ZoneLabel {
                 zone: self.zone_name.clone(),
             })

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -257,7 +257,6 @@ pub enum HaltMode {
 pub struct XfrLabels {
     pub zone: StoredName,
     pub r#type: XfrType,
-    pub transport: XfrTransport,
 }
 
 //------------ XfrType -------------------------------------------------------
@@ -266,14 +265,6 @@ pub struct XfrLabels {
 pub enum XfrType {
     Axfr,
     Ixfr,
-}
-
-//------------ XfrTransport --------------------------------------------------
-
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, EncodeLabelValue)]
-pub enum XfrTransport {
-    Tcp,
-    Udp,
 }
 
 //------------ StateMetrics --------------------------------------------------
@@ -448,24 +439,22 @@ pub struct ZoneMetrics {
 }
 
 impl ZoneMetrics {
-    pub fn inc_xfr_requests_to_upstream_attempted(&self, ty: XfrType, transport: XfrTransport) {
+    pub fn inc_xfr_requests_to_upstream_attempted(&self, ty: XfrType) {
         self.per_zone_metrics
             .xfr_requests_to_upstream_attempted
             .get_or_create(&XfrLabels {
                 zone: self.zone_name.clone(),
                 r#type: ty,
-                transport,
             })
             .inc();
     }
 
-    pub fn inc_xfr_requests_to_upstream_succeeded(&self, ty: XfrType, transport: XfrTransport) {
+    pub fn inc_xfr_requests_to_upstream_succeeded(&self, ty: XfrType) {
         self.per_zone_metrics
             .xfr_requests_to_upstream_succeeded
             .get_or_create(&XfrLabels {
                 zone: self.zone_name.clone(),
                 r#type: ty,
-                transport,
             })
             .inc();
     }

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -20,6 +20,7 @@
 use std::{
     ops::{BitOr, BitOrAssign},
     sync::{Arc, RwLock},
+    time::Instant,
 };
 
 use tracing::{debug, error};
@@ -65,11 +66,17 @@ fn sign(
     permit: SigningPermit,
     status: Arc<RwLock<SigningStatusPerZone>>,
 ) {
+    let start = Instant::now();
+
     let result = if let Some(patcher) = builder.patch() {
         self::incremental::sign_incrementally(patcher, &zone, &center, trigger, status.clone())
     } else {
         self::full::sign_zone(&center, &zone, &mut builder, trigger, status.clone())
     };
+
+    let end = Instant::now();
+    let duration = (end - start).as_secs_f64();
+    zone.metrics.last_sign_duration(duration);
 
     let mut status = status.write().unwrap();
     let mut handle = zone.write_handle(&center);
@@ -82,6 +89,7 @@ fn sign(
             let built = builder.finish().unwrap_or_else(|_| unreachable!());
             handle.get().finish_signing(built);
             status.status.finish(true);
+            zone.metrics.last_successful_sign_duration(duration);
             status.current_action = "Finished".to_string();
         }
         Err(SignerError::NothingToDo) => {


### PR DESCRIPTION
Adds the following metrics:

- `zone_last_load_duration`
- `zone_last_successful_load_duration`
- `zone_last_sign_duration`
- `zone_last_successful_sign_duration`

They are all represented by `f64` to represent the number of seconds (because [base units should be used](https://prometheus.io/docs/practices/naming/#base-units)).

Closes #870 

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [ ] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?

