### PR TITLE
Apply ignore case to the RR argument on `cascade keyset <zone> get <RR>`

### DIFF
--- a/crates/cli/src/commands/keyset.rs
+++ b/crates/cli/src/commands/keyset.rs
@@ -55,6 +55,7 @@ enum KeySetCommand {
     /// Get the zones key(s).
     Get {
         /// Which key RRset to print.
+        #[arg(ignore_case = true)]
         rr: KeyGetType,
     },
 }


### PR DESCRIPTION
As suggested by @maertsen.

Now accepts
```
cascade keyset example.com get DNSKEY
```
in addition to any other variation of case in the RR type.
