### PR TITLE
Fix broken markup in release instructions.

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,7 +24,7 @@
 
 # Merge and release
 - `git checkout main`
-- `git tag -a -m "Release vX.Y.Z[-xxx] '<NAME>'"`
+- `git tag -a -m "Release vX.Y.Z[-xxx] '<NAME>'" vX.Y.Z[-xxx]`
 - Verify that the release tag version is the same as the Cargo.toml version but with a `v` prefix
 - `git push --tags`
 - GH should automatically run the packaging workflow again creating run NNNNNNNN

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,7 +16,7 @@
 - `git push`
 - `./act-wrapper --rm` - make sure that the integration tests pass
 - in GH UI invoke the packaging workflow on the release branch
-- make a PR for the branch and mention the workflow run URL in the descrption
+- make a PR for the branch and mention the workflow run URL in the description
 - review the PR and ensure the workflow succeeds
 - dog food: upgrade cascade.nlnetlabs.nl using a package attached as an output artifact to
   the workflow run

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,19 +1,19 @@
 # Prepare
-- think of a release <NAME>
-- add new O/S versions in pkg/rules/packages-to-build.yml if needed
-- update Changelog.md with the release date, version X.Y.Z[-NNN], <NAME> and release summary
+- think of a release &lt;NAME&gt;
+- add new O/S versions in `pkg/rules/packages-to-build.yml` if needed
+- update `Changelog.md` with the release date, version X.Y.Z[-NNN], &lt;NAME&gt; and release summary
 
 # Make a release branch and test packaging
-- git checkout -b release-vX.Y.Z[-xxx]
-- cargo update
-- bump application version in Cargo.toml to X.Y.Z[-xxx]
-- cargo check (to bump the application version in Cargo.lock)
-- pushd doc/manual
-- make man
-- popd
-- git add Cargo.toml Cargo.lock Changelog.md pkg/rules/packages-to-build.yml doc/manual/build/man/*.*
-- git commit
-- git push
+- `git checkout -b release-vX.Y.Z[-xxx]`
+- `cargo update`
+- bump application version in `Cargo.toml` to X.Y.Z[-xxx]
+- `cargo check` (to bump the application version in Cargo.lock)
+- `pushd doc/manual`
+- `make man`
+- `popd`
+- `git add Cargo.toml Cargo.lock Changelog.md pkg/rules/packages-to-build.yml doc/manual/build/man/*.*`
+- `git commit`
+- `git push`
 - `./act-wrapper --rm` - make sure that the integration tests pass
 - in GH UI invoke the packaging workflow on the release branch
 - make a PR for the branch and mention the workflow run URL in the descrption
@@ -23,29 +23,29 @@
 - merge the release branch to main
 
 # Merge and release
-- git checkout main
-- git tag -a -m "Release vX.Y.Z[-xxx] '<NAME>'"
+- `git checkout main`
+- `git tag -a -m "Release vX.Y.Z[-xxx] '<NAME>'"`
 - Verify that the release tag version is the same as the Cargo.toml version but with a `v` prefix
-- git push --tags
+- `git push --tags`
 - GH should automatically run the packaging workflow again creating run NNNNNNNN
 - if successful:
-  - publish_helper.sh --dry-run https://github.com/NLnetLabs/cascade/actions/runs/NNNNNNNN
-  - publish_helper.sh https://github.com/NLnetLabs/cascade/actions/runs/NNNNNNNN
+  - `publish_helper.sh --dry-run https://github.com/NLnetLabs/cascade/actions/runs/NNNNNNNN`
+  - `publish_helper.sh https://github.com/NLnetLabs/cascade/actions/runs/NNNNNNNN`
 - create a GH release with tag vX.Y.Z[-NNN] and title 'X.Y.Z[-NNN] <NAME>"
 - close the GH milestone for this release (if any)
 - announce via post in the Cascade topic on https://community.nlnetlabs.nl/.
   - remember to tag it as #release.
 
 # Prepare for development
-- git checkout -b prep-for-dev
-- bump application version in Cargo.toml to next minor version with suffix `-dev`
-- cargo check (to also bump the application version in Cargo.lock)
-- git add Cargo.toml Cargo.lock
-- git commit
-- git push
+- `git checkout -b prep-for-dev`
+- bump application version in `Cargo.toml` to next minor version with suffix `-dev`
+- `cargo check` (to also bump the application version in `Cargo.lock`)
+- `git add Cargo.toml Cargo.lock`
+- `git commit`
+- `git push`
 - make a PR for the branch
 - review the PR and ensure the workflow succeeds
-- merge the prep-for-dev branch to main
+- merge the `prep-for-dev` branch to main
 - create a GH milestone for the next release (if needed)
 
 # Final steps


### PR DESCRIPTION
E.g. <NAME> doesn't render because the angle brackets are interpreted if not replaced by entity references.

Provide your description here

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [ ] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?

- If you are adding/deleting man pages:
  - [ ] Did you update the `man_pages` config in `doc/manual/source/conf.py`?
  - [ ] Did you update the packaged man pages in the `Cargo.toml`?
  - [ ] Did you commit the freshly built man pages?

- If you are modifying man pages:
  - [ ] Did you commit the updated built man pages?
