### PR TITLE
Use instances

### DIFF
--- a/integration-tests/tests/review-signed-zone/action.yml
+++ b/integration-tests/tests/review-signed-zone/action.yml
@@ -112,7 +112,9 @@ runs:
       env:
         EXPECTED_SERIAL: ${{ steps.expected-serial.outputs.serial }}
       run: |
-        cascade zone approve --signed example.test ${EXPECTED_SERIAL}
+        # `EXPECTED_SERIAL` was used when the zone was first signed; it has
+        # since been re-signed, so the serial number has increased.
+        cascade zone approve --signed example.test $((EXPECTED_SERIAL + 1))
         
     - name: Querying the zone at the publication server should succeed
       run: |

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -139,8 +139,7 @@ impl Metrics {
                 }
 
                 // Check whether an instance has been published.
-                // TODO: Use a more appropriate check.
-                if zone_state.min_expiration.is_some() {
+                if zone_state.instances.current.is_some() {
                     zones_published += 1;
                     zones_signed += 1;
                     zones_unsigned += 1;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,15 +3,16 @@
 use std::{fmt, sync::Arc};
 
 use domain::base::Serial;
+use tracing::{debug, error, info, warn};
 
 use crate::{
-    api::{ZoneReviewDecision, ZoneReviewResult},
     center::Center,
     daemon::SocketProvider,
     manager::Terminated,
+    policy::OnReject,
     units::zone_server::{Source, ZoneServer},
     util::AbortOnDrop,
-    zone::Zone,
+    zone::{Zone, machine::ZoneStateMachine},
     zonedata::{LoadedZoneReviewer, SignedZoneReviewer, ZoneViewer},
 };
 
@@ -63,14 +64,75 @@ impl LoadedReviewServer {
     }
 
     /// Process a review of a served instance.
+    #[tracing::instrument(
+        level = "trace",
+        skip_all,
+        fields(zone = %zone.name, serial = %zone_serial.0, ?decision),
+    )]
     pub fn process_review(
         center: &Arc<Center>,
         zone: &Arc<Zone>,
         zone_serial: Serial,
-        decision: ZoneReviewDecision,
-    ) -> ZoneReviewResult {
-        // TODO: Inline.
-        ZoneServer::new(Source::Unsigned).on_zone_review(center, zone, zone_serial, decision)
+        decision: crate::api::ZoneReviewDecision,
+    ) -> crate::api::ZoneReviewResult {
+        let mut handle = zone.write_handle(center);
+
+        if !matches!(handle.state.machine, ZoneStateMachine::LoadedReview(_)) {
+            debug!("The zone is not undergoing loaded review");
+            return Err(crate::api::ZoneReviewError::NotUnderReview);
+        }
+
+        let instance = handle
+            .state
+            .instances
+            .upcoming
+            .as_ref()
+            .and_then(|i| i.loaded.as_ref())
+            .expect("There must be an upcoming instance in the `LoadedReview` state");
+
+        if instance.serial().get() != zone_serial.0 {
+            debug!(
+                "A review of a loaded instance with SOA serial {} was received, \
+                but the loaded instance under review actually has SOA serial {}",
+                zone_serial.0,
+                instance.serial().get()
+            );
+            return Err(crate::api::ZoneReviewError::NotUnderReview);
+        }
+
+        let Some(policy) = handle.state.policy.as_ref() else {
+            warn!("Bug: zone has no policy, it might be mid removal");
+            return Err(crate::api::ZoneReviewError::NoSuchZone);
+        };
+
+        match decision {
+            crate::api::ZoneReviewDecision::Approve => {
+                info!(
+                    "The loaded instance of zone '{}' (SOA serial {}) has been approved.",
+                    zone.name, zone_serial.0
+                );
+
+                handle.get().approve_loaded();
+            }
+
+            crate::api::ZoneReviewDecision::Reject => {
+                error!(
+                    "The loaded instance of zone '{}' (SOA serial {}) has been rejected.",
+                    zone.name, zone_serial.0
+                );
+
+                match policy.loader.review.on_reject {
+                    OnReject::Discard => {
+                        handle.get().soft_reject_loaded();
+                    }
+                    OnReject::Halt => {
+                        handle.get().hard_reject_loaded();
+                    }
+                }
+            }
+        }
+
+        Ok(crate::api::ZoneReviewOutput {})
     }
 
     /// Register a new zone.
@@ -152,14 +214,75 @@ impl SignedReviewServer {
     }
 
     /// Process a review of a served instance.
+    #[tracing::instrument(
+        level = "trace",
+        skip_all,
+        fields(zone = %zone.name, serial = %zone_serial.0, ?decision),
+    )]
     pub fn process_review(
         center: &Arc<Center>,
         zone: &Arc<Zone>,
         zone_serial: Serial,
-        decision: ZoneReviewDecision,
-    ) -> ZoneReviewResult {
-        // TODO: Inline.
-        ZoneServer::new(Source::Signed).on_zone_review(center, zone, zone_serial, decision)
+        decision: crate::api::ZoneReviewDecision,
+    ) -> crate::api::ZoneReviewResult {
+        let mut handle = zone.write_handle(center);
+
+        if !matches!(handle.state.machine, ZoneStateMachine::SignedReview(_)) {
+            debug!("The zone is not undergoing signed review");
+            return Err(crate::api::ZoneReviewError::NotUnderReview);
+        }
+
+        let instance = handle
+            .state
+            .instances
+            .upcoming
+            .as_ref()
+            .and_then(|i| i.signed.as_ref())
+            .expect("There must be an upcoming instance in the `SignedReview` state");
+
+        if instance.serial().get() != zone_serial.0 {
+            debug!(
+                "A review of a signed instance with SOA serial {} was received, \
+                but the signed instance under review actually has SOA serial {}",
+                zone_serial.0,
+                instance.serial().get()
+            );
+            return Err(crate::api::ZoneReviewError::NotUnderReview);
+        }
+
+        let Some(policy) = handle.state.policy.as_ref() else {
+            warn!("Bug: zone has no policy, it might be mid removal");
+            return Err(crate::api::ZoneReviewError::NoSuchZone);
+        };
+
+        match decision {
+            crate::api::ZoneReviewDecision::Approve => {
+                info!(
+                    "The signed instance of zone '{}' (SOA serial {}) has been approved.",
+                    zone.name, zone_serial.0
+                );
+
+                handle.get().approve_signed();
+            }
+
+            crate::api::ZoneReviewDecision::Reject => {
+                error!(
+                    "The signed instance of zone '{}' (SOA serial {}) has been rejected.",
+                    zone.name, zone_serial.0
+                );
+
+                match policy.signer.review.on_reject {
+                    OnReject::Discard => {
+                        handle.get().soft_reject_signed();
+                    }
+                    OnReject::Halt => {
+                        handle.get().hard_reject_signed();
+                    }
+                }
+            }
+        }
+
+        Ok(crate::api::ZoneReviewOutput {})
     }
 
     /// Register a new zone.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,7 +3,7 @@
 use std::{fmt, sync::Arc};
 
 use domain::base::Serial;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::{
     center::Center,
@@ -12,10 +12,11 @@ use crate::{
     policy::OnReject,
     units::zone_server::{Source, ZoneServer},
     util::AbortOnDrop,
-    zone::{Zone, machine::ZoneStateMachine},
+    zone::{Zone, ZoneHandle, machine::ZoneStateMachine},
     zonedata::{LoadedZoneReviewer, SignedZoneReviewer, ZoneViewer},
 };
 
+mod notify;
 mod request;
 mod service;
 
@@ -352,10 +353,52 @@ impl PublicationServer {
         )
     }
 
-    /// Publish an instance.
-    pub fn publish(center: &Arc<Center>, zone: &Arc<Zone>, zone_serial: Serial) {
-        // TODO: Inline.
-        ZoneServer::new(Source::Published).on_publish_signed_zone(center, zone, zone_serial)
+    /// React to the publication of an instance.
+    ///
+    /// Sends NOTIFY messages to downstream servers if configured to do so.
+    #[tracing::instrument(
+        level = "trace",
+        skip_all,
+        fields(zone = %handle.zone.name),
+    )]
+    pub fn after_publication(handle: &mut ZoneHandle<'_>) {
+        let instance = handle
+            .state
+            .instances
+            .current
+            .as_ref()
+            .expect("A published zone must have a current instance");
+        let policy = handle
+            .state
+            .policy
+            .as_ref()
+            .expect("A published zone always has a policy");
+
+        let targets = policy
+            .server
+            .outbound
+            .send_notify_to
+            .iter()
+            .filter(|&s| s.addr.port() != 0)
+            .collect::<Vec<_>>();
+
+        debug!(
+            "Sending NOTIFY messages to {} downstream name servers",
+            targets.len()
+        );
+
+        if targets.is_empty() {
+            return;
+        }
+
+        trace!("Target name servers: {targets:?}");
+
+        self::notify::send_notify_to_addrs(
+            handle.zone.name.clone(),
+            instance.signed.soa.clone(),
+            targets.into_iter(),
+            handle.center,
+        );
     }
 
     /// Register a new zone.

--- a/src/server/notify.rs
+++ b/src/server/notify.rs
@@ -1,0 +1,96 @@
+//! Notifying downstream servers.
+
+use std::{sync::Arc, time::Duration};
+
+use bytes::Bytes;
+use cascade_zonedata::OldRecord;
+use domain::{
+    base::{MessageBuilder, Name, Rtype, iana::Opcode},
+    net::client::{
+        dgram,
+        protocol::UdpConnect,
+        request::{RequestMessage, SendRequest},
+        tsig,
+    },
+};
+use tracing::{debug, trace, warn};
+
+use crate::{center::Center, policy::NameserverCommsPolicy, zonedata::SoaRecord};
+
+pub fn send_notify_to_addrs<'a>(
+    apex_name: Name<Bytes>,
+    soa: SoaRecord,
+    notify_set: impl Iterator<Item = &'a NameserverCommsPolicy>,
+    center: &Arc<Center>,
+) {
+    let mut dgram_config = domain::net::client::dgram::Config::new();
+    dgram_config.set_max_parallel(1);
+    dgram_config.set_read_timeout(Duration::from_millis(1000));
+    dgram_config.set_max_retries(1);
+    dgram_config.set_udp_payload_size(Some(1400));
+
+    let mut msg = MessageBuilder::new_vec();
+    msg.header_mut().set_opcode(Opcode::NOTIFY);
+    let mut msg = msg.question();
+    msg.push((apex_name, Rtype::SOA)).unwrap();
+
+    // Include the current zone SOA as an RFC 1996 "unsecure hint" (see
+    // section 3.7) to the receiving nameserver so that it can choose to avoid
+    // sending a SOA query if it deems that it has this version of the zone
+    // already.
+    let mut msg = msg.answer();
+    msg.push(OldRecord::from(soa)).unwrap();
+
+    for nameserver in notify_set {
+        let dgram_config = dgram_config.clone();
+        let req = RequestMessage::new(msg.clone()).unwrap();
+
+        let nameserver = nameserver.clone();
+        let center = center.clone();
+        tokio::spawn(async move {
+            // TODO: Use the connection factory here.
+            let udp_connect = UdpConnect::new(nameserver.addr);
+            let client = dgram::Connection::with_config(udp_connect, dgram_config.clone());
+
+            trace!("Sending NOTIFY to nameserver {nameserver}");
+            let span = tracing::trace_span!("auth", addr = %nameserver);
+            let _guard = span.enter();
+
+            // https://datatracker.ietf.org/doc/html/rfc1996
+            //   "4.8 Master Receives a NOTIFY Response from Slave
+            //
+            //    When a master server receives a NOTIFY response, it deletes this
+            //    query from the retry queue, thus completing the "notification
+            //    process" of "this" RRset change to "that" server."
+            //
+            // TODO: We have no retry queue at the moment. Do we need one?
+
+            let tsig_key = {
+                let state = center.state.lock().unwrap();
+                nameserver
+                    .tsig_key_name
+                    .as_ref()
+                    .and_then(|tsig_key_name| state.tsig_store.get(tsig_key_name))
+                    .map(|key| key.inner.clone())
+            };
+
+            if let Some(key) = &tsig_key {
+                debug!(
+                    "Found TSIG key '{}' (algorithm {}) for NOTIFY to {nameserver}",
+                    key.name(),
+                    key.algorithm()
+                );
+            }
+            let res = if let Some(key) = tsig_key {
+                let client = tsig::Connection::new(key.clone(), client);
+                client.send_request(req.clone()).get_response().await
+            } else {
+                client.send_request(req.clone()).get_response().await
+            };
+
+            if let Err(err) = res {
+                warn!("Unable to send NOTIFY to nameserver {nameserver}: {err}");
+            }
+        });
+    }
+}

--- a/src/signer/zone.rs
+++ b/src/signer/zone.rs
@@ -191,23 +191,15 @@ impl SignerZoneHandle<'_> {
         // needs re-signing (i.e. that the signing keys used for building that
         // instance are different from the latest ones).
         //
-        // TODO: Stop relying on `{next_,}min_expiration` to tell us about the
-        // published and upcoming instances of the zone.
-        //
-        // TODO: Verify that `min_expiration` is set to `None` when Cascade is
-        // starting up and trying to restoring zones from the disk.
-        //
         // If a published instance of the zone exists, we definitely want to
         // re-sign it. If a published instance of the zone does not exist, but
-        // an upcoming signed instance does, we should try re-signing it too.
-        // But before re-signing is actually initiated, we will verify that
-        // the upcoming instance was accepted and published (and ignore the
-        // re-signing request otherwise).
-        if self
-            .state
-            .min_expiration
-            .or(self.state.next_min_expiration)
-            .is_none()
+        // an upcoming signed instance does (or if the zone is being restored
+        // from disk), we should try re-signing it too. Before re-signing is
+        // actually initiated, we will verify that the upcoming instance was
+        // accepted and published (and ignore the re-signing request otherwise).
+        if self.state.instances.current.is_none()
+            && self.state.instances.upcoming.is_none()
+            && !self.state.storage.is_restoring()
         {
             debug!(
                 "Ignoring re-signing request; \
@@ -224,17 +216,9 @@ impl SignerZoneHandle<'_> {
             return;
         }
 
-        // TODO: Track expiration time in 'SignerState'.
-        let expiration_time = self
-            .state
-            .next_min_expiration
-            .or(self.state.min_expiration)
-            .unwrap_or_else(|| panic!("re-sign enqueued but the zone has not been signed"))
-            .to_system_time(SystemTime::now());
-
         // Make sure a published instance exists.
         // Then, try to obtain a `SignedZoneBuilder` so building can begin.
-        if self.state.min_expiration.is_some()
+        if self.state.instances.current.is_some()
             && let Some(builder) = self.zone().try_start_resign()
         {
             // A zone can have at most one 'SignedZoneBuilder' at a time.
@@ -261,7 +245,6 @@ impl SignerZoneHandle<'_> {
                         builder: Some(builder),
                         pending: Some(pending),
                         trigger,
-                        expiration_time,
                     });
                 }
             }
@@ -271,7 +254,6 @@ impl SignerZoneHandle<'_> {
                 builder: None,
                 pending: None,
                 trigger,
-                expiration_time,
             });
         }
     }
@@ -301,7 +283,6 @@ impl SignerZoneHandle<'_> {
             builder,
             pending,
             trigger,
-            expiration_time,
         }) = self.state.signer.enqueued_resign.take()
         else {
             // A re-sign is not enqueued, nothing to do.
@@ -320,7 +301,7 @@ impl SignerZoneHandle<'_> {
         // of the zone. If a published signed instance does not exist either,
         // there is nothing to re-sign, and we should just abandon the existing
         // re-signing operation.
-        if self.state.min_expiration.is_none() {
+        if self.state.instances.current.is_none() {
             debug!(
                 ?trigger,
                 "Dropping previously enqueued re-signing request; \
@@ -352,7 +333,6 @@ impl SignerZoneHandle<'_> {
                     builder: Some(builder),
                     pending: Some(pending),
                     trigger,
-                    expiration_time,
                 });
             }
         }
@@ -381,7 +361,6 @@ impl SignerZoneHandle<'_> {
                 builder,
                 pending,
                 trigger,
-                expiration_time: _, // TODO
             } = op;
 
             let Some(pending) = pending else {
@@ -503,16 +482,6 @@ pub struct EnqueuedResign {
 
     /// The trigger causing this operation.
     pub trigger: ResigningTrigger,
-
-    /// When signatures in the zone will expire.
-    ///
-    /// `self` represents an enqueued re-sign, which means that a current signed
-    /// instance of the zone exists. This field tracks the expiration time (not
-    /// the time to enqueue re-signing) for that instance, to ensure it will be
-    /// re-signed in time.
-    //
-    // TODO: Force loading to cancel if this gets too close?
-    pub expiration_time: SystemTime,
     //
     // TODO:
     // - The ID of the signed instance to re-sign.

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -449,20 +449,24 @@ impl HttpServer {
                 });
 
             unsigned_serial = zone_state
-                .storage
-                .loaded_review_soa
+                .instances
+                .upcoming
                 .as_ref()
-                .map(|r| Serial::from(u32::from(r.rdata.serial)));
+                .and_then(|i| i.loaded.as_ref())
+                .map(|i| Serial(i.serial().into()));
+
             signed_serial = zone_state
-                .storage
-                .signed_review_soa
+                .instances
+                .upcoming
                 .as_ref()
-                .map(|r| Serial::from(u32::from(r.rdata.serial)));
+                .and_then(|i| i.signed.as_ref())
+                .map(|i| Serial(i.serial().into()));
+
             published_serial = zone_state
-                .storage
-                .published_soa
+                .instances
+                .current
                 .as_ref()
-                .map(|r| Serial::from(u32::from(r.rdata.serial)));
+                .map(|i| Serial(i.signed.serial().into()));
 
             progress = match zone_state.machine {
                 ZoneStateMachine::Waiting(..) => {
@@ -494,13 +498,14 @@ impl HttpServer {
             };
 
             last_published = zone_state
-                .last_published
+                .instances
+                .current
                 .as_ref()
-                .map(|p| LastPublishedZone {
-                    loaded_serial: p.loaded_serial,
-                    signed_serial: p.signed_serial,
-                    num_records: p.num_records,
-                    timestamp: p.timestamp,
+                .map(|i| LastPublishedZone {
+                    loaded_serial: Serial(i.loaded.serial().into()),
+                    signed_serial: Serial(i.signed.serial().into()),
+                    num_records: i.signed.num_records().get() as usize,
+                    timestamp: i.pub_time,
                 });
 
             let mut found_error = None;

--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -26,20 +26,16 @@ use domain::tsig::{Algorithm, KeyStore};
 use domain::zonetree::StoredName;
 use tracing::{debug, error, info, trace, warn};
 
-use crate::api::{
-    ZoneReviewDecision, ZoneReviewError, ZoneReviewOutput, ZoneReviewResult, ZoneReviewStatus,
-};
+use crate::api::{ZoneReviewDecision, ZoneReviewStatus};
 use crate::center::Center;
 use crate::config::SocketConfig;
 use crate::daemon::SocketProvider;
 use crate::manager::Terminated;
 use crate::manager::record_zone_event;
-use crate::policy::{NameserverCommsPolicy, OnReject, ReviewMode};
+use crate::policy::{NameserverCommsPolicy, ReviewMode};
 use crate::server::{LoadedReviewServer, PublicationServer, SignedReviewServer};
 use crate::util::AbortOnDrop;
-use crate::zone::{
-    HistoricalEvent, SignedZoneVersionState, UnsignedZoneVersionState, Zone, ZoneVersionReviewState,
-};
+use crate::zone::{HistoricalEvent, Zone};
 use crate::zonedata::{OldRecord, SoaRecord};
 
 /// The source of a zone server.
@@ -333,37 +329,6 @@ impl ZoneServer {
             }
         };
 
-        // Mark this version of the zone as pending approval.
-        //
-        // TODO: These entries should have been created a long time ago, but
-        // not all components use these fields yet.  For now, they need to be
-        // created over here -- hence 'or_insert_with()'.
-        {
-            let mut zone_state = zone.write(center);
-            match self.source {
-                Source::Unsigned => {
-                    zone_state
-                        .unsigned
-                        .entry(zone_serial)
-                        .or_insert_with(|| UnsignedZoneVersionState {
-                            review: Default::default(),
-                        })
-                        .review = ZoneVersionReviewState::Pending;
-                }
-                Source::Signed => {
-                    zone_state
-                        .signed
-                        .entry(zone_serial)
-                        .or_insert_with(|| SignedZoneVersionState {
-                            unsigned_serial: Serial::from(0), // TODO
-                            review: Default::default(),
-                        })
-                        .review = ZoneVersionReviewState::Pending;
-                }
-                Source::Published => unreachable!(),
-            }
-        }
-
         record_zone_event(center, zone, pending_event, Some(zone_serial));
 
         let ReviewMode::Script { hook } = review.mode else {
@@ -457,27 +422,25 @@ impl ZoneServer {
                 );
 
                 {
-                    let mut zone_state = zone.write(center);
+                    let mut handle = zone.write_handle(center);
                     match self.source {
                         Source::Unsigned => {
-                            zone_state.record_event(
+                            handle.state.record_event(
                                 HistoricalEvent::UnsignedHookFailed {
                                     err: err.to_string(),
                                 },
                                 Some(zone_serial),
                             );
-                            zone_state.unsigned.get_mut(&zone_serial).unwrap().review =
-                                ZoneVersionReviewState::Rejected;
+                            handle.get().hard_reject_loaded();
                         }
                         Source::Signed => {
-                            zone_state.record_event(
+                            handle.state.record_event(
                                 HistoricalEvent::SignedHookFailed {
                                     err: err.to_string(),
                                 },
                                 Some(zone_serial),
                             );
-                            zone_state.signed.get_mut(&zone_serial).unwrap().review =
-                                ZoneVersionReviewState::Rejected;
+                            handle.get().hard_reject_signed();
                         }
                         Source::Published => unreachable!(),
                     }
@@ -522,124 +485,6 @@ impl ZoneServer {
             }
         }
         Ok(())
-    }
-
-    pub fn on_zone_review(
-        &self,
-        center: &Arc<Center>,
-        zone: &Arc<Zone>,
-        zone_serial: Serial,
-        decision: ZoneReviewDecision,
-    ) -> ZoneReviewResult {
-        let unit_name = self.unit_name();
-        let zone_name = &zone.name;
-
-        // Look up the zone.
-
-        let new_review_state = match decision {
-            ZoneReviewDecision::Approve => ZoneVersionReviewState::Approved,
-            ZoneReviewDecision::Reject => ZoneVersionReviewState::Rejected,
-        };
-
-        // Look up the version of the zone being reviewed.
-        match self.source {
-            Source::Unsigned => {
-                {
-                    let mut zone_state = zone.write(center);
-                    let Some(version) = zone_state.unsigned.get_mut(&zone_serial) else {
-                        // 'on_seek_approval_for_zone_cmd()' should have created
-                        // this.  Since it doesn't exist, the zone is not under
-                        // review.
-
-                        debug!(
-                            "[{unit_name}] Got a review for {zone_name}/{zone_serial}, but it was not pending review"
-                        );
-                        return Err(ZoneReviewError::NotUnderReview);
-                    };
-
-                    // Check that the zone was not already approved.
-                    if matches!(version.review, ZoneVersionReviewState::Approved) {
-                        // This version of the zone is no longer being reviewed.
-                        //
-                        // TODO: Differentiate this from 'NotUnderReview'?
-
-                        return Err(ZoneReviewError::NotUnderReview);
-                    }
-
-                    version.review = new_review_state;
-                }
-                if matches!(decision, ZoneReviewDecision::Approve) {
-                    info!(
-                        "Unsigned zone '{zone_name}' with serial {zone_serial} has been approved."
-                    );
-                    self.on_unsigned_zone_approved(center, zone, zone_serial);
-                } else {
-                    error!(
-                        "Unsigned zone '{zone_name}' with serial {zone_serial} has been rejected."
-                    );
-
-                    let mut handle = zone.write_handle(center);
-                    let policy = handle.state.policy.as_ref().unwrap();
-                    match policy.loader.review.on_reject {
-                        OnReject::Discard => {
-                            handle.get().soft_reject_loaded();
-                        }
-                        OnReject::Halt => {
-                            handle.get().hard_reject_loaded();
-                        }
-                    }
-                }
-            }
-
-            Source::Signed => {
-                {
-                    let mut zone_state = zone.write(center);
-                    let Some(version) = zone_state.signed.get_mut(&zone_serial) else {
-                        // 'on_seek_approval_for_zone_cmd()' should have created
-                        // this.  Since it doesn't exist, the zone is not under
-                        // review.
-
-                        debug!(
-                            "[{unit_name}] Got a review for {zone_name}/{zone_serial}, but it was not pending review"
-                        );
-                        return Err(ZoneReviewError::NotUnderReview);
-                    };
-
-                    // Check that the zone was not already approved.
-                    if matches!(version.review, ZoneVersionReviewState::Approved) {
-                        // This version of the zone is no longer being reviewed.
-                        //
-                        // TODO: Differentiate this from 'NotUnderReview'?
-
-                        return Err(ZoneReviewError::NotUnderReview);
-                    }
-
-                    version.review = new_review_state;
-                }
-                if matches!(decision, ZoneReviewDecision::Approve) {
-                    info!("Signed zone '{zone_name}' with serial {zone_serial} has been approved.");
-                    self.on_signed_zone_approved(center, zone, zone_serial);
-                } else {
-                    error!(
-                        "Signed zone '{zone_name}' with serial {zone_serial} has been rejected."
-                    );
-                    let mut handle = zone.write_handle(center);
-                    let policy = handle.state.policy.as_ref().unwrap();
-                    match policy.signer.review.on_reject {
-                        OnReject::Discard => {
-                            handle.get().soft_reject_signed();
-                        }
-                        OnReject::Halt => {
-                            handle.get().hard_reject_signed();
-                        }
-                    }
-                }
-            }
-
-            Source::Published => unreachable!(),
-        };
-
-        Ok(ZoneReviewOutput {})
     }
 }
 

--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -4,14 +4,10 @@ use std::net::IpAddr;
 use std::pin::Pin;
 use std::process::Stdio;
 use std::sync::Arc;
-use std::time::Duration;
 
 use bytes::Bytes;
-use domain::base::iana::{Class, Opcode};
-use domain::base::{MessageBuilder, Name, Rtype, Serial, ToName};
-use domain::net::client::dgram::Connection;
-use domain::net::client::protocol::UdpConnect;
-use domain::net::client::request::{RequestMessage, SendRequest};
+use domain::base::iana::Class;
+use domain::base::{Name, Serial, ToName};
 use domain::net::server::ConnectionConfig;
 use domain::net::server::buf::VecBufSource;
 use domain::net::server::dgram::{self, DgramServer};
@@ -23,8 +19,7 @@ use domain::net::server::middleware::tsig::TsigMiddlewareSvc;
 use domain::net::server::service::Service;
 use domain::net::server::stream::{self, StreamServer};
 use domain::tsig::{Algorithm, KeyStore};
-use domain::zonetree::StoredName;
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::api::{ZoneReviewDecision, ZoneReviewStatus};
 use crate::center::Center;
@@ -32,11 +27,10 @@ use crate::config::SocketConfig;
 use crate::daemon::SocketProvider;
 use crate::manager::Terminated;
 use crate::manager::record_zone_event;
-use crate::policy::{NameserverCommsPolicy, ReviewMode};
-use crate::server::{LoadedReviewServer, PublicationServer, SignedReviewServer};
+use crate::policy::ReviewMode;
+use crate::server::{LoadedReviewServer, SignedReviewServer};
 use crate::util::AbortOnDrop;
 use crate::zone::{HistoricalEvent, Zone};
-use crate::zonedata::{OldRecord, SoaRecord};
 
 /// The source of a zone server.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -202,55 +196,6 @@ impl ZoneServer {
             Source::Unsigned => "RS",
             Source::Signed => "RS2",
             Source::Published => "PS",
-        }
-    }
-
-    pub fn on_publish_signed_zone(
-        &self,
-        center: &Arc<Center>,
-        zone: &Arc<Zone>,
-        zone_serial: Serial,
-    ) {
-        let unit_name = self.unit_name();
-        let zone_name = &zone.name;
-        info!("[{unit_name}]: Publishing signed zone '{zone_name}' at serial {zone_serial}.",);
-
-        // Move next_min_expiration to min_expiration, and determine policy.
-        let (policy, soa) = {
-            // Use a block to make sure that the lock is clearly dropped.
-            let mut zone_state = zone.write(center);
-
-            // Save as next_min_expiration. After the signed zone is approved
-            // this value should be move to min_expiration.
-            zone_state.min_expiration = zone_state.next_min_expiration;
-            zone_state.next_min_expiration = None;
-
-            (
-                zone_state.policy.clone(),
-                zone_state.storage.signed_review_soa.clone().unwrap(),
-            )
-        };
-
-        // Send NOTIFY if configured to do so.
-        if let Some(policy) = policy {
-            info!(
-                "[{unit_name}]: Found {} NOTIFY targets",
-                policy.server.outbound.send_notify_to.len()
-            );
-            trace!(
-                "NOTIFY targets: {:?}",
-                policy.server.outbound.send_notify_to
-            );
-            if !policy.server.outbound.send_notify_to.is_empty() {
-                let addrs = policy
-                    .server
-                    .outbound
-                    .send_notify_to
-                    .iter()
-                    .filter(|s| s.addr.port() != 0);
-
-                send_notify_to_addrs(zone_name.clone(), soa.clone(), addrs, center);
-            }
         }
     }
 
@@ -461,12 +406,11 @@ impl ZoneServer {
     }
 
     fn on_signed_zone_approved(&self, center: &Arc<Center>, zone: &Arc<Zone>, zone_serial: Serial) {
+        let _ = zone_serial;
+
         {
             zone.write_handle(center).get().approve_signed();
         }
-
-        info!("[CC]: Instructing publication server to publish the signed zone");
-        PublicationServer::publish(center, zone, zone_serial);
     }
 
     async fn process_output(
@@ -589,83 +533,5 @@ impl Notifiable for LoaderNotifier {
         }
 
         Box::pin(std::future::ready(Ok(())))
-    }
-}
-
-pub fn send_notify_to_addrs<'a>(
-    apex_name: StoredName,
-    soa: SoaRecord,
-    notify_set: impl Iterator<Item = &'a NameserverCommsPolicy>,
-    center: &Arc<Center>,
-) {
-    let mut dgram_config = domain::net::client::dgram::Config::new();
-    dgram_config.set_max_parallel(1);
-    dgram_config.set_read_timeout(Duration::from_millis(1000));
-    dgram_config.set_max_retries(1);
-    dgram_config.set_udp_payload_size(Some(1400));
-
-    let mut msg = MessageBuilder::new_vec();
-    msg.header_mut().set_opcode(Opcode::NOTIFY);
-    let mut msg = msg.question();
-    msg.push((apex_name, Rtype::SOA)).unwrap();
-
-    // Include the current zone SOA as an RFC 1996 "unsecure hint" (see
-    // section 3.7) to the receiving nameserver so that it can choose to avoid
-    // sending a SOA query if it deems that it has this version of the zone
-    // already.
-    let mut msg = msg.answer();
-    msg.push(OldRecord::from(soa)).unwrap();
-
-    for nameserver in notify_set {
-        let dgram_config = dgram_config.clone();
-        let req = RequestMessage::new(msg.clone()).unwrap();
-
-        let nameserver = nameserver.clone();
-        let center = center.clone();
-        tokio::spawn(async move {
-            // TODO: Use the connection factory here.
-            let udp_connect = UdpConnect::new(nameserver.addr);
-            let client = Connection::with_config(udp_connect, dgram_config.clone());
-
-            trace!("Sending NOTIFY to nameserver {nameserver}");
-            let span = tracing::trace_span!("auth", addr = %nameserver);
-            let _guard = span.enter();
-
-            // https://datatracker.ietf.org/doc/html/rfc1996
-            //   "4.8 Master Receives a NOTIFY Response from Slave
-            //
-            //    When a master server receives a NOTIFY response, it deletes this
-            //    query from the retry queue, thus completing the "notification
-            //    process" of "this" RRset change to "that" server."
-            //
-            // TODO: We have no retry queue at the moment. Do we need one?
-
-            let tsig_key = {
-                let state = center.state.lock().unwrap();
-                nameserver
-                    .tsig_key_name
-                    .as_ref()
-                    .and_then(|tsig_key_name| state.tsig_store.get(tsig_key_name))
-                    .map(|key| key.inner.clone())
-            };
-
-            if let Some(key) = &tsig_key {
-                debug!(
-                    "Found TSIG key '{}' (algorithm {}) for NOTIFY to {nameserver}",
-                    key.name(),
-                    key.algorithm()
-                );
-            }
-            let res = if let Some(key) = tsig_key {
-                let client = domain::net::client::tsig::Connection::new(key.clone(), client);
-                client.send_request(req.clone()).get_response().await
-            } else {
-                client.send_request(req.clone()).get_response().await
-            };
-
-            if let Err(err) = res {
-                warn!("Unable to send NOTIFY to nameserver {nameserver}: {err}");
-            }
-        });
     }
 }

--- a/src/zone/instance.rs
+++ b/src/zone/instance.rs
@@ -519,4 +519,11 @@ impl SignedInstance {
     pub fn serial(&self) -> Serial {
         self.soa.rdata.serial
     }
+
+    /// The total number of records in this instance.
+    pub fn num_records(&self) -> NonZeroU64 {
+        self.num_generated_records
+            .checked_add(self.num_loaded_records)
+            .unwrap()
+    }
 }

--- a/src/zone/machine.rs
+++ b/src/zone/machine.rs
@@ -2,6 +2,7 @@ use tracing::{info, trace};
 
 use crate::{
     api::ZoneReviewStatus,
+    server::PublicationServer,
     units::zone_signer::SignerError,
     zone::{HistoricalEvent, ZoneHandle},
     zonedata::{
@@ -358,7 +359,7 @@ impl<'a> ZoneHandle<'a> {
 /// # Signed Review operations
 impl<'a> ZoneHandle<'a> {
     pub(crate) fn approve_signed(&mut self) {
-        info!("The signed instance has been approved");
+        info!("The signed instance has been approved; publishing");
 
         self.state.record_event(
             HistoricalEvent::SignedZoneReview {
@@ -440,13 +441,33 @@ impl<'a> ZoneHandle<'a> {
         let viewer = self.storage().finish_signed_persistence(persisted);
 
         self.state.instances.switch();
+        // TODO: Handle this with `Instances`.
+        self.state.min_expiration = self.state.next_min_expiration;
+        self.state.next_min_expiration = None;
 
         self.state.storage.published_soa = viewer.read().map(|r| r.soa().clone());
         self.state.storage.published_loaded_soa = viewer.read().map(|r| r.loaded().soa().clone());
 
+        let serial = self
+            .state
+            .instances
+            .current
+            .as_ref()
+            .unwrap()
+            .signed
+            .serial();
+
+        info!(
+            "Published a signed instance of '{}' with SOA serial {}",
+            self.zone.name,
+            serial.get()
+        );
+
         self.signer().on_publication();
 
         self.storage().start_publishing(viewer);
+
+        PublicationServer::after_publication(self);
     }
 }
 

--- a/src/zone/machine.rs
+++ b/src/zone/machine.rs
@@ -1,12 +1,9 @@
-use std::time::SystemTime;
-
-use domain::base::Serial;
 use tracing::{info, trace};
 
 use crate::{
     api::ZoneReviewStatus,
     units::zone_signer::SignerError,
-    zone::{HistoricalEvent, LastPublished, ZoneHandle},
+    zone::{HistoricalEvent, ZoneHandle},
     zonedata::{
         LoadedZoneBuilder, LoadedZoneBuilt, LoadedZonePersisted, SignedZoneBuilder,
         SignedZoneBuilt, SignedZonePersisted,
@@ -446,40 +443,6 @@ impl<'a> ZoneHandle<'a> {
 
         self.state.storage.published_soa = viewer.read().map(|r| r.soa().clone());
         self.state.storage.published_loaded_soa = viewer.read().map(|r| r.loaded().soa().clone());
-
-        // Compute the total number of records
-        let reader = viewer.read().unwrap();
-        let generated_records = reader.generated_records().len();
-        let loaded_records = reader.loaded().regular_records().len() - 1;
-        let num_records = generated_records + loaded_records;
-
-        let loaded_serial = Serial(
-            self.state
-                .storage
-                .published_loaded_soa
-                .as_ref()
-                .unwrap()
-                .rdata
-                .serial
-                .into(),
-        );
-        let signed_serial = Serial(
-            self.state
-                .storage
-                .published_soa
-                .as_ref()
-                .unwrap()
-                .rdata
-                .serial
-                .into(),
-        );
-        let timestamp = SystemTime::now();
-        self.state.last_published = Some(LastPublished {
-            loaded_serial,
-            signed_serial,
-            timestamp,
-            num_records,
-        });
 
         self.signer().on_publication();
 

--- a/src/zone/machine.rs
+++ b/src/zone/machine.rs
@@ -215,8 +215,6 @@ impl<'a> ZoneHandle<'a> {
             Some(domain::base::Serial(serial.into())),
         );
 
-        self.state.storage.loaded_review_soa = loaded_reviewer.read().map(|r| r.soa().clone());
-
         self.storage().start_loaded_review(loaded_reviewer);
     }
 }
@@ -264,7 +262,6 @@ impl<'a> ZoneHandle<'a> {
         let loaded_reviewer = self.storage().abandon_loaded_review();
         // Abandon the entire upcoming instance.
         self.state.instances.abandon();
-        self.state.storage.loaded_review_soa = loaded_reviewer.read().map(|r| r.soa().clone());
         // Stop serving the abandoned instance.
         self.storage()
             .start_rewinding_loaded_review(loaded_reviewer);
@@ -308,8 +305,6 @@ impl<'a> ZoneHandle<'a> {
         self.state.instances.finish_sign(&built);
 
         let signed_reviewer = self.storage().finish_sign(built);
-        // Update the instance metadata.
-        self.state.storage.signed_review_soa = signed_reviewer.read().map(|r| r.soa().clone());
         // Begin reviewing the prepared instance.
         self.storage().start_signed_review(signed_reviewer);
     }
@@ -329,7 +324,6 @@ impl<'a> ZoneHandle<'a> {
         let loaded_reviewer = self.storage().abandon_sign(builder);
         // Abandon the entire upcoming instance.
         self.state.instances.abandon();
-        self.state.storage.loaded_review_soa = loaded_reviewer.read().map(|r| r.soa().clone());
         // Stop serving the abandoned instance.
         self.storage()
             .start_rewinding_loaded_review(loaded_reviewer);
@@ -349,7 +343,6 @@ impl<'a> ZoneHandle<'a> {
         let loaded_reviewer = self.storage().abandon_sign(builder);
         // Abandon the entire upcoming instance.
         self.state.instances.abandon();
-        self.state.storage.loaded_review_soa = loaded_reviewer.read().map(|r| r.soa().clone());
         // Stop serving the abandoned instance.
         self.storage()
             .start_rewinding_loaded_review(loaded_reviewer);
@@ -406,8 +399,6 @@ impl<'a> ZoneHandle<'a> {
         self.state.instances.abandon();
         // TODO: This should be handled by 'Instances'.
         self.state.next_min_expiration = None;
-        self.state.storage.loaded_review_soa = loaded_reviewer.read().map(|r| r.soa().clone());
-        self.state.storage.signed_review_soa = signed_reviewer.read().map(|r| r.soa().clone());
 
         self.storage()
             .start_rewinding_review(loaded_reviewer, signed_reviewer);
@@ -445,9 +436,6 @@ impl<'a> ZoneHandle<'a> {
         self.state.min_expiration = self.state.next_min_expiration;
         self.state.next_min_expiration = None;
 
-        self.state.storage.published_soa = viewer.read().map(|r| r.soa().clone());
-        self.state.storage.published_loaded_soa = viewer.read().map(|r| r.loaded().soa().clone());
-
         let serial = self
             .state
             .instances
@@ -482,8 +470,6 @@ impl<'a> ZoneHandle<'a> {
                 transition.move_to(ZoneStateMachine::Waiting(waiting));
                 let loaded_reviewer = self.storage().abandon_loaded_review();
                 self.state.instances.abandon();
-                self.state.storage.loaded_review_soa =
-                    loaded_reviewer.read().map(|r| r.soa().clone());
                 self.storage()
                     .start_rewinding_loaded_review(loaded_reviewer);
             }

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -380,12 +380,6 @@ pub struct ZoneState {
     /// serial for the Increment serial policy.
     pub previous_serial: Option<Serial>,
 
-    /// Unsigned versions of the zone.
-    pub unsigned: foldhash::HashMap<Serial, UnsignedZoneVersionState>,
-
-    /// Signed versions of the zone.
-    pub signed: foldhash::HashMap<Serial, SignedZoneVersionState>,
-
     /// Instances of the zone.
     pub instances: Instances,
 
@@ -447,8 +441,6 @@ impl Default for ZoneState {
             key_roll: Default::default(),
             last_signature_refresh: faketime_or_now(),
             previous_serial: Default::default(),
-            unsigned: Default::default(),
-            signed: Default::default(),
             instances: Default::default(),
             history: Default::default(),
             loader: Default::default(),
@@ -457,45 +449,6 @@ impl Default for ZoneState {
             persistence: Default::default(),
         }
     }
-}
-
-/// The state of an unsigned version of a zone.
-#[derive(Clone, Debug)]
-pub struct UnsignedZoneVersionState {
-    /// The review state of the zone version.
-    pub review: ZoneVersionReviewState,
-}
-
-/// The state of a signed version of a zone.
-#[derive(Clone, Debug)]
-pub struct SignedZoneVersionState {
-    /// The serial number of the corresponding unsigned version of the zone.
-    pub unsigned_serial: Serial,
-
-    /// The review state of the zone version.
-    pub review: ZoneVersionReviewState,
-}
-
-/// The review state of a version of a zone.
-#[derive(Clone, Debug, Default)]
-pub enum ZoneVersionReviewState {
-    /// The zone is pending review.
-    ///
-    /// If a review script has been configured, it is running now.  Otherwise,
-    /// the zone must be manually reviewed.
-    #[default]
-    Pending,
-
-    /// The zone has been approved.
-    ///
-    /// This is a terminal state.  The zone may have progressed further through
-    /// the pipeline, so it is no longer possible to reject it.
-    Approved,
-
-    /// The zone has been rejected.
-    ///
-    /// The zone has not yet been approved; it can be approved at any time.
-    Rejected,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -325,9 +325,6 @@ pub struct ZoneState {
     /// operations automatically.
     pub maintenance_mode: bool,
 
-    /// Metadata related to the last published zone version.
-    pub last_published: Option<LastPublished>,
-
     /// An enqueued save of this state.
     ///
     /// The enqueued save operation will persist the current state in a short
@@ -441,7 +438,6 @@ impl Default for ZoneState {
             machine: Default::default(),
             policy: Default::default(),
             maintenance_mode: Default::default(),
-            last_published: Default::default(),
             enqueued_save: Default::default(),
             min_expiration: Default::default(),
             next_min_expiration: Default::default(),
@@ -461,22 +457,6 @@ impl Default for ZoneState {
             persistence: Default::default(),
         }
     }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct LastPublished {
-    pub loaded_serial: Serial,
-    pub signed_serial: Serial,
-
-    /// Time of publication
-    pub timestamp: SystemTime,
-
-    /// Number of records in the signed zone
-    pub num_records: usize,
-    //
-    // TODO: add the size
-    // /// Size in bytes
-    // pub size: usize,
 }
 
 /// The state of an unsigned version of a zone.

--- a/src/zone/state/mod.rs
+++ b/src/zone/state/mod.rs
@@ -85,7 +85,6 @@ impl Spec {
         match self {
             Self::V1(v1::Spec {
                 policy,
-                last_published,
                 instances,
                 source,
                 min_expiration,
@@ -128,7 +127,6 @@ impl Spec {
                 Ok(ZoneState {
                     policy,
                     instances: instances.parse(),
-                    last_published,
                     min_expiration,
                     next_min_expiration,
                     apex_remove,

--- a/src/zone/state/v1.rs
+++ b/src/zone/state/v1.rs
@@ -24,7 +24,7 @@ use crate::policy::file::v1::{NameserverCommsSpec, OutboundSpec};
 use crate::policy::{AutoConfig, DsAlgorithm, KeyParameters};
 use crate::tsig::TsigStore;
 use crate::zone::instance::PersistedInstance;
-use crate::zone::{HistoryItem, Instances, LastPublished, LoadedInstance, SignedInstance};
+use crate::zone::{HistoryItem, Instances, LoadedInstance, SignedInstance};
 use crate::{
     policy::{
         KeyManagerPolicy, LoaderPolicy, PolicyVersion, ReviewPolicy, ServerPolicy,
@@ -46,9 +46,6 @@ pub struct Spec {
     /// The full details of the policy are stored here, as there may be a newer
     /// version of the policy that is not yet in use.
     pub policy: Option<PolicySpec>,
-
-    /// Metadata related to the last published zone version.
-    pub last_published: Option<LastPublished>,
 
     /// Instances of the zone.
     pub instances: InstancesSpec,
@@ -125,7 +122,6 @@ impl Spec {
     pub fn build(zone: &ZoneState) -> Self {
         Self {
             policy: zone.policy.as_ref().map(|p| PolicySpec::build(p)),
-            last_published: zone.last_published.clone(),
             instances: InstancesSpec::build(&zone.instances),
             source: ZoneLoadSourceSpec::build(&zone.loader.source),
             min_expiration: zone.min_expiration,

--- a/src/zone/storage.rs
+++ b/src/zone/storage.rs
@@ -31,7 +31,7 @@ use crate::zonedata::{
     DiffData, LoadedZoneBuilder, LoadedZoneBuilt, LoadedZonePersisted, LoadedZonePersister,
     LoadedZoneRestored, LoadedZoneRestorer, LoadedZoneReviewer, SignedZoneBuilder, SignedZoneBuilt,
     SignedZonePersisted, SignedZonePersister, SignedZoneRestored, SignedZoneRestorer,
-    SignedZoneReviewer, SoaRecord, ZoneCleaner, ZoneDataStorage, ZoneViewer,
+    SignedZoneReviewer, ZoneCleaner, ZoneDataStorage, ZoneViewer,
 };
 use crate::{
     center::Center,
@@ -830,33 +830,6 @@ pub struct StorageState {
     /// passed to [`StorageZoneHandle::abandon_loaded_restoration()`].
     pub restorer: Option<LoadedZoneRestorer>,
 
-    /// The SOA record of the loaded instance of the zone being reviewed, if
-    /// any.
-    //
-    // TODO: This should move into a component of 'ZoneState' tracking the
-    // upcoming zone instance.
-    pub loaded_review_soa: Option<SoaRecord>,
-
-    /// The SOA record of the signed instance of the zone being reviewed, if
-    /// any.
-    //
-    // TODO: This should move into a component of 'ZoneState' tracking the
-    // upcoming zone instance.
-    pub signed_review_soa: Option<SoaRecord>,
-
-    /// The SOA record of the published instance of the zone, if any.
-    //
-    // TODO: This should move into a component of 'ZoneState' tracking the
-    // current i.e. published zone instance.
-    pub published_soa: Option<SoaRecord>,
-
-    /// The SOA record of the loaded instance underlying the published instance
-    /// of the zone, if any.
-    //
-    // TODO: This should move into a component of 'ZoneState' tracking the
-    // current i.e. published zone instance.
-    pub published_loaded_soa: Option<SoaRecord>,
-
     /// Diffs from one serial to another for responding to IXFR requests.
     pub diffs: IxfrZoneDiffs,
 
@@ -875,10 +848,6 @@ impl StorageState {
         Self {
             machine,
             restorer: Some(restorer),
-            loaded_review_soa: None,
-            signed_review_soa: None,
-            published_soa: None,
-            published_loaded_soa: None,
             diffs: Default::default(),
             background_tasks: Default::default(),
         }


### PR DESCRIPTION
This PR makes Cascade use `Instances` (as introduced by #873) and replaces a lot of workarounds we had introduced in lieu of it.

TODO: I would also like to replace the current use of `min_expiration` / `next_min_expiration` and store the relevant data in `Instances`, but #863 should be merged first.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?