### PR TITLE
Refactor computation of signed serial

### DIFF
--- a/src/signer/full.rs
+++ b/src/signer/full.rs
@@ -92,7 +92,7 @@ pub fn sign_zone(
         .expect("a non-empty loaded instance must exist");
     let loaded_serial = loaded.soa().rdata.serial;
 
-    let serial: Serial = super::update_soa_serial(
+    let serial = super::next_signed_soa_serial(
         policy.signer.serial_policy,
         Serial::from(loaded_serial.0.get()),
         previous_serial,

--- a/src/signer/full.rs
+++ b/src/signer/full.rs
@@ -35,7 +35,6 @@ use domain::{
     },
     rdata::ZoneRecordData,
 };
-use jiff::{Timestamp as JiffTimestamp, Zoned, tz::TimeZone};
 use rayon::{
     iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelExtend, ParallelIterator},
     slice::ParallelSliceMut,
@@ -45,7 +44,7 @@ use tracing::{debug, info};
 use crate::{
     center::Center,
     manager::record_zone_event,
-    policy::{PolicyVersion, SignerDenialPolicy, SignerSerialPolicy},
+    policy::{PolicyVersion, SignerDenialPolicy},
     signer::{
         SigningTrigger,
         incremental::LocalState,
@@ -93,49 +92,12 @@ pub fn sign_zone(
         .expect("a non-empty loaded instance must exist");
     let loaded_serial = loaded.soa().rdata.serial;
 
-    let serial: Serial = match policy.signer.serial_policy {
-        SignerSerialPolicy::Keep => {
-            let loaded_serial = Serial::from(Into::<u32>::into(loaded_serial));
-            if let Some(previous_serial) = previous_serial
-                && loaded_serial <= previous_serial
-            {
-                return Err(SignerError::KeepSerialPolicyViolated);
-            }
+    let serial: Serial = super::update_soa_serial(
+        policy.signer.serial_policy,
+        Serial::from(loaded_serial.0.get()),
+        previous_serial,
+    )?;
 
-            loaded_serial
-        }
-        SignerSerialPolicy::Counter => {
-            // Always increment the serial number, ignore the serial
-            // number in the unsigned zone.
-            let previous_serial = previous_serial.unwrap_or(Serial::from(0));
-            previous_serial.add(1)
-        }
-        SignerSerialPolicy::UnixTime => {
-            let mut serial = Serial::now();
-            if let Some(previous_serial) = previous_serial
-                && serial <= previous_serial
-            {
-                serial = previous_serial.add(1);
-            }
-
-            serial
-        }
-        SignerSerialPolicy::DateCounter => {
-            let ts = JiffTimestamp::now();
-            let zone = Zoned::new(ts, TimeZone::UTC);
-            let serial =
-                ((zone.year() as u32 * 100 + zone.month() as u32) * 100 + zone.day() as u32) * 100;
-            let mut serial: Serial = serial.into();
-
-            if let Some(previous_serial) = previous_serial
-                && serial <= previous_serial
-            {
-                serial = previous_serial.add(1);
-            }
-
-            serial
-        }
-    };
     local_state.previous_serial = Some(serial);
     let serial = NewBaseSerial::from(serial.into_int());
     let new_soa = {

--- a/src/signer/incremental.rs
+++ b/src/signer/incremental.rs
@@ -1100,7 +1100,7 @@ impl WorkSpace<'_> {
         let loaded_serial = zone_soa.serial();
         let previous_serial = self.local_state.previous_serial;
 
-        let signed_serial = super::update_soa_serial(
+        let signed_serial = super::next_signed_soa_serial(
             self.policy.signer.serial_policy,
             loaded_serial,
             previous_serial,

--- a/src/signer/incremental.rs
+++ b/src/signer/incremental.rs
@@ -13,9 +13,7 @@ use domain::base::iana::{Class, ZonemdAlgorithm, ZonemdScheme};
 use domain::base::name::FlattenInto;
 use domain::base::rdata::ComposeRecordData;
 use domain::base::wire::Composer;
-use domain::base::{
-    CanonicalOrd, Name, NameBuilder, Record, Rtype, Serial as DomainSerial, ToName, Ttl,
-};
+use domain::base::{CanonicalOrd, Name, NameBuilder, Record, Rtype, ToName, Ttl};
 use domain::dep::octseq::OctetsFrom;
 use domain::dep::octseq::builder::with_infallible;
 use domain::dnssec::common::nsec3_hash;
@@ -37,8 +35,6 @@ use domain::utils::base32;
 use domain::utils::dst::UnsizedCopy;
 use domain::zonefile::inplace::Entry;
 use domain::zonetree::StoredRecord;
-use jiff::tz::TimeZone;
-use jiff::{Timestamp as JiffTimestamp, Zoned};
 use rayon::slice::ParallelSliceMut;
 use ring::digest;
 use tokio::time::Instant;
@@ -47,7 +43,7 @@ use tracing::error;
 
 use crate::center::Center;
 use crate::manager::record_zone_event;
-use crate::policy::{PolicyVersion, SignerDenialPolicy, SignerSerialPolicy};
+use crate::policy::{PolicyVersion, SignerDenialPolicy};
 use crate::signer::SigningTrigger;
 use crate::signer::keys::ZoneSigningKeys;
 use crate::signer::status::SigningStatusPerZone;
@@ -1097,134 +1093,37 @@ impl WorkSpace<'_> {
     }
 
     fn update_soa_serial(&mut self, old_soa: &Zrd) -> Result<Zrd, SignerError> {
-        // Implement SOA serial policies. There are four policies:
-        // 1) Keep. Copy the serial from the unsigned zone. Refuse to sign
-        //    if the serial did not change.
-        // 2) Increment. Copy the serial from the unsigned zone but increment
-        //    the serial if the zone needs to be signed an the serial in
-        //    the unsigned zone did not change.
-        // 3) Unix timestamp. The current time in Unix seconds. Increment if
-        //    that does not result in a higher serial.
-        // 4) Broken down time (YYYYMMDDnn). The current day plus a serial
-        //    number. Implies increment to generate different serial numbers
-        //    over a day.
-
         let ZoneRecordData::Soa(zone_soa) = old_soa.data() else {
             unreachable!();
         };
 
-        let curr_previous_serial = &self.local_state.previous_serial;
-        match self.policy.signer.serial_policy {
-            SignerSerialPolicy::Keep => {
-                if let Some(previous_serial) = curr_previous_serial
-                    && zone_soa.serial() <= *previous_serial
-                {
-                    return Err(SignerError::KeepSerialPolicyViolated);
-                }
+        let loaded_serial = zone_soa.serial();
+        let previous_serial = self.local_state.previous_serial;
 
-                // Save the new SOA serial.
-                self.local_state.previous_serial = Some(zone_soa.serial());
-                Ok(old_soa.clone())
-            }
-            SignerSerialPolicy::Counter => {
-                // Always increment the serial number, ignore the serial
-                // number in the unsigned zone.
-                let previous_serial = if let Some(serial) = curr_previous_serial {
-                    *serial
-                } else {
-                    DomainSerial::from(0)
-                };
+        let signed_serial = super::update_soa_serial(
+            self.policy.signer.serial_policy,
+            loaded_serial,
+            previous_serial,
+        )?;
 
-                let serial = previous_serial.add(1);
+        let new_soa = ZoneRecordData::Soa(Soa::new(
+            zone_soa.mname().clone(),
+            zone_soa.rname().clone(),
+            signed_serial,
+            zone_soa.refresh(),
+            zone_soa.retry(),
+            zone_soa.expire(),
+            zone_soa.minimum(),
+        ));
 
-                // Save the new SOA serial.
-                self.local_state.previous_serial = Some(serial);
+        let record = RecordFullCmp::new(
+            old_soa.owner().clone(),
+            old_soa.class(),
+            old_soa.ttl(),
+            new_soa,
+        );
 
-                let new_soa = ZoneRecordData::Soa(Soa::new(
-                    zone_soa.mname().clone(),
-                    zone_soa.rname().clone(),
-                    serial,
-                    zone_soa.refresh(),
-                    zone_soa.retry(),
-                    zone_soa.expire(),
-                    zone_soa.minimum(),
-                ));
-                let record = RecordFullCmp::new(
-                    old_soa.owner().clone(),
-                    old_soa.class(),
-                    old_soa.ttl(),
-                    new_soa,
-                );
-
-                Ok(record)
-            }
-            SignerSerialPolicy::UnixTime => {
-                let mut serial = DomainSerial::now();
-                if let Some(previous_serial) = curr_previous_serial
-                    && serial <= *previous_serial
-                {
-                    serial = previous_serial.add(1);
-                }
-
-                // Save the new SOA serial.
-                self.local_state.previous_serial = Some(serial);
-
-                let new_soa = ZoneRecordData::Soa(Soa::new(
-                    zone_soa.mname().clone(),
-                    zone_soa.rname().clone(),
-                    serial,
-                    zone_soa.refresh(),
-                    zone_soa.retry(),
-                    zone_soa.expire(),
-                    zone_soa.minimum(),
-                ));
-
-                let record = RecordFullCmp::new(
-                    old_soa.owner().clone(),
-                    old_soa.class(),
-                    old_soa.ttl(),
-                    new_soa,
-                );
-
-                Ok(record)
-            }
-            SignerSerialPolicy::DateCounter => {
-                let ts = JiffTimestamp::now();
-                let zone = Zoned::new(ts, TimeZone::UTC);
-                let serial = ((zone.year() as u32 * 100 + zone.month() as u32) * 100
-                    + zone.day() as u32)
-                    * 100;
-                let mut serial: DomainSerial = serial.into();
-
-                if let Some(previous_serial) = curr_previous_serial
-                    && serial <= *previous_serial
-                {
-                    serial = previous_serial.add(1);
-                }
-
-                // Save the new SOA serial.
-                self.local_state.previous_serial = Some(serial);
-
-                let new_soa = ZoneRecordData::Soa(Soa::new(
-                    zone_soa.mname().clone(),
-                    zone_soa.rname().clone(),
-                    serial,
-                    zone_soa.refresh(),
-                    zone_soa.retry(),
-                    zone_soa.expire(),
-                    zone_soa.minimum(),
-                ));
-
-                let record = RecordFullCmp::new(
-                    old_soa.owner().clone(),
-                    old_soa.class(),
-                    old_soa.ttl(),
-                    new_soa,
-                );
-
-                Ok(record)
-            }
-        }
+        Ok(record)
     }
 
     pub fn sign_pass_through(&mut self) -> Result<(), SignerError> {

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -22,10 +22,13 @@ use std::{
     sync::{Arc, RwLock},
 };
 
+use domain::base::Serial;
+use jiff::{Timestamp as JiffTimestamp, Zoned, tz::TimeZone};
 use tracing::{debug, error};
 
 use crate::{
     center::Center,
+    policy::SignerSerialPolicy,
     signer::{queue::SigningPermit, status::SigningStatusPerZone},
     units::zone_signer::SignerError,
     zone::{HistoricalEvent, Zone},
@@ -130,6 +133,69 @@ fn sign(
                 },
                 None, // TODO
             );
+        }
+    }
+}
+
+/// Implement SOA serial policies.
+///
+/// There are four policies:
+///
+/// 1) Keep. Copy the serial from the unsigned zone. Refuse to sign
+///    if the serial did not change.
+/// 2) Increment. Copy the serial from the unsigned zone but increment
+///    the serial if the zone needs to be signed an the serial in
+///    the unsigned zone did not change.
+/// 3) Unix timestamp. The current time in Unix seconds. Increment if
+///    that does not result in a higher serial.
+/// 4) Broken down time (YYYYMMDDnn). The current day plus a serial
+///    number. Implies increment to generate different serial numbers
+///    over a day.
+fn update_soa_serial(
+    policy: SignerSerialPolicy,
+    loaded_serial: Serial,
+    previous_serial: Option<Serial>,
+) -> Result<Serial, SignerError> {
+    match policy {
+        SignerSerialPolicy::Keep => {
+            if let Some(previous_serial) = previous_serial
+                && loaded_serial <= previous_serial
+            {
+                return Err(SignerError::KeepSerialPolicyViolated);
+            }
+
+            Ok(loaded_serial)
+        }
+        SignerSerialPolicy::Counter => {
+            // Always increment the serial number, ignore the serial
+            // number in the unsigned zone.
+            let previous_serial = previous_serial.unwrap_or(Serial::from(0));
+            Ok(previous_serial.add(1))
+        }
+        SignerSerialPolicy::UnixTime => {
+            let mut serial = Serial::now();
+            if let Some(previous_serial) = previous_serial
+                && serial <= previous_serial
+            {
+                serial = previous_serial.add(1);
+            }
+
+            Ok(serial)
+        }
+        SignerSerialPolicy::DateCounter => {
+            let ts = JiffTimestamp::now();
+            let zone = Zoned::new(ts, TimeZone::UTC);
+            let serial =
+                ((zone.year() as u32 * 100 + zone.month() as u32) * 100 + zone.day() as u32) * 100;
+            let mut serial: Serial = serial.into();
+
+            if let Some(previous_serial) = previous_serial
+                && serial <= previous_serial
+            {
+                serial = previous_serial.add(1);
+            }
+
+            Ok(serial)
         }
     }
 }

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -137,7 +137,7 @@ fn sign(
     }
 }
 
-/// Implement SOA serial policies.
+/// Compute the SOA serial for a signed zone.
 ///
 /// There are four policies:
 ///
@@ -151,7 +151,7 @@ fn sign(
 /// 4) Broken down time (YYYYMMDDnn). The current day plus a serial
 ///    number. Implies increment to generate different serial numbers
 ///    over a day.
-fn update_soa_serial(
+fn next_signed_soa_serial(
     policy: SignerSerialPolicy,
     loaded_serial: Serial,
     previous_serial: Option<Serial>,


### PR DESCRIPTION
There were two places where the signed serial was computed: in `incremental.rs` and `full.rs`. To ensure that these stay in sync I merged them into a function defined in `src/signer/mod.rs

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [ ] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
