### PR TITLE
Report signing step to zone status

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -528,7 +528,6 @@ pub enum ZoneReviewStatus {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SigningReport {
-    pub current_action: String,
     pub stage_report: SigningStageReport,
 }
 

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -637,16 +637,6 @@ pub struct SigningInProgressReport {
     pub loaded_serial: Serial,
     pub signed_serial: Serial,
     pub started_at: SystemTime,
-    pub unsigned_rr_count: Option<usize>,
-    pub walk_time: Option<Duration>,
-    pub sort_time: Option<Duration>,
-    pub denial_rr_count: Option<usize>,
-    pub denial_time: Option<Duration>,
-    pub rrsig_count: Option<usize>,
-    pub rrsig_reused_count: Option<usize>,
-    pub rrsig_time: Option<Duration>,
-    pub total_time: Option<Duration>,
-    pub threads_used: Option<usize>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -655,18 +645,7 @@ pub struct SigningFinishedReport {
     pub loaded_serial: Serial,
     pub signed_serial: Serial,
     pub started_at: SystemTime,
-    pub unsigned_rr_count: usize,
-    pub walk_time: Duration,
-    pub sort_time: Duration,
-    pub denial_rr_count: usize,
-    pub denial_time: Duration,
-    pub rrsig_count: usize,
-    pub rrsig_reused_count: usize,
-    pub rrsig_time: Duration,
-    pub total_time: Duration,
-    pub threads_used: usize,
     pub finished_at: SystemTime,
-    pub succeeded: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -597,6 +597,13 @@ impl SigningStep {
         }
     }
 
+    pub fn signing_strategy(&self) -> &str {
+        match self {
+            SigningStep::Full(_) => "full",
+            SigningStep::Incremental(_) => "incremental",
+        }
+    }
+
     pub fn get_current_step(&self) -> usize {
         match self {
             SigningStep::Full(s) => match s {

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -555,9 +555,70 @@ pub struct SigningRequestedReport {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum SigningStep {
+    Full(FullSigningStep),
+    Incremental(IncrementalSigningStep),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum FullSigningStep {
+    CollectingRecords,
+    FetchingKeys,
+    SortingRecords,
+    GeneratingDenialRecords,
+    GeneratingSignatureRecords,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum IncrementalSigningStep {
+    SigningIncrementally,
+}
+
+impl SigningStep {
+    pub fn as_str(&self) -> &str {
+        match self {
+            SigningStep::Full(s) => match s {
+                FullSigningStep::CollectingRecords => "collecting records",
+                FullSigningStep::FetchingKeys => "fetching keys",
+                FullSigningStep::SortingRecords => "sorting records",
+                FullSigningStep::GeneratingDenialRecords => "generating denial records",
+                FullSigningStep::GeneratingSignatureRecords => "generating signature records",
+            },
+            SigningStep::Incremental(s) => match s {
+                IncrementalSigningStep::SigningIncrementally => "signing incrementally",
+            },
+        }
+    }
+
+    pub fn get_current_step(&self) -> usize {
+        match self {
+            SigningStep::Full(s) => match s {
+                FullSigningStep::CollectingRecords => 1,
+                FullSigningStep::FetchingKeys => 2,
+                FullSigningStep::SortingRecords => 3,
+                FullSigningStep::GeneratingDenialRecords => 4,
+                FullSigningStep::GeneratingSignatureRecords => 5,
+            },
+            SigningStep::Incremental(s) => match s {
+                IncrementalSigningStep::SigningIncrementally => 1,
+            },
+        }
+    }
+
+    pub fn get_total_steps(&self) -> usize {
+        match self {
+            SigningStep::Full(_) => 5,
+            SigningStep::Incremental(_) => 1,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SigningInProgressReport {
+    pub step: SigningStep,
     pub requested_at: SystemTime,
-    pub zone_serial: Serial,
+    pub loaded_serial: Serial,
+    pub signed_serial: Serial,
     pub started_at: SystemTime,
     pub unsigned_rr_count: Option<usize>,
     pub walk_time: Option<Duration>,
@@ -574,7 +635,8 @@ pub struct SigningInProgressReport {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SigningFinishedReport {
     pub requested_at: SystemTime,
-    pub zone_serial: Serial,
+    pub loaded_serial: Serial,
+    pub signed_serial: Serial,
     pub started_at: SystemTime,
     pub unsigned_rr_count: usize,
     pub walk_time: Duration,

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -570,7 +570,10 @@ pub enum FullSigningStep {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum IncrementalSigningStep {
-    SigningIncrementally,
+    CollectingRecords,
+    GeneratingSignatures,
+    GeneratingDiffs,
+    DeterminingMinExpirationTime,
 }
 
 impl SigningStep {
@@ -584,7 +587,12 @@ impl SigningStep {
                 FullSigningStep::GeneratingSignatureRecords => "generating signature records",
             },
             SigningStep::Incremental(s) => match s {
-                IncrementalSigningStep::SigningIncrementally => "signing incrementally",
+                IncrementalSigningStep::CollectingRecords => "collecting records",
+                IncrementalSigningStep::GeneratingSignatures => "generating signatures",
+                IncrementalSigningStep::GeneratingDiffs => "generating diffs",
+                IncrementalSigningStep::DeterminingMinExpirationTime => {
+                    "determining min expiration time"
+                }
             },
         }
     }
@@ -599,7 +607,10 @@ impl SigningStep {
                 FullSigningStep::GeneratingSignatureRecords => 5,
             },
             SigningStep::Incremental(s) => match s {
-                IncrementalSigningStep::SigningIncrementally => 1,
+                IncrementalSigningStep::CollectingRecords => 1,
+                IncrementalSigningStep::GeneratingSignatures => 2,
+                IncrementalSigningStep::GeneratingDiffs => 3,
+                IncrementalSigningStep::DeterminingMinExpirationTime => 4,
             },
         }
     }
@@ -607,7 +618,7 @@ impl SigningStep {
     pub fn get_total_steps(&self) -> usize {
         match self {
             SigningStep::Full(_) => 5,
-            SigningStep::Incremental(_) => 1,
+            SigningStep::Incremental(_) => 4,
         }
     }
 }

--- a/crates/cli/src/commands/status.rs
+++ b/crates/cli/src/commands/status.rs
@@ -105,16 +105,16 @@ impl Status {
                     println!("  {:>2}:   {:<25} {:<16} Action", "#", "When", "Zone");
                     for (i, report) in response.signing_queue.iter().enumerate() {
                         let zone_name = report.zone_name.to_string();
-                        let action = &report.signing_report.current_action;
-                        let (colour, state, when) = match &report.signing_report.stage_report {
+                        let (colour, state, when, step) = match &report.signing_report.stage_report
+                        {
                             SigningStageReport::Requested(r) => {
-                                (ansi::GRAY, "\u{23F8}", r.requested_at)
+                                (ansi::GRAY, "\u{23F8}", r.requested_at, "requested")
                             }
                             SigningStageReport::InProgress(r) => {
-                                (ansi::YELLOW, "\u{23F5}", r.started_at)
+                                (ansi::YELLOW, "\u{23F5}", r.started_at, r.step.as_str())
                             }
                             SigningStageReport::Finished(r) => {
-                                (ansi::GREEN, "\u{2714}", r.finished_at)
+                                (ansi::GREEN, "\u{2714}", r.finished_at, "finished")
                             }
                         };
                         let when = jiff::Timestamp::try_from(when)
@@ -122,7 +122,7 @@ impl Status {
                             .round(jiff::Unit::Second)
                             .unwrap();
                         println!(
-                            "  {i:>2}: {colour}{state}{} {when:<25} {zone_name:<16} {action}",
+                            "  {i:>2}: {colour}{state}{} {when:<25} {zone_name:<16} {step}",
                             ansi::RESET
                         );
                     }

--- a/crates/cli/src/commands/zone.rs
+++ b/crates/cli/src/commands/zone.rs
@@ -865,15 +865,19 @@ fn print_sign_phase(
             Some(SigningStageReport::Finished(r)) => Some(r.started_at),
         };
 
-        let step = match &signing_report.as_ref().map(|r| &r.stage_report) {
-            None => "step: not started yet".into(),
-            Some(SigningStageReport::Requested(_)) => "step: not started yet".into(),
+        let (strategy, step) = match &signing_report.as_ref().map(|r| &r.stage_report) {
+            None => ("not started yet", "step: not started yet".into()),
+            Some(SigningStageReport::Requested(_)) => {
+                ("not started yet", "step: not started yet".into())
+            }
             Some(SigningStageReport::InProgress(SigningInProgressReport { step, .. })) => {
                 let step_num = step.get_current_step();
                 let step_total = step.get_total_steps();
-                format!("step {step_num}/{step_total}: {}", step.as_str())
+                let strategy = step.signing_strategy();
+                let step = format!("step {step_num}/{step_total}: {}", step.as_str());
+                (strategy, step)
             }
-            Some(SigningStageReport::Finished(_)) => "step: finished".into(),
+            Some(SigningStageReport::Finished(_)) => ("finished", "step: finished".into()),
         };
 
         let unsigned_serial = serial_to_string(unsigned_serial);
@@ -887,6 +891,7 @@ fn print_sign_phase(
         println!("  {Ongoing} sign{short_signed_serial}");
         println!("  |   loaded serial: {unsigned_serial}");
         println!("  |   signed serial: {signed_serial}");
+        println!("  |   strategy: {strategy}");
         println!("  |   {step}");
         println!(
             "  |   start time: {}",

--- a/crates/cli/src/commands/zone.rs
+++ b/crates/cli/src/commands/zone.rs
@@ -725,12 +725,7 @@ pub fn print_status(zone: &ZoneStatus, policy: &PolicyInfo) {
         current,
         &zone.unsigned_review_addr,
     );
-    print_sign_phase(
-        current,
-        zone.unsigned_serial,
-        zone.signed_serial,
-        &zone.signing_report,
-    );
+    print_sign_phase(current, zone.unsigned_serial, &zone.signing_report);
     print_signed_review_phase(
         &zone.name,
         zone.signed_serial,
@@ -849,9 +844,14 @@ fn print_loaded_review_phase(
 fn print_sign_phase(
     current: Progress,
     unsigned_serial: Option<Serial>,
-    signed_serial: Option<Serial>,
     signing_report: &Option<SigningReport>,
 ) {
+    let signed_serial = signing_report.as_ref().and_then(|r| match &r.stage_report {
+        SigningStageReport::Requested(_) => None,
+        SigningStageReport::InProgress(s) => Some(s.signed_serial),
+        SigningStageReport::Finished(s) => Some(s.signed_serial),
+    });
+
     if current < Progress::Signing {
         println!("  {Pending} sign");
     } else if current > Progress::Signing {
@@ -864,6 +864,18 @@ fn print_sign_phase(
             Some(SigningStageReport::Requested(_)) => None,
             Some(SigningStageReport::Finished(r)) => Some(r.started_at),
         };
+
+        let step = match &signing_report.as_ref().map(|r| &r.stage_report) {
+            None => "step: not started yet".into(),
+            Some(SigningStageReport::Requested(_)) => "step: not started yet".into(),
+            Some(SigningStageReport::InProgress(SigningInProgressReport { step, .. })) => {
+                let step_num = step.get_current_step();
+                let step_total = step.get_total_steps();
+                format!("step {step_num}/{step_total}: {}", step.as_str())
+            }
+            Some(SigningStageReport::Finished(_)) => "step: finished".into(),
+        };
+
         let unsigned_serial = serial_to_string(unsigned_serial);
 
         let short_signed_serial = if let Some(signed_serial) = signed_serial {
@@ -875,6 +887,7 @@ fn print_sign_phase(
         println!("  {Ongoing} sign{short_signed_serial}");
         println!("  |   loaded serial: {unsigned_serial}");
         println!("  |   signed serial: {signed_serial}");
+        println!("  |   {step}");
         println!(
             "  |   start time: {}",
             to_rfc3339_ago(start_time, "<not started yet>")

--- a/src/signer/full.rs
+++ b/src/signer/full.rs
@@ -125,7 +125,6 @@ pub fn sign_zone(
         let mut status = status.write().unwrap();
         // Record the start of signing for this zone.
         status.status.start(loaded_serial, serial).unwrap();
-        status.current_action = "Collecting records to sign".to_string();
         status.step = SigningStep::Full(FullSigningStep::CollectingRecords);
     }
 
@@ -153,7 +152,6 @@ pub fn sign_zone(
     debug!("Reading dnst keyset DNSKEY RRs and RRSIG RRs");
     {
         let mut status = status.write().unwrap();
-        status.current_action = "Fetching apex RRs from the key manager".to_string();
         status.step = SigningStep::Full(FullSigningStep::FetchingKeys);
     }
     // Read the DNSKEY RRs and DNSKEY RRSIG RR from the keyset state.
@@ -207,7 +205,6 @@ pub fn sign_zone(
     debug!("[ZS]: Sorting collected records for zone '{zone_name}'.");
     {
         let mut status = status.write().unwrap();
-        status.current_action = "Sorting records".to_string();
         status.step = SigningStep::Full(FullSigningStep::SortingRecords);
     }
     let sort_start = Instant::now();
@@ -230,7 +227,6 @@ pub fn sign_zone(
     debug!("[ZS]: Generating denial records for zone '{zone_name}'.");
     {
         let mut status = status.write().unwrap();
-        status.current_action = "Generating denial records".to_string();
         status.step = SigningStep::Full(FullSigningStep::GeneratingDenialRecords);
     }
     let denial_start = Instant::now();
@@ -302,7 +298,6 @@ pub fn sign_zone(
     debug!("[ZS]: Generating RRSIG records.");
     {
         let mut status = status.write().unwrap();
-        status.current_action = "Generating signature records".to_string();
         status.step = SigningStep::Full(FullSigningStep::GeneratingSignatureRecords);
     }
 

--- a/src/signer/full.rs
+++ b/src/signer/full.rs
@@ -178,7 +178,7 @@ pub fn sign_zone(
 
     debug!("Loading dnst keyset signing keys");
     // Load the signing keys indicated by the keyset state.
-    let signing_keys = ZoneSigningKeys::load(center, zone, &state, &status)?;
+    let signing_keys = ZoneSigningKeys::load(center, zone, &state)?;
 
     // Save the current zone signing keys and clear key_roll
     let mut key_tags = HashSet::new();

--- a/src/signer/full.rs
+++ b/src/signer/full.rs
@@ -49,7 +49,7 @@ use crate::{
         SigningTrigger,
         incremental::LocalState,
         keys::ZoneSigningKeys,
-        status::{FullSigningStep, SigningStatusPerZone, SigningStep, ZoneSigningStatus},
+        status::{FullSigningStep, SigningStatusPerZone, SigningStep},
     },
     units::{
         key_manager::mk_dnst_keyset_state_file_path,
@@ -138,16 +138,6 @@ pub fn sign_zone(
         .collect::<Vec<_>>();
     records.push(new_soa.clone().into());
     let walk_time = walk_start.elapsed();
-    let unsigned_rr_count = records.len();
-
-    {
-        let mut v = status.write().unwrap();
-        let v2 = &mut v.status;
-        if let ZoneSigningStatus::InProgress(s) = v2 {
-            s.unsigned_rr_count = Some(unsigned_rr_count);
-            s.walk_time = Some(walk_time);
-        }
-    }
 
     debug!("Reading dnst keyset DNSKEY RRs and RRSIG RRs");
     {
@@ -213,14 +203,6 @@ pub fn sign_zone(
     let sort_time = sort_start.elapsed();
     let unsigned_rr_count = records.len();
 
-    {
-        let mut v = status.write().unwrap();
-        let v2 = &mut v.status;
-        if let ZoneSigningStatus::InProgress(s) = v2 {
-            s.sort_time = Some(sort_time);
-        }
-    }
-
     //
     // Generate NSEC(3) RRs.
     //
@@ -278,15 +260,6 @@ pub fn sign_zone(
     let denial_time = denial_start.elapsed();
     let denial_rr_count = unsigned_records.len() - unsigned_rr_count;
 
-    {
-        let mut v = status.write().unwrap();
-        let v2 = &mut v.status;
-        if let ZoneSigningStatus::InProgress(s) = v2 {
-            s.denial_rr_count = Some(denial_rr_count);
-            s.denial_time = Some(denial_time);
-        }
-    }
-
     //
     // Generate RRSIG RRs concurrently.
     //
@@ -304,14 +277,6 @@ pub fn sign_zone(
     // TODO: Configure Rayon's thread pool to set the number of threads. By
     // default, it relies on 'std::thread::available_parallelism()'.
     let parallelism = rayon::current_num_threads();
-
-    {
-        let mut v = status.write().unwrap();
-        let v2 = &mut v.status;
-        if let ZoneSigningStatus::InProgress(s) = v2 {
-            s.threads_used = Some(parallelism);
-        }
-    }
 
     let generation_start = Instant::now();
 
@@ -424,14 +389,7 @@ pub fn sign_zone(
 
     {
         let mut v = status.write().unwrap();
-        let v2 = &mut v.status;
-        if let ZoneSigningStatus::InProgress(s) = v2 {
-            s.rrsig_count = Some(total_signatures);
-            s.rrsig_reused_count = Some(0); // Not implemented yet
-            s.rrsig_time = Some(generation_time);
-            s.total_time = Some(total_time);
-        }
-        v.status.finish(true);
+        v.status.finish();
     }
 
     // Log signing statistics.

--- a/src/signer/full.rs
+++ b/src/signer/full.rs
@@ -49,7 +49,7 @@ use crate::{
         SigningTrigger,
         incremental::LocalState,
         keys::ZoneSigningKeys,
-        status::{SigningStatusPerZone, ZoneSigningStatus},
+        status::{FullSigningStep, SigningStatusPerZone, SigningStep, ZoneSigningStatus},
     },
     units::{
         key_manager::mk_dnst_keyset_state_file_path,
@@ -113,18 +113,6 @@ pub fn sign_zone(
     );
 
     //
-    // Record the start of signing for this zone.
-    //
-    {
-        status
-            .write()
-            .unwrap()
-            .status
-            .start(loaded_serial)
-            .map_err(|_| SignerError::InternalError("Invalid status".to_string()))?;
-    }
-
-    //
     // Create a signing configuration.
     //
     let signing_config = signing_config(&policy)?;
@@ -133,7 +121,14 @@ pub fn sign_zone(
     //
     // Convert zone records into a form we can sign.
     //
-    status.write().unwrap().current_action = "Collecting records to sign".to_string();
+    {
+        let mut status = status.write().unwrap();
+        // Record the start of signing for this zone.
+        status.status.start(loaded_serial, serial).unwrap();
+        status.current_action = "Collecting records to sign".to_string();
+        status.step = SigningStep::Full(FullSigningStep::CollectingRecords);
+    }
+
     debug!("[ZS]: Collecting records to sign for zone '{zone_name}'.");
     let walk_start = Instant::now();
     let mut records = loaded
@@ -156,7 +151,11 @@ pub fn sign_zone(
     }
 
     debug!("Reading dnst keyset DNSKEY RRs and RRSIG RRs");
-    status.write().unwrap().current_action = "Fetching apex RRs from the key manager".to_string();
+    {
+        let mut status = status.write().unwrap();
+        status.current_action = "Fetching apex RRs from the key manager".to_string();
+        status.step = SigningStep::Full(FullSigningStep::FetchingKeys);
+    }
     // Read the DNSKEY RRs and DNSKEY RRSIG RR from the keyset state.
     let state_path = mk_dnst_keyset_state_file_path(&center.config.keys_dir, &zone.name);
     let state = std::fs::read_to_string(&state_path)
@@ -206,7 +205,11 @@ pub fn sign_zone(
     // Sort them into DNSSEC order ready for NSEC(3) generation.
     //
     debug!("[ZS]: Sorting collected records for zone '{zone_name}'.");
-    status.write().unwrap().current_action = "Sorting records".to_string();
+    {
+        let mut status = status.write().unwrap();
+        status.current_action = "Sorting records".to_string();
+        status.step = SigningStep::Full(FullSigningStep::SortingRecords);
+    }
     let sort_start = Instant::now();
     // Note: This may briefly use lots of CPU and many CPU cores.
     records.par_sort_by(CanonicalOrd::canonical_cmp);
@@ -225,7 +228,11 @@ pub fn sign_zone(
     // Generate NSEC(3) RRs.
     //
     debug!("[ZS]: Generating denial records for zone '{zone_name}'.");
-    status.write().unwrap().current_action = "Generating denial records".to_string();
+    {
+        let mut status = status.write().unwrap();
+        status.current_action = "Generating denial records".to_string();
+        status.step = SigningStep::Full(FullSigningStep::GeneratingDenialRecords);
+    }
     let denial_start = Instant::now();
     match &signing_config.denial {
         DenialConfig::AlreadyPresent => {}
@@ -293,7 +300,11 @@ pub fn sign_zone(
     // mpsc::channel and accumulates them into the signed zone.
     //
     debug!("[ZS]: Generating RRSIG records.");
-    status.write().unwrap().current_action = "Generating signature records".to_string();
+    {
+        let mut status = status.write().unwrap();
+        status.current_action = "Generating signature records".to_string();
+        status.step = SigningStep::Full(FullSigningStep::GeneratingSignatureRecords);
+    }
 
     // TODO: Configure Rayon's thread pool to set the number of threads. By
     // default, it relies on 'std::thread::available_parallelism()'.

--- a/src/signer/incremental.rs
+++ b/src/signer/incremental.rs
@@ -84,7 +84,7 @@ pub fn sign_incrementally(
 
     {
         let mut status = status.write().unwrap();
-        status.step = SigningStep::Incremental(IncrementalSigningStep::SigningIncrementally);
+        status.step = SigningStep::Incremental(IncrementalSigningStep::CollectingRecords);
     }
 
     let load_unsigned = patch.next_loaded().is_some();
@@ -153,8 +153,7 @@ pub fn sign_incrementally(
         return Err(SignerError::NothingToDo);
     }
 
-    let mut iss =
-        IncrementalSigningState::new(zone, &policy, center, &ws.keyset_state, status.clone())?;
+    let mut iss = IncrementalSigningState::new(zone, &policy, center, &ws.keyset_state)?;
 
     let start = Instant::now();
     let patch_curr = ws.patch.curr();
@@ -184,7 +183,7 @@ pub fn sign_incrementally(
                 domain::new::base::Serial::from(signed_serial.into_int()),
             )
             .unwrap();
-        status.step = SigningStep::Incremental(IncrementalSigningStep::SigningIncrementally);
+        status.step = SigningStep::Incremental(IncrementalSigningStep::GeneratingSignatures);
     }
 
     iss.initial_diffs()?;
@@ -211,6 +210,11 @@ pub fn sign_incrementally(
     }
     debug!("incremental signing took {:?}", start.elapsed());
 
+    {
+        let mut status = status.write().unwrap();
+        status.step = SigningStep::Incremental(IncrementalSigningStep::GeneratingDiffs)
+    }
+
     let start = Instant::now();
     ws.incremental_generate_diffs(&iss)?;
     debug!("generating diffs took {:?}", start.elapsed());
@@ -218,6 +222,11 @@ pub fn sign_incrementally(
     ws.patch
         .apply()
         .map_err(|e| SignerError::PatchFailed(format!("apply failed: {e}")))?;
+
+    {
+        let mut status = status.write().unwrap();
+        status.step = SigningStep::Incremental(IncrementalSigningStep::DeterminingMinExpirationTime)
+    }
 
     debug!("SIGNER: Determining min expiration time");
     let min_expiration = Arc::new(MinTimestamp::new());
@@ -1369,9 +1378,8 @@ impl<'a> IncrementalSigningState<'a> {
         policy: &PolicyVersion,
         center: &Arc<Center>,
         keyset_state: &KeySetState,
-        status: Arc<RwLock<SigningStatusPerZone>>,
     ) -> Result<Self, SignerError> {
-        let keys = ZoneSigningKeys::load(center, zone, keyset_state, &status)?;
+        let keys = ZoneSigningKeys::load(center, zone, keyset_state)?;
 
         let now = faketime_or_now();
         let now_u32 = Into::<Duration>::into(now.clone()).as_secs() as u32;

--- a/src/signer/incremental.rs
+++ b/src/signer/incremental.rs
@@ -82,11 +82,6 @@ pub fn sign_incrementally(
 
     info!("Start signing zone '{}' incrementally", zone.name);
 
-    {
-        let mut status = status.write().unwrap();
-        status.step = SigningStep::Incremental(IncrementalSigningStep::CollectingRecords);
-    }
-
     let load_unsigned = patch.next_loaded().is_some();
 
     let origin = &zone.name;
@@ -102,7 +97,6 @@ pub fn sign_incrementally(
 
     // If we have a new loaded version then the loaded serial is the one that
     // we just loaded, otherwise it's the one that we loaded before.
-    // We don't use this directly but we do report it to the zone status.
     let loaded_serial = patch
         .next_loaded()
         .or_else(|| patch.curr_loaded())
@@ -110,6 +104,9 @@ pub fn sign_incrementally(
         .soa()
         .rdata
         .serial;
+
+    let previous_serial = patch.curr().soa().rdata.serial;
+    let previous_serial = Serial::from(previous_serial.0.get());
 
     let local_state = LocalState::new(zone)?;
     let mut ws = WorkSpace {
@@ -153,6 +150,24 @@ pub fn sign_incrementally(
         return Err(SignerError::NothingToDo);
     }
 
+    let signed_serial = super::next_signed_soa_serial(
+        policy.signer.serial_policy,
+        Serial::from(loaded_serial.0.get()),
+        Some(previous_serial),
+    )?;
+
+    {
+        let mut status = status.write().unwrap();
+        status
+            .status
+            .start(
+                loaded_serial,
+                domain::new::base::Serial::from(signed_serial.0),
+            )
+            .unwrap();
+        status.step = SigningStep::Incremental(IncrementalSigningStep::CollectingRecords);
+    }
+
     let mut iss = IncrementalSigningState::new(zone, &policy, center, &ws.keyset_state)?;
 
     let start = Instant::now();
@@ -172,17 +187,10 @@ pub fn sign_incrementally(
     }
 
     let start = Instant::now();
-    let signed_serial = ws.load_apex_records(&mut iss)?;
+    ws.load_apex_records(signed_serial, &mut iss)?;
 
     {
         let mut status = status.write().unwrap();
-        status
-            .status
-            .start(
-                loaded_serial,
-                domain::new::base::Serial::from(signed_serial.into_int()),
-            )
-            .unwrap();
         status.step = SigningStep::Incremental(IncrementalSigningStep::GeneratingSignatures);
     }
 
@@ -255,6 +263,11 @@ pub fn sign_incrementally(
         "SIGNER: Determined min expiration time: {:?}",
         ws.local_state.next_min_expiration
     );
+
+    {
+        let mut status = status.write().unwrap();
+        status.status.finish();
+    }
 
     record_zone_event(
         center,
@@ -1067,19 +1080,14 @@ impl WorkSpace<'_> {
         Ok(())
     }
 
-    fn update_soa_serial(&mut self, old_soa: &Zrd) -> Result<(Serial, Zrd), SignerError> {
+    fn update_soa_serial(
+        &mut self,
+        old_soa: &Zrd,
+        signed_serial: Serial,
+    ) -> Result<Zrd, SignerError> {
         let ZoneRecordData::Soa(zone_soa) = old_soa.data() else {
             unreachable!();
         };
-
-        let loaded_serial = zone_soa.serial();
-        let previous_serial = self.local_state.previous_serial;
-
-        let signed_serial = super::next_signed_soa_serial(
-            self.policy.signer.serial_policy,
-            loaded_serial,
-            previous_serial,
-        )?;
 
         // Save the new SOA serial.
         self.local_state.previous_serial = Some(signed_serial);
@@ -1101,7 +1109,7 @@ impl WorkSpace<'_> {
             new_soa,
         );
 
-        Ok((signed_serial, record))
+        Ok(record)
     }
 
     pub fn sign_pass_through(&mut self) -> Result<(), SignerError> {
@@ -1139,8 +1147,9 @@ impl WorkSpace<'_> {
 
     pub fn load_apex_records(
         &mut self,
+        signed_serial: Serial,
         iss: &mut IncrementalSigningState,
-    ) -> Result<Serial, SignerError> {
+    ) -> Result<(), SignerError> {
         // Assume that the apex records have been copied from KeySetState to
         // state. Now update the apex in new_data.
 
@@ -1217,11 +1226,11 @@ impl WorkSpace<'_> {
 
         // Update the SOA serial.
         let zone_soa_rr = &iss.new_apex.get(&Rtype::SOA).expect("SOA should exist")[0];
-        let (signed_serial, new_soa) = self.update_soa_serial(zone_soa_rr)?;
+        let new_soa = self.update_soa_serial(zone_soa_rr, signed_serial)?;
         let new_rrset = vec![new_soa];
         iss.new_apex.insert(Rtype::SOA, new_rrset);
 
-        Ok(signed_serial)
+        Ok(())
     }
 
     pub fn new_nsec_nsec3_sigs(

--- a/src/signer/incremental.rs
+++ b/src/signer/incremental.rs
@@ -84,7 +84,6 @@ pub fn sign_incrementally(
 
     {
         let mut status = status.write().unwrap();
-        status.current_action = "Start incremental signing".to_string();
         status.step = SigningStep::Incremental(IncrementalSigningStep::SigningIncrementally);
     }
 
@@ -185,7 +184,6 @@ pub fn sign_incrementally(
                 domain::new::base::Serial::from(signed_serial.into_int()),
             )
             .unwrap();
-        status.current_action = "Start incremental signing".to_string();
         status.step = SigningStep::Incremental(IncrementalSigningStep::SigningIncrementally);
     }
 

--- a/src/signer/incremental.rs
+++ b/src/signer/incremental.rs
@@ -44,15 +44,15 @@ use domain::zonetree::StoredRecord;
 use rayon::slice::ParallelSliceMut;
 use ring::digest;
 use tokio::time::Instant;
-use tracing::debug;
 use tracing::error;
+use tracing::{debug, info};
 
 use crate::center::Center;
 use crate::manager::record_zone_event;
 use crate::policy::{PolicyVersion, SignerDenialPolicy};
 use crate::signer::SigningTrigger;
 use crate::signer::keys::ZoneSigningKeys;
-use crate::signer::status::SigningStatusPerZone;
+use crate::signer::status::{IncrementalSigningStep, SigningStatusPerZone, SigningStep};
 use crate::units::key_manager::mk_dnst_keyset_state_file_path;
 use crate::units::zone_signer::{
     KeySetState, MinTimestamp, PassThroughMode, SignerError, faketime_or_now,
@@ -80,8 +80,14 @@ pub fn sign_incrementally(
     // signatures need to be updated.
     // Resign using the unsigned zonefile when load_unsigned is true.
 
-    status.write().expect("should not fail").current_action =
-        "Start incremental signing".to_string();
+    info!("Start signing zone '{}' incrementally", zone.name);
+
+    {
+        let mut status = status.write().unwrap();
+        status.current_action = "Start incremental signing".to_string();
+        status.step = SigningStep::Incremental(IncrementalSigningStep::SigningIncrementally);
+    }
+
     let load_unsigned = patch.next_loaded().is_some();
 
     let origin = &zone.name;
@@ -94,6 +100,17 @@ pub fn sign_incrementally(
     let policy = zone.read().policy.clone().unwrap();
 
     let use_nsec3 = matches!(policy.signer.denial, SignerDenialPolicy::NSec3 { .. });
+
+    // If we have a new loaded version then the loaded serial is the one that
+    // we just loaded, otherwise it's the one that we loaded before.
+    // We don't use this directly but we do report it to the zone status.
+    let loaded_serial = patch
+        .next_loaded()
+        .or_else(|| patch.curr_loaded())
+        .unwrap()
+        .soa()
+        .rdata
+        .serial;
 
     let local_state = LocalState::new(zone)?;
     let mut ws = WorkSpace {
@@ -137,7 +154,8 @@ pub fn sign_incrementally(
         return Err(SignerError::NothingToDo);
     }
 
-    let mut iss = IncrementalSigningState::new(zone, &policy, center, &ws.keyset_state, status)?;
+    let mut iss =
+        IncrementalSigningState::new(zone, &policy, center, &ws.keyset_state, status.clone())?;
 
     let start = Instant::now();
     let patch_curr = ws.patch.curr();
@@ -156,7 +174,20 @@ pub fn sign_incrementally(
     }
 
     let start = Instant::now();
-    ws.load_apex_records(&mut iss)?;
+    let signed_serial = ws.load_apex_records(&mut iss)?;
+
+    {
+        let mut status = status.write().unwrap();
+        status
+            .status
+            .start(
+                loaded_serial,
+                domain::new::base::Serial::from(signed_serial.into_int()),
+            )
+            .unwrap();
+        status.current_action = "Start incremental signing".to_string();
+        status.step = SigningStep::Incremental(IncrementalSigningStep::SigningIncrementally);
+    }
 
     iss.initial_diffs()?;
 
@@ -1029,7 +1060,7 @@ impl WorkSpace<'_> {
         Ok(())
     }
 
-    fn update_soa_serial(&mut self, old_soa: &Zrd) -> Result<Zrd, SignerError> {
+    fn update_soa_serial(&mut self, old_soa: &Zrd) -> Result<(Serial, Zrd), SignerError> {
         let ZoneRecordData::Soa(zone_soa) = old_soa.data() else {
             unreachable!();
         };
@@ -1063,7 +1094,7 @@ impl WorkSpace<'_> {
             new_soa,
         );
 
-        Ok(record)
+        Ok((signed_serial, record))
     }
 
     pub fn sign_pass_through(&mut self) -> Result<(), SignerError> {
@@ -1102,7 +1133,7 @@ impl WorkSpace<'_> {
     pub fn load_apex_records(
         &mut self,
         iss: &mut IncrementalSigningState,
-    ) -> Result<(), SignerError> {
+    ) -> Result<Serial, SignerError> {
         // Assume that the apex records have been copied from KeySetState to
         // state. Now update the apex in new_data.
 
@@ -1179,11 +1210,11 @@ impl WorkSpace<'_> {
 
         // Update the SOA serial.
         let zone_soa_rr = &iss.new_apex.get(&Rtype::SOA).expect("SOA should exist")[0];
-        let new_soa = self.update_soa_serial(zone_soa_rr)?;
+        let (signed_serial, new_soa) = self.update_soa_serial(zone_soa_rr)?;
         let new_rrset = vec![new_soa];
         iss.new_apex.insert(Rtype::SOA, new_rrset);
 
-        Ok(())
+        Ok(signed_serial)
     }
 
     pub fn new_nsec_nsec3_sigs(

--- a/src/signer/keys.rs
+++ b/src/signer/keys.rs
@@ -66,8 +66,6 @@ impl ZoneSigningKeys {
         keyset_state: &KeySetState,
         status: &RwLock<SigningStatusPerZone>,
     ) -> Result<Self, Box<LoadError>> {
-        status.write().unwrap().current_action = "Loading signing keys".to_string();
-
         let mut list = Vec::new();
 
         for (pub_key_name, key_info) in keyset_state.keyset.keys() {
@@ -282,9 +280,6 @@ impl KeyPair {
         let kmip_conn_pool = match kmip_servers.entry(priv_key_url.server_id().to_string()) {
             std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
             std::collections::hash_map::Entry::Vacant(e) => {
-                status.write().unwrap().current_action =
-                    format!("Connecting to KMIP server '{}'", priv_key_url.server_id());
-
                 // Try and load the KMIP server settings.
                 let server_state_path = center
                     .config
@@ -375,11 +370,6 @@ impl KeyPair {
                 e.insert(pool)
             }
         };
-
-        status.write().unwrap().current_action = format!(
-            "Fetching keys from KMIP server '{}'",
-            priv_key_url.server_id()
-        );
 
         let priv_key_url_inner = (*priv_key_url).clone();
         let pub_key_url_inner = (*pub_key_url).clone();

--- a/src/signer/keys.rs
+++ b/src/signer/keys.rs
@@ -1,10 +1,7 @@
 //! Handling signing keys.
 
 use core::fmt;
-use std::{
-    sync::{Arc, RwLock},
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
 use bytes::Bytes;
 use camino::Utf8Path;
@@ -26,7 +23,6 @@ use url::Url;
 
 use crate::{
     center::Center,
-    signer::status::SigningStatusPerZone,
     units::{
         http_server::KmipServerState,
         key_manager::{KmipClientCredentialsFile, KmipServerCredentialsFileMode},
@@ -64,7 +60,6 @@ impl ZoneSigningKeys {
         center: &Center,
         zone: &Zone,
         keyset_state: &KeySetState,
-        status: &RwLock<SigningStatusPerZone>,
     ) -> Result<Self, Box<LoadError>> {
         let mut list = Vec::new();
 
@@ -113,7 +108,7 @@ impl ZoneSigningKeys {
                             error,
                         })
                     })?;
-                    KeyPair::load_kmip(center, priv_url, pub_url, status)?
+                    KeyPair::load_kmip(center, priv_url, pub_url)?
                 }
                 _ => {
                     return Err(Box::new(LoadError::UnsupportedScheme { url: pub_url }));
@@ -271,7 +266,6 @@ impl KeyPair {
         center: &Center,
         priv_key_url: KeyUrl,
         pub_key_url: KeyUrl,
-        status: &RwLock<SigningStatusPerZone>,
     ) -> Result<Self, Box<LoadError>> {
         // TODO: Replace the connection pool if the persisted KMIP server settings
         // were updated more recently than the pool was created.

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -100,12 +100,12 @@ fn sign(
 
             let built = builder.finish().unwrap_or_else(|_| unreachable!());
             handle.get().finish_signing(built);
-            status.status.finish(true);
+            status.status.finish();
             zone.metrics.last_successful_sign_duration(duration);
         }
         Err(SignerError::NothingToDo) => {
             handle.get().abandon_signing(builder);
-            status.status.finish(true);
+            status.status.finish();
         }
         Err(SignerError::KeepSerialPolicyViolated) => {
             // Also ignore Keep errors. We can ignore these errors for
@@ -113,7 +113,7 @@ fn sign(
             // TODO: But if nothing happens for too long we should warn.
             // Something in status would be good.
             handle.get().abandon_signing(builder);
-            status.status.finish(true);
+            status.status.finish();
 
             // If the sign operation was triggered by a load, the user forgot to increase the
             // serial of the zone, so we should tell them about that by emitting an error.
@@ -136,7 +136,7 @@ fn sign(
         Err(error) => {
             error!("Signing failed: {error}");
             handle.get().signing_failed(builder, error.clone());
-            status.status.finish(false);
+            status.status.finish();
 
             handle.state.record_event(
                 HistoricalEvent::SigningFailed {

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -102,12 +102,10 @@ fn sign(
             handle.get().finish_signing(built);
             status.status.finish(true);
             zone.metrics.last_successful_sign_duration(duration);
-            status.current_action = "Finished".to_string();
         }
         Err(SignerError::NothingToDo) => {
             handle.get().abandon_signing(builder);
             status.status.finish(true);
-            status.current_action = "Nothing to do".to_string();
         }
         Err(SignerError::KeepSerialPolicyViolated) => {
             // Also ignore Keep errors. We can ignore these errors for
@@ -116,8 +114,6 @@ fn sign(
             // Something in status would be good.
             handle.get().abandon_signing(builder);
             status.status.finish(true);
-
-            status.current_action = "Resign failed due to Keep policy".to_string();
 
             // If the sign operation was triggered by a load, the user forgot to increase the
             // serial of the zone, so we should tell them about that by emitting an error.
@@ -141,7 +137,6 @@ fn sign(
             error!("Signing failed: {error}");
             handle.get().signing_failed(builder, error.clone());
             status.status.finish(false);
-            status.current_action = "Aborted".to_string();
 
             handle.state.record_event(
                 HistoricalEvent::SigningFailed {

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -25,7 +25,7 @@ use std::{
 
 use domain::base::Serial;
 use jiff::{Timestamp as JiffTimestamp, Zoned, tz::TimeZone};
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 
 use crate::{
     center::Center,
@@ -70,6 +70,7 @@ fn sign(
     status: Arc<RwLock<SigningStatusPerZone>>,
 ) {
     let start = Instant::now();
+    info!("Starting a sign operation for '{}'", zone.name);
 
     let result = if let Some(patcher) = builder.patch() {
         self::incremental::sign_incrementally(patcher, &zone, &center, trigger, status.clone())

--- a/src/signer/status.rs
+++ b/src/signer/status.rs
@@ -15,7 +15,6 @@ use crate::util::{
 
 #[derive(Debug)]
 pub struct SigningStatusPerZone {
-    pub current_action: String,
     pub step: SigningStep,
     pub status: ZoneSigningStatus,
 }
@@ -118,10 +117,7 @@ impl SigningStatusPerZone {
             ZoneSigningStatus::Aborted => None,
         };
 
-        stage_report.map(|stage_report| SigningReport {
-            current_action: self.current_action.clone(),
-            stage_report,
-        })
+        stage_report.map(|stage_report| SigningReport { stage_report })
     }
 }
 

--- a/src/signer/status.rs
+++ b/src/signer/status.rs
@@ -16,7 +16,54 @@ use crate::util::{
 #[derive(Debug)]
 pub struct SigningStatusPerZone {
     pub current_action: String,
+    pub step: SigningStep,
     pub status: ZoneSigningStatus,
+}
+
+#[derive(Debug)]
+pub enum SigningStep {
+    Full(FullSigningStep),
+    Incremental(IncrementalSigningStep),
+}
+
+#[derive(Debug)]
+pub enum FullSigningStep {
+    CollectingRecords,
+    FetchingKeys,
+    SortingRecords,
+    GeneratingDenialRecords,
+    GeneratingSignatureRecords,
+}
+
+#[derive(Debug)]
+pub enum IncrementalSigningStep {
+    // TODO: Add more steps here.
+    SigningIncrementally,
+}
+
+impl SigningStep {
+    fn to_api(&self) -> cascade_api::SigningStep {
+        match self {
+            SigningStep::Full(s) => cascade_api::SigningStep::Full(match s {
+                FullSigningStep::CollectingRecords => {
+                    cascade_api::FullSigningStep::CollectingRecords
+                }
+                FullSigningStep::FetchingKeys => cascade_api::FullSigningStep::FetchingKeys,
+                FullSigningStep::SortingRecords => cascade_api::FullSigningStep::SortingRecords,
+                FullSigningStep::GeneratingDenialRecords => {
+                    cascade_api::FullSigningStep::GeneratingDenialRecords
+                }
+                FullSigningStep::GeneratingSignatureRecords => {
+                    cascade_api::FullSigningStep::GeneratingSignatureRecords
+                }
+            }),
+            SigningStep::Incremental(s) => cascade_api::SigningStep::Incremental(match s {
+                IncrementalSigningStep::SigningIncrementally => {
+                    cascade_api::IncrementalSigningStep::SigningIncrementally
+                }
+            }),
+        }
+    }
 }
 
 impl SigningStatusPerZone {
@@ -31,8 +78,10 @@ impl SigningStatusPerZone {
             }
             ZoneSigningStatus::InProgress(s) => {
                 Some(SigningStageReport::InProgress(SigningInProgressReport {
+                    step: self.step.to_api(),
                     requested_at: now_t.checked_sub(now.duration_since(s.requested_at))?,
-                    zone_serial: domain::base::Serial(s.zone_serial.into()),
+                    loaded_serial: domain::base::Serial(s.loaded_serial.into()),
+                    signed_serial: domain::base::Serial(s.signed_serial.into()),
                     started_at: now_t.checked_sub(now.duration_since(s.started_at))?,
                     unsigned_rr_count: s.unsigned_rr_count,
                     walk_time: s.walk_time,
@@ -49,7 +98,8 @@ impl SigningStatusPerZone {
             ZoneSigningStatus::Finished(s) => {
                 Some(SigningStageReport::Finished(SigningFinishedReport {
                     requested_at: now_t.checked_sub(now.duration_since(s.requested_at))?,
-                    zone_serial: domain::base::Serial(s.zone_serial.into()),
+                    loaded_serial: domain::base::Serial(s.loaded_serial.into()),
+                    signed_serial: domain::base::Serial(s.signed_serial.into()),
                     started_at: now_t.checked_sub(now.duration_since(s.started_at))?,
                     unsigned_rr_count: s.unsigned_rr_count,
                     walk_time: s.walk_time,
@@ -94,10 +144,14 @@ impl ZoneSigningStatus {
     }
 
     #[allow(clippy::result_unit_err)] // TODO
-    pub fn start(&mut self, zone_serial: domain::new::base::Serial) -> Result<(), ()> {
+    pub fn start(
+        &mut self,
+        loaded_serial: domain::new::base::Serial,
+        signed_serial: domain::new::base::Serial,
+    ) -> Result<(), ()> {
         match *self {
             ZoneSigningStatus::Requested(s) => {
-                *self = Self::InProgress(InProgressStatus::new(s, zone_serial));
+                *self = Self::InProgress(InProgressStatus::new(s, loaded_serial, signed_serial));
                 Ok(())
             }
             ZoneSigningStatus::Aborted
@@ -149,7 +203,8 @@ impl RequestedStatus {
 pub struct InProgressStatus {
     #[serde(serialize_with = "serialize_instant_as_duration_secs")]
     pub requested_at: tokio::time::Instant,
-    pub zone_serial: domain::base::Serial,
+    pub loaded_serial: domain::base::Serial,
+    pub signed_serial: domain::base::Serial,
     #[serde(serialize_with = "serialize_instant_as_duration_secs")]
     pub started_at: tokio::time::Instant,
     pub unsigned_rr_count: Option<usize>,
@@ -170,10 +225,15 @@ pub struct InProgressStatus {
 }
 
 impl InProgressStatus {
-    pub fn new(requested_status: RequestedStatus, zone_serial: domain::new::base::Serial) -> Self {
+    pub fn new(
+        requested_status: RequestedStatus,
+        loaded_serial: domain::new::base::Serial,
+        signed_serial: domain::new::base::Serial,
+    ) -> Self {
         Self {
             requested_at: requested_status.requested_at,
-            zone_serial: domain::base::Serial(zone_serial.into()),
+            loaded_serial: domain::base::Serial(loaded_serial.into()),
+            signed_serial: domain::base::Serial(signed_serial.into()),
             started_at: Instant::now(),
             unsigned_rr_count: None,
             walk_time: None,
@@ -195,7 +255,8 @@ pub struct FinishedStatus {
     pub requested_at: tokio::time::Instant,
     #[serde(serialize_with = "serialize_instant_as_duration_secs")]
     pub started_at: tokio::time::Instant,
-    pub zone_serial: domain::base::Serial,
+    pub loaded_serial: domain::base::Serial,
+    pub signed_serial: domain::base::Serial,
     pub unsigned_rr_count: usize,
     #[serde(serialize_with = "serialize_duration_as_secs")]
     pub walk_time: Duration,
@@ -220,7 +281,8 @@ impl FinishedStatus {
     fn new(in_progress_status: InProgressStatus, succeeded: bool) -> Self {
         Self {
             requested_at: in_progress_status.requested_at,
-            zone_serial: in_progress_status.zone_serial,
+            loaded_serial: in_progress_status.loaded_serial,
+            signed_serial: in_progress_status.signed_serial,
             started_at: Instant::now(),
             unsigned_rr_count: in_progress_status.unsigned_rr_count.unwrap_or_default(),
             walk_time: in_progress_status.walk_time.unwrap_or_default(),

--- a/src/signer/status.rs
+++ b/src/signer/status.rs
@@ -1,6 +1,6 @@
 //! Tracking the status of zone signing.
 
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 use serde::Serialize;
 use tokio::time::Instant;
@@ -9,9 +9,7 @@ use crate::api::{
     SigningFinishedReport, SigningInProgressReport, SigningReport, SigningRequestedReport,
     SigningStageReport,
 };
-use crate::util::{
-    serialize_duration_as_secs, serialize_instant_as_duration_secs, serialize_opt_duration_as_secs,
-};
+use crate::util::serialize_instant_as_duration_secs;
 
 #[derive(Debug)]
 pub struct SigningStatusPerZone {
@@ -93,16 +91,6 @@ impl SigningStatusPerZone {
                     loaded_serial: domain::base::Serial(s.loaded_serial.into()),
                     signed_serial: domain::base::Serial(s.signed_serial.into()),
                     started_at: now_t.checked_sub(now.duration_since(s.started_at))?,
-                    unsigned_rr_count: s.unsigned_rr_count,
-                    walk_time: s.walk_time,
-                    sort_time: s.sort_time,
-                    denial_rr_count: s.denial_rr_count,
-                    denial_time: s.denial_time,
-                    rrsig_count: s.rrsig_count,
-                    rrsig_reused_count: s.rrsig_reused_count,
-                    rrsig_time: s.rrsig_time,
-                    total_time: s.total_time,
-                    threads_used: s.threads_used,
                 }))
             }
             ZoneSigningStatus::Finished(s) => {
@@ -111,18 +99,7 @@ impl SigningStatusPerZone {
                     loaded_serial: domain::base::Serial(s.loaded_serial.into()),
                     signed_serial: domain::base::Serial(s.signed_serial.into()),
                     started_at: now_t.checked_sub(now.duration_since(s.started_at))?,
-                    unsigned_rr_count: s.unsigned_rr_count,
-                    walk_time: s.walk_time,
-                    sort_time: s.sort_time,
-                    denial_rr_count: s.denial_rr_count,
-                    denial_time: s.denial_time,
-                    rrsig_count: s.rrsig_count,
-                    rrsig_reused_count: s.rrsig_reused_count,
-                    rrsig_time: s.rrsig_time,
-                    total_time: s.total_time,
-                    threads_used: s.threads_used,
                     finished_at: now_t.checked_sub(now.duration_since(s.finished_at))?,
-                    succeeded: s.succeeded,
                 }))
             }
             ZoneSigningStatus::Aborted => None,
@@ -167,13 +144,13 @@ impl ZoneSigningStatus {
         }
     }
 
-    pub fn finish(&mut self, succeeded: bool) {
+    pub fn finish(&mut self) {
         match *self {
             ZoneSigningStatus::Requested(_) => {
                 *self = Self::Aborted;
             }
             ZoneSigningStatus::InProgress(status) => {
-                *self = Self::Finished(FinishedStatus::new(status, succeeded))
+                *self = Self::Finished(FinishedStatus::new(status))
             }
             ZoneSigningStatus::Finished(_) | ZoneSigningStatus::Aborted => { /* Nothing to do */ }
         }
@@ -214,21 +191,6 @@ pub struct InProgressStatus {
     pub signed_serial: domain::base::Serial,
     #[serde(serialize_with = "serialize_instant_as_duration_secs")]
     pub started_at: tokio::time::Instant,
-    pub unsigned_rr_count: Option<usize>,
-    #[serde(serialize_with = "serialize_opt_duration_as_secs")]
-    pub walk_time: Option<Duration>,
-    #[serde(serialize_with = "serialize_opt_duration_as_secs")]
-    pub sort_time: Option<Duration>,
-    pub denial_rr_count: Option<usize>,
-    #[serde(serialize_with = "serialize_opt_duration_as_secs")]
-    pub denial_time: Option<Duration>,
-    pub rrsig_count: Option<usize>,
-    pub rrsig_reused_count: Option<usize>,
-    #[serde(serialize_with = "serialize_opt_duration_as_secs")]
-    pub rrsig_time: Option<Duration>,
-    #[serde(serialize_with = "serialize_opt_duration_as_secs")]
-    pub total_time: Option<Duration>,
-    pub threads_used: Option<usize>,
 }
 
 impl InProgressStatus {
@@ -242,16 +204,6 @@ impl InProgressStatus {
             loaded_serial: domain::base::Serial(loaded_serial.into()),
             signed_serial: domain::base::Serial(signed_serial.into()),
             started_at: Instant::now(),
-            unsigned_rr_count: None,
-            walk_time: None,
-            sort_time: None,
-            denial_rr_count: None,
-            denial_time: None,
-            rrsig_count: None,
-            rrsig_reused_count: None,
-            rrsig_time: None,
-            total_time: None,
-            threads_used: None,
         }
     }
 }
@@ -262,47 +214,20 @@ pub struct FinishedStatus {
     pub requested_at: tokio::time::Instant,
     #[serde(serialize_with = "serialize_instant_as_duration_secs")]
     pub started_at: tokio::time::Instant,
-    pub loaded_serial: domain::base::Serial,
-    pub signed_serial: domain::base::Serial,
-    pub unsigned_rr_count: usize,
-    #[serde(serialize_with = "serialize_duration_as_secs")]
-    pub walk_time: Duration,
-    #[serde(serialize_with = "serialize_duration_as_secs")]
-    pub sort_time: Duration,
-    pub denial_rr_count: usize,
-    #[serde(serialize_with = "serialize_duration_as_secs")]
-    pub denial_time: Duration,
-    pub rrsig_count: usize,
-    pub rrsig_reused_count: usize,
-    #[serde(serialize_with = "serialize_duration_as_secs")]
-    pub rrsig_time: Duration,
-    #[serde(serialize_with = "serialize_duration_as_secs")]
-    pub total_time: Duration,
-    pub threads_used: usize,
     #[serde(serialize_with = "serialize_instant_as_duration_secs")]
     pub finished_at: tokio::time::Instant,
-    pub succeeded: bool,
+    pub loaded_serial: domain::base::Serial,
+    pub signed_serial: domain::base::Serial,
 }
 
 impl FinishedStatus {
-    fn new(in_progress_status: InProgressStatus, succeeded: bool) -> Self {
+    fn new(in_progress_status: InProgressStatus) -> Self {
         Self {
             requested_at: in_progress_status.requested_at,
             loaded_serial: in_progress_status.loaded_serial,
             signed_serial: in_progress_status.signed_serial,
-            started_at: Instant::now(),
-            unsigned_rr_count: in_progress_status.unsigned_rr_count.unwrap_or_default(),
-            walk_time: in_progress_status.walk_time.unwrap_or_default(),
-            sort_time: in_progress_status.sort_time.unwrap_or_default(),
-            denial_rr_count: in_progress_status.denial_rr_count.unwrap_or_default(),
-            denial_time: in_progress_status.denial_time.unwrap_or_default(),
-            rrsig_count: in_progress_status.rrsig_count.unwrap_or_default(),
-            rrsig_reused_count: in_progress_status.rrsig_reused_count.unwrap_or_default(),
-            rrsig_time: in_progress_status.rrsig_time.unwrap_or_default(),
-            total_time: in_progress_status.total_time.unwrap_or_default(),
-            threads_used: in_progress_status.threads_used.unwrap_or_default(),
+            started_at: in_progress_status.started_at,
             finished_at: Instant::now(),
-            succeeded,
         }
     }
 }

--- a/src/signer/status.rs
+++ b/src/signer/status.rs
@@ -36,8 +36,10 @@ pub enum FullSigningStep {
 
 #[derive(Debug)]
 pub enum IncrementalSigningStep {
-    // TODO: Add more steps here.
-    SigningIncrementally,
+    CollectingRecords,
+    GeneratingSignatures,
+    GeneratingDiffs,
+    DeterminingMinExpirationTime,
 }
 
 impl SigningStep {
@@ -57,8 +59,17 @@ impl SigningStep {
                 }
             }),
             SigningStep::Incremental(s) => cascade_api::SigningStep::Incremental(match s {
-                IncrementalSigningStep::SigningIncrementally => {
-                    cascade_api::IncrementalSigningStep::SigningIncrementally
+                IncrementalSigningStep::CollectingRecords => {
+                    cascade_api::IncrementalSigningStep::CollectingRecords
+                }
+                IncrementalSigningStep::GeneratingSignatures => {
+                    cascade_api::IncrementalSigningStep::GeneratingSignatures
+                }
+                IncrementalSigningStep::GeneratingDiffs => {
+                    cascade_api::IncrementalSigningStep::GeneratingDiffs
+                }
+                IncrementalSigningStep::DeterminingMinExpirationTime => {
+                    cascade_api::IncrementalSigningStep::DeterminingMinExpirationTime
                 }
             }),
         }

--- a/src/signer/zone.rs
+++ b/src/signer/zone.rs
@@ -12,12 +12,14 @@ use crate::{
     signer::{
         ResigningTrigger, SigningTrigger,
         queue::{SigningPending, SigningPermit, SigningQueueLock},
-        status::{SigningStatusPerZone, ZoneSigningStatus},
+        status::{SigningStatusPerZone, SigningStep, ZoneSigningStatus},
     },
     util::BackgroundTasks,
     zone::{Zone, ZoneByPtr, ZoneHandle, ZoneState},
     zonedata::SignedZoneBuilder,
 };
+
+use super::status::FullSigningStep;
 
 //----------- SignerZoneHandle -------------------------------------------------
 
@@ -422,6 +424,7 @@ impl SignerZoneHandle<'_> {
     ) {
         let status = Arc::new(RwLock::new(SigningStatusPerZone {
             current_action: "Initiating signing".into(),
+            step: SigningStep::Full(FullSigningStep::CollectingRecords),
             status: ZoneSigningStatus::new(),
         }));
 

--- a/src/signer/zone.rs
+++ b/src/signer/zone.rs
@@ -423,7 +423,6 @@ impl SignerZoneHandle<'_> {
         permit: SigningPermit,
     ) {
         let status = Arc::new(RwLock::new(SigningStatusPerZone {
-            current_action: "Initiating signing".into(),
             step: SigningStep::Full(FullSigningStep::CollectingRecords),
             status: ZoneSigningStatus::new(),
         }));

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -483,7 +483,7 @@ impl HttpServer {
             };
 
             // Query signing status
-            signing_report = if progress >= Progress::SignedReview {
+            signing_report = if progress >= Progress::Signing {
                 zone_state
                     .signer
                     .active_signing_status

--- a/src/util.rs
+++ b/src/util.rs
@@ -199,6 +199,7 @@ where
     serializer.serialize_u64(duration.as_secs())
 }
 
+#[expect(dead_code)]
 pub fn serialize_opt_duration_as_secs<S>(
     instant: &Option<Duration>,
     serializer: S,


### PR DESCRIPTION
Does a few things:

- Report signing steps to the zone status.
- This required adding a `step` to the `SigningStatus`, which kind of overlaps with the `current_action` but I left that in, because that still shows more granular information that might be helpful for debugging or something.
- There was some info in the status that was shown as "not yet known" even though it was, because the HTTP server only included the signing report on signing review, which is now fixed.
- We now also trigger `SigningStatus::InProgress` in incremental signing, which turned out to not happen yet.
- We now show the signed serial in the zone status because we now take it from the signing status and not from the `signed_review_soa` on the storage because the signer knows the serial earlier.
- We now also show the signing strategy (full or incremental).
- Finally, some unused metrics were removed. They were also not created for incremental signing, so this is not a very big deal.

```
zone:   se
policy: default
source: /home/terts/data/zones/se.zone.stripped.txt

review
  loaded: off
  signed: off

last published
  <no versions published yet>

status: signing
  ✔ load (serial: 1776081352)
  ○ review loaded zone (disabled)
  ● sign (serial: 2026071300)
  |   loaded serial: 1776081352
  |   signed serial: 2026071300
  |   strategy: sign the entire zone
  |   step 1/5: collecting records
  |   start time: 2026-07-13T14:18:15 (9s ago)
  |
  ○ review signed zone (disabled)
  ○ publish
```

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [ ] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?