### PR TITLE
Log the reason when unable to restore zone state on startup.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -142,13 +142,16 @@ fn main() -> ExitCode {
                 );
                 let zone = match Zone::restore(
                     &config,
-                    name,
+                    name.clone(),
                     &mut state.policies,
                     &state.tsig_store,
                     &metrics,
                 ) {
                     Ok(zone) => zone,
-                    Err(_) => return ExitCode::FAILURE,
+                    Err(err) => {                                                                                                                                                       
+                        error!("Unable to restore zone '{name}': {err}");                                                                                                               
+                        return ExitCode::FAILURE;                                                                                                                                       
+                    }                                                                                                                                                                   
                 };
                 state.zones.insert(ZoneByName(Arc::new(zone)));
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,10 +148,10 @@ fn main() -> ExitCode {
                     &metrics,
                 ) {
                     Ok(zone) => zone,
-                    Err(err) => {                                                                                                                                                       
-                        error!("Unable to restore zone '{name}': {err}");                                                                                                               
-                        return ExitCode::FAILURE;                                                                                                                                       
-                    }                                                                                                                                                                   
+                    Err(err) => {
+                        error!("Unable to restore zone '{name}': {err}");
+                        return ExitCode::FAILURE;
+                    }
                 };
                 state.zones.insert(ZoneByName(Arc::new(zone)));
             }


### PR DESCRIPTION
Otherwise `cascaded` exits without any indication why.