### PR TITLE
Trim the dependency tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,7 +222,6 @@ dependencies = [
  "camino",
  "cascade-api",
  "clap",
- "futures-util",
  "jiff",
  "reqwest",
  "tokio",
@@ -278,7 +277,6 @@ dependencies = [
  "domain",
  "domain-kmip",
  "foldhash",
- "futures",
  "futures-util",
  "hostname",
  "jiff",
@@ -694,28 +692,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -723,23 +705,6 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
@@ -770,13 +735,9 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "slab",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,13 +272,13 @@ dependencies = [
  "cascade-cfg",
  "cascade-zonedata",
  "clap",
- "crossbeam-utils",
  "daemonbase",
  "domain",
  "domain-kmip",
  "foldhash",
  "futures-util",
  "hostname",
+ "idna_adapter",
  "jiff",
  "lazy_static",
  "prometheus-client",
@@ -523,17 +523,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -952,88 +941,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "utf8_iter",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
-
-[[package]]
-name = "icu_properties"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
-
-[[package]]
-name = "icu_provider"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,13 +959,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
+checksum = "cfdf4f5d937a025381f5ab13624b1c5f51414bfe5c9885663226eae8d6d39560"
 
 [[package]]
 name = "indexmap"
@@ -1213,12 +1116,6 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "litemap"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1453,15 +1350,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
-]
-
-[[package]]
-name = "potential_utf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
-dependencies = [
- "zerovec",
 ]
 
 [[package]]
@@ -1961,12 +1849,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2005,17 +1887,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
  "futures-core",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2112,16 +1983,6 @@ checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
-dependencies = [
- "displaydoc",
- "zerovec",
 ]
 
 [[package]]
@@ -2666,93 +2527,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "writeable"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "yoke"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
-
-[[package]]
-name = "zerotrie"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,13 @@ hostname = "0.4.1"
 # organization.
 prometheus-client = "0.24.0"
 
+# `idna`, which provides internationalized domain names, is pulled in by `url`.
+# It adds a significant number of dependencies. But Cascade only uses pure-ASCII
+# URLs, so IDN support is unnecessary. `url` does not offer a way to disable
+# `idna` directly; instead, the documented (albeit hacky) method to disable IDN
+# support is to force the version of the `idna_adapter` dependency.
+idna_adapter = { version = "=1.0.0" }
+
 cascade-api = { path = "crates/api" }
 cascade-cfg = { path = "crates/cfg" }
 cascade-zonedata = { path = "crates/zonedata" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,10 +158,11 @@ tracing-subscriber.workspace = true
 lazy_static = { version = "1.5" }
 
 # support-color checks various environment variables and terminal settings for
-# whether ANSI escape codes should be emitted. It is also used by `anstream`
-# (and therefore `clap`).
+# whether ANSI escape codes should be emitted.
 #
-# TODO: `anstream` now uses `anstyle-query` instead of `supports-color`.
+# TODO: This dependency was chosen because `anstream` (which we depend on
+# elsewhere) used it, but `anstream` now uses `anstyle-query`. We now have two
+# crates in our dependency graph that have the same functionality.
 supports-color = "3.0.2"
 
 # `hostname` is a very popular crate to get the hostname of the current process.
@@ -177,6 +178,7 @@ prometheus-client = "0.24.0"
 # URLs, so IDN support is unnecessary. `url` does not offer a way to disable
 # `idna` directly; instead, the documented (albeit hacky) method to disable IDN
 # support is to force the version of the `idna_adapter` dependency.
+# See <https://crates.io/crates/idna_adapter>.
 idna_adapter = { version = "=1.0.0" }
 
 cascade-api = { path = "crates/api" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,6 @@ version = "0.3.20"
 [dependencies]
 axum               = { version = "0.8.4", default-features = false, features = ["http1", "http2", "query", "original-uri", "json", "tokio", "tracing"] }
 bytes              = "1.0"
-crossbeam-utils    = "0.8"
 daemonbase         = { version = "0.1.5", features = ["tokio"] }
 serde              = { workspace = true, features = ["derive", "rc"] }
 rayon = "1.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ version = "1.1.6"
 # TODO: Maintenance?
 [workspace.dependencies.clap]
 version = "4.5"
+default-features = false
 
 # 'domain' is a general-purpose library for DNS.
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,8 @@ lazy_static = { version = "1.5" }
 # support-color checks various environment variables and terminal settings for
 # whether ANSI escape codes should be emitted. It is also used by `anstream`
 # (and therefore `clap`).
+#
+# TODO: `anstream` now uses `anstyle-query` instead of `supports-color`.
 supports-color = "3.0.2"
 
 # `hostname` is a very popular crate to get the hostname of the current process.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,13 +116,14 @@ axum               = { version = "0.8.4", default-features = false, features = [
 bytes              = "1.0"
 crossbeam-utils    = "0.8"
 daemonbase         = { version = "0.1.5", features = ["tokio"] }
-futures            = "0.3.17"
-futures-util       = "0.3"
 serde              = { workspace = true, features = ["derive", "rc"] }
 rayon = "1.10.0"
 serde_json         = "1.0"
 serde_with         = "3"
 url                = { version = "2.4", features = ["serde"] }
+
+# `futures` provides some async functionality not available in `std` yet.
+futures-util = "0.3"
 
 # Jiff is used by zone_signer for the DateCounter serial policy.
 jiff.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,9 @@ serde_json         = "1.0"
 serde_with         = "3"
 url                = { version = "2.4", features = ["serde"] }
 
-# `futures` provides some async functionality not available in `std` yet.
+# `futures` provides some async functionality not available in `std` yet. It's
+# quite a big crate, and we only need a subset of the functionality, so we only
+# import the `-util` subcrate.
 futures-util = "0.3"
 
 # Jiff is used by zone_signer for the DateCounter serial policy.

--- a/crates/cfg/Cargo.toml
+++ b/crates/cfg/Cargo.toml
@@ -29,7 +29,7 @@ features = ["serde1"]
 # 'clap' is used for defining and parsing command-line arguments.
 [dependencies.clap]
 workspace = true
-features = ["wrap_help"]
+default-features = false
 
 # 'foldhash' offers fast, non-cryptographic hash tables.
 [dependencies.foldhash]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -41,11 +41,6 @@ path = "../api"
 workspace = true
 features = ["cargo", "derive", "env", "wrap_help"]
 
-# TODO: Evaluate this choice.
-[dependencies.futures-util]
-version = "0.3"
-default-features = false
-
 # The CLI uses 'jiff' to process timestamps and durations, and to print them in
 # human-readable terms.
 [dependencies.jiff]

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -97,6 +97,7 @@ mod compat {
         tsig,
     };
     use futures::Stream;
+    use futures_util as futures;
     use tracing::{Level, debug, trace, warn};
 
     use crate::{


### PR DESCRIPTION
A clean `cargo check` on `main` pulls in 279 crates, fills 660MiB in `target`, and takes ~25 seconds.

A clean `cargo check` with this PR pulls in 251 crates (-28), fills 597MiB in `target` (-63MiB), and takes ~23 seconds.

- Disabled IDN support for URLs, saving a good number of dependencies.
- `futures` is an umbrella project pulling in many crates, I limited it to `futures-util` which provides what we need (and is already being pulled in by `domain`).
- `cascade-cfg` unnecessarily required `clap` features, I disabled all of them.
- Removed the `crossbeam-utils` dependency, which was unused.

Further savings can be obtained removing `syslog` and `time` from `daemonbase` (we already do our own logging, and we use `jiff` for the rest of Cascade). Left for future work.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [ ] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?