### PR TITLE
Fix: use id's to sort persisted diffs instead of file paths

### DIFF
--- a/src/persistence/zone.rs
+++ b/src/persistence/zone.rs
@@ -656,7 +656,12 @@ impl PersistedDiffManager {
                 self.next_uniqifier
             ))
             .into_std_path_buf();
-        let file_info = PersistedDiffFileInfo::new(path.clone(), loaded_serial, signed_serial);
+        let file_info = PersistedDiffFileInfo::new(
+            self.next_uniqifier,
+            path.clone(),
+            loaded_serial,
+            signed_serial,
+        );
 
         trace!(
             "Pushing diff with loaded serial {loaded_serial:?} and signed serial {signed_serial:?} for zone '{}' with path '{}'",
@@ -741,6 +746,8 @@ impl PersistedDiffManager {
 /// Information about a single persisted zone data file.
 #[derive(Clone, Debug)]
 pub struct PersistedDiffFileInfo {
+    id: usize,
+
     /// The location on disk where the zone data file exists.
     path: PathBuf,
 
@@ -758,15 +765,21 @@ pub struct PersistedDiffFileInfo {
 
 impl PersistedDiffFileInfo {
     pub fn new(
+        id: usize,
         path: PathBuf,
         loaded_serial: Option<Serial>,
         signed_serial: Option<Serial>,
     ) -> Self {
         Self {
+            id,
             path,
             loaded_serial,
             signed_serial,
         }
+    }
+
+    pub fn id(&self) -> usize {
+        self.id
     }
 
     pub fn path(&self) -> &PathBuf {
@@ -798,7 +811,7 @@ impl PartialOrd for PersistedDiffFileInfo {
 
 impl Ord for PersistedDiffFileInfo {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.path.cmp(&other.path)
+        self.id.cmp(&other.id)
     }
 }
 

--- a/src/zone/state/v1.rs
+++ b/src/zone/state/v1.rs
@@ -921,6 +921,7 @@ impl PersistedDiffsSpec {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct PersistedDiffFileInfoSpec {
+    id: usize,
     path: PathBuf,
     #[serde(skip_serializing_if = "Option::is_none")]
     loaded_serial: Option<Serial>,
@@ -932,6 +933,7 @@ impl PersistedDiffFileInfoSpec {
     /// Parse from this specification.
     fn parse(self) -> PersistedDiffFileInfo {
         PersistedDiffFileInfo::new(
+            self.id,
             self.path,
             self.loaded_serial
                 .map(|s| domain::new::base::Serial::from(s.0)),
@@ -943,6 +945,7 @@ impl PersistedDiffFileInfoSpec {
     /// Build into this specification.
     fn build(info: &PersistedDiffFileInfo) -> Self {
         Self {
+            id: info.id(),
             path: info.path().to_path_buf(),
             loaded_serial: info.loaded_serial().map(|s| Serial(s.into())),
             signed_serial: info.signed_serial().map(|s| Serial(s.into())),


### PR DESCRIPTION
This was something I missed during the purging review. I think this is the simplest fix for it. I'm intentionally keeping this very small and self-contained to get the fix in as quickly as possible.

The issue is that the paths get sorted lexicographically so the path `se.loaded.10` is sorted before `se.loaded.2`. To fix this, we store the id as a `usize` separately and implement `Ord` by comparing just that field.

Closes #908