### PR TITLE
Make signing functions unit-testable

### DIFF
--- a/src/signer/full.rs
+++ b/src/signer/full.rs
@@ -2,9 +2,9 @@
 
 use std::{
     cmp::Ordering,
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     env::{self, VarError},
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex, RwLock},
     time::Instant,
 };
 
@@ -35,6 +35,7 @@ use domain::{
     },
     rdata::ZoneRecordData,
 };
+use domain_kmip::dep::kmip::client::pool::SyncConnPool;
 use rayon::{
     iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelExtend, ParallelIterator},
     slice::ParallelSliceMut,
@@ -42,11 +43,8 @@ use rayon::{
 use tracing::{debug, info};
 
 use crate::{
-    center::Center,
-    manager::record_zone_event,
     policy::{PolicyVersion, SignerDenialPolicy},
     signer::{
-        SigningTrigger,
         incremental::LocalState,
         keys::ZoneSigningKeys,
         status::{SigningStatusPerZone, ZoneSigningStatus},
@@ -55,30 +53,21 @@ use crate::{
         key_manager::mk_dnst_keyset_state_file_path,
         zone_signer::{KeySetState, MinTimestamp, SignerError},
     },
-    zone::{HistoricalEvent, Zone},
     zonedata::{OldRecord, RegularRecord, SignedZoneBuilder},
 };
 
 pub fn sign_zone(
-    center: &Arc<Center>,
-    zone: &Arc<Zone>,
+    config: &crate::config::Config,
+    zone_name: &domain::base::Name<Bytes>,
+    policy: &PolicyVersion,
+    kmip_servers: &Mutex<HashMap<String, SyncConnPool>>,
     builder: &mut SignedZoneBuilder,
-    trigger: SigningTrigger,
+    local_state: &mut LocalState,
     status: Arc<RwLock<SigningStatusPerZone>>,
 ) -> Result<(), SignerError> {
-    let zone_name = &zone.name;
-
     info!("[ZS]: Starting signing operation for zone '{zone_name}'");
     let start = Instant::now();
 
-    let mut local_state = LocalState::new(zone)?;
-
-    let policy = {
-        // Use a block to make sure that the lock is clearly dropped.
-        let zone_state = zone.read();
-
-        zone_state.policy.clone().unwrap()
-    };
     let previous_serial = local_state.previous_serial;
 
     //
@@ -127,7 +116,7 @@ pub fn sign_zone(
     //
     // Create a signing configuration.
     //
-    let signing_config = signing_config(&policy)?;
+    let signing_config = signing_config(policy)?;
     let rrsig_cfg = GenerateRrsigConfig::new(signing_config.inception, signing_config.expiration);
 
     //
@@ -158,7 +147,7 @@ pub fn sign_zone(
     debug!("Reading dnst keyset DNSKEY RRs and RRSIG RRs");
     status.write().unwrap().current_action = "Fetching apex RRs from the key manager".to_string();
     // Read the DNSKEY RRs and DNSKEY RRSIG RR from the keyset state.
-    let state_path = mk_dnst_keyset_state_file_path(&center.config.keys_dir, &zone.name);
+    let state_path = mk_dnst_keyset_state_file_path(&config.keys_dir, zone_name);
     let state = std::fs::read_to_string(&state_path)
         .map_err(|_| SignerError::CannotReadStateFile(state_path.into_string()))?;
     let state: KeySetState = serde_json::from_str(&state).unwrap();
@@ -181,7 +170,7 @@ pub fn sign_zone(
 
     debug!("Loading dnst keyset signing keys");
     // Load the signing keys indicated by the keyset state.
-    let signing_keys = ZoneSigningKeys::load(center, zone, &state, &status)?;
+    let signing_keys = ZoneSigningKeys::load(config, zone_name, kmip_servers, &state, &status)?;
 
     // Save the current zone signing keys and clear key_roll
     let mut key_tags = HashSet::new();
@@ -231,7 +220,7 @@ pub fn sign_zone(
         DenialConfig::AlreadyPresent => {}
 
         DenialConfig::Nsec(cfg) => {
-            let nsecs = generate_nsecs(&zone.name, RecordsIter::new_from_owned(&records), cfg)
+            let nsecs = generate_nsecs(zone_name, RecordsIter::new_from_owned(&records), cfg)
                 .map_err(|err: SigningError| {
                     SignerError::SigningError(format!("Failed to generate denial RRs: {err}"))
                 })?;
@@ -249,7 +238,7 @@ pub fn sign_zone(
             // order." We store the NSEC3s as we create them and sort them
             // afterwards.
             let Nsec3Records { nsec3s, nsec3param } =
-                generate_nsec3s(&zone.name, RecordsIter::new_from_owned(&records), cfg).map_err(
+                generate_nsec3s(zone_name, RecordsIter::new_from_owned(&records), cfg).map_err(
                     |err: SigningError| {
                         SignerError::SigningError(format!("Failed to generate denial RRs: {err}"))
                     },
@@ -337,7 +326,7 @@ pub fn sign_zone(
         // Generate signatures from each segment.
         let signatures = segments.map(|range| {
             sign_sorted_zone_records(
-                &zone.name,
+                zone_name,
                 RecordsIter::new_from_owned(&unsigned_records[range]),
                 &keys,
                 &rrsig_cfg,
@@ -358,7 +347,7 @@ pub fn sign_zone(
             .map_err(|err| SignerError::SigningError(err.to_string()))?
     } else {
         let signatures = sign_sorted_zone_records(
-            &zone.name,
+            zone_name,
             RecordsIter::new_from_owned(&unsigned_records),
             &keys,
             &rrsig_cfg,
@@ -414,6 +403,8 @@ pub fn sign_zone(
     }
     local_state.next_min_expiration = saved_min_expiration.get();
 
+    local_state.last_signature_refresh = UnixTime::now();
+
     let total_time = start.elapsed();
 
     {
@@ -441,18 +432,6 @@ pub fn sign_zone(
         generation_time.as_secs_f64(),
         total_time.as_secs_f64()
     );
-
-    record_zone_event(
-        center,
-        zone,
-        HistoricalEvent::SigningSucceeded {
-            trigger: trigger.into(),
-        },
-        Some(Serial(serial.into())),
-    );
-
-    local_state.last_signature_refresh = UnixTime::now();
-    local_state.save(center, zone);
 
     Ok(())
 }

--- a/src/signer/incremental.rs
+++ b/src/signer/incremental.rs
@@ -4,7 +4,7 @@ use core::ops::RangeBounds;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet, btree_map, hash_map, hash_set};
 use std::hash;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, UNIX_EPOCH};
 
 use bytes::{Bytes, BytesMut};
@@ -40,30 +40,30 @@ use domain::rdata::{Nsec, Nsec3, Nsec3param, Soa, ZoneRecordData, Zonemd};
 use domain::utils::base32;
 use domain::utils::dst::UnsizedCopy;
 use domain::zonefile::inplace::Entry;
+use domain_kmip::dep::kmip::client::pool::SyncConnPool;
 use rayon::slice::ParallelSliceMut;
 use ring::digest;
 use tokio::time::Instant;
 use tracing::debug;
 use tracing::error;
 
-use crate::center::Center;
-use crate::manager::record_zone_event;
 use crate::policy::{PolicyVersion, SignerDenialPolicy};
-use crate::signer::SigningTrigger;
 use crate::signer::keys::ZoneSigningKeys;
 use crate::signer::status::SigningStatusPerZone;
 use crate::units::key_manager::mk_dnst_keyset_state_file_path;
 use crate::units::zone_signer::{
     KeySetState, MinTimestamp, PassThroughMode, SignerError, faketime_or_now,
 };
-use crate::zone::{HistoricalEvent, Zone};
+use crate::zone::{Zone, ZoneState};
 use crate::zonedata::{DiffData, RegularRecord, SignedZonePatcher, SignedZoneReader, SoaRecord};
 
 pub fn sign_incrementally(
+    config: &crate::config::Config,
+    zone_name: &Name<Bytes>,
+    policy: &PolicyVersion,
+    kmip_servers: &Mutex<HashMap<String, SyncConnPool>>,
     patch: SignedZonePatcher,
-    zone: &Arc<Zone>,
-    center: &Arc<Center>,
-    trigger: SigningTrigger,
+    local_state: &mut LocalState,
     status: Arc<RwLock<SigningStatusPerZone>>,
 ) -> Result<(), SignerError> {
     // Check what work needs to be done. If the keyset state
@@ -80,24 +80,18 @@ pub fn sign_incrementally(
         "Start incremental signing".to_string();
     let load_unsigned = patch.next_loaded().is_some();
 
-    let origin = &zone.name;
-    let state_path = mk_dnst_keyset_state_file_path(&center.config.keys_dir, origin);
+    let state_path = mk_dnst_keyset_state_file_path(&config.keys_dir, zone_name);
     let state = std::fs::read_to_string(&state_path)
         .map_err(|_| SignerError::CannotReadStateFile(state_path.into_string()))?;
     let keyset_state: KeySetState = serde_json::from_str(&state)
         .map_err(|e| SignerError::SigningError(format!("loading keyset state failed: {e}")))?;
 
-    let policy = zone.read().policy.clone().unwrap();
-
     let use_nsec3 = matches!(policy.signer.denial, SignerDenialPolicy::NSec3 { .. });
 
-    let local_state = LocalState::new(zone)?;
     let mut ws = WorkSpace {
         keyset_state,
         use_nsec3,
-        policy: policy.clone(),
-        zone: zone.clone(),
-        center: center.clone(),
+        policy,
         patch,
         zonemd: HashSet::new(),
         //zonemd: [(ZonemdScheme::SIMPLE, ZonemdAlgorithm::SHA384)].into(),
@@ -133,7 +127,14 @@ pub fn sign_incrementally(
         return Err(SignerError::NothingToDo);
     }
 
-    let mut iss = IncrementalSigningState::new(zone, &policy, center, &ws.keyset_state, status)?;
+    let mut iss = IncrementalSigningState::new(
+        config,
+        zone_name,
+        kmip_servers,
+        policy,
+        &ws.keyset_state,
+        &status,
+    )?;
 
     let start = Instant::now();
     let patch_curr = ws.patch.curr();
@@ -214,19 +215,6 @@ pub fn sign_incrementally(
         ws.local_state.next_min_expiration
     );
 
-    record_zone_event(
-        center,
-        zone,
-        HistoricalEvent::SigningSucceeded {
-            trigger: trigger.into(),
-        },
-        ws.local_state
-            .previous_serial
-            .map(|s| domain::base::Serial(s.into())),
-    );
-
-    ws.local_state.save(&ws.center, &ws.zone);
-
     Ok(())
 }
 
@@ -237,9 +225,7 @@ type ChangesValue = (RtypeSet, RtypeSet); // add set followed by delete set.
 struct WorkSpace<'a> {
     pub keyset_state: KeySetState,
     pub use_nsec3: bool,
-    pub policy: Arc<PolicyVersion>,
-    pub zone: Arc<Zone>,
-    pub center: Arc<Center>,
+    pub policy: &'a PolicyVersion,
     pub patch: SignedZonePatcher<'a>,
 
     // Extra fields that should go to policy.
@@ -247,7 +233,7 @@ struct WorkSpace<'a> {
     pub pass_through_mode: PassThroughMode,
 
     // Local copy of state variables we need.
-    local_state: LocalState,
+    local_state: &'a mut LocalState,
 }
 
 impl WorkSpace<'_> {
@@ -362,7 +348,7 @@ impl WorkSpace<'_> {
                     .expect("NSEC record should exist");
                 let records = [record.clone().into()];
                 sign_records(
-                    &iss.origin,
+                    iss.origin,
                     &records,
                     &iss.keys,
                     iss.inception,
@@ -377,7 +363,7 @@ impl WorkSpace<'_> {
                 let record: Zrd = record.clone().into();
                 let records = [record.clone()];
                 sign_records(
-                    &iss.origin,
+                    iss.origin,
                     &records,
                     &iss.keys,
                     iss.inception,
@@ -385,7 +371,7 @@ impl WorkSpace<'_> {
                     &mut new_sigs,
                 )?;
             } else {
-                let new_origin = old_base_name_to_revnamebuf(&iss.origin);
+                let new_origin = old_base_name_to_revnamebuf(iss.origin);
                 let records = if *key.0 == *new_origin.as_ref() {
                     iss.new_apex
                         .get(&key.1)
@@ -397,7 +383,7 @@ impl WorkSpace<'_> {
                 }
                 .expect("records should exist");
                 sign_records(
-                    &iss.origin,
+                    iss.origin,
                     &records,
                     &iss.keys,
                     iss.inception,
@@ -464,7 +450,7 @@ impl WorkSpace<'_> {
                         .expect("NSEC record should exist");
                     let records = [record.clone().into()];
                     sign_records(
-                        &iss.origin,
+                        iss.origin,
                         &records,
                         &iss.keys,
                         iss.inception,
@@ -479,7 +465,7 @@ impl WorkSpace<'_> {
                     let record: Zrd = record.clone().into();
                     let records = [record.clone()];
                     sign_records(
-                        &iss.origin,
+                        iss.origin,
                         &records,
                         &iss.keys,
                         iss.inception,
@@ -487,7 +473,7 @@ impl WorkSpace<'_> {
                         &mut new_sigs,
                     )?;
                 } else {
-                    let new_origin = old_base_name_to_revnamebuf(&iss.origin);
+                    let new_origin = old_base_name_to_revnamebuf(iss.origin);
                     let records: Vec<Zrd> = if *key.0 == *new_origin.as_ref() {
                         iss.new_apex
                             .get(&key.1)
@@ -499,7 +485,7 @@ impl WorkSpace<'_> {
                     }
                     .expect("records should exist");
                     sign_records(
-                        &iss.origin,
+                        iss.origin,
                         &records,
                         &iss.keys,
                         iss.inception,
@@ -558,7 +544,7 @@ impl WorkSpace<'_> {
                     .expect("NSEC record should exist");
                 let records = [record.clone().into()];
                 sign_records(
-                    &iss.origin,
+                    iss.origin,
                     &records,
                     &iss.keys,
                     iss.inception,
@@ -573,7 +559,7 @@ impl WorkSpace<'_> {
                 let record: Zrd = record.clone().into();
                 let records = [record.clone()];
                 sign_records(
-                    &iss.origin,
+                    iss.origin,
                     &records,
                     &iss.keys,
                     iss.inception,
@@ -581,7 +567,7 @@ impl WorkSpace<'_> {
                     &mut new_sigs,
                 )?;
             } else {
-                let new_origin = old_base_name_to_revnamebuf(&iss.origin);
+                let new_origin = old_base_name_to_revnamebuf(iss.origin);
                 let records: Vec<Zrd> = if *key.0 == *new_origin.as_ref() {
                     iss.new_apex
                         .get(&key.1)
@@ -593,7 +579,7 @@ impl WorkSpace<'_> {
                 }
                 .expect("records should exist");
                 sign_records(
-                    &iss.origin,
+                    iss.origin,
                     &records,
                     &iss.keys,
                     iss.inception,
@@ -947,7 +933,7 @@ impl WorkSpace<'_> {
         );
 
         let mut all_data: Vec<Zrd> = vec![];
-        let new_origin = old_base_name_to_revnamebuf(&iss.origin);
+        let new_origin = old_base_name_to_revnamebuf(iss.origin);
         all_data.extend(
             iss.data
                 .iter_unordered()
@@ -982,7 +968,7 @@ impl WorkSpace<'_> {
         all.extend(all_nsec3s);
 
         let mut all_rrsigs: Vec<Zrd> = vec![];
-        let new_origin = old_base_name_to_revnamebuf(&iss.origin);
+        let new_origin = old_base_name_to_revnamebuf(iss.origin);
         all_rrsigs.extend(
             iss.rrsigs
                 .iter()
@@ -1049,7 +1035,7 @@ impl WorkSpace<'_> {
         let key = (iss.origin.clone(), NewRtype::ZONEMD);
         let mut new_sigs = vec![];
         sign_records(
-            &iss.origin,
+            iss.origin,
             &zonemd_records,
             &iss.keys,
             iss.inception,
@@ -1143,7 +1129,7 @@ impl WorkSpace<'_> {
         // Delete all types in apex_remove.
         let curr_apex_remove = &self.local_state.apex_remove;
         for t in curr_apex_remove {
-            let new_origin = old_base_name_to_revnamebuf(&iss.origin);
+            let new_origin = old_base_name_to_revnamebuf(iss.origin);
             let new_t = old_base_rtype_to_new_base(*t);
             let key = (new_origin.as_ref(), new_t);
             iss.new_apex.remove(&new_t);
@@ -1236,7 +1222,7 @@ impl WorkSpace<'_> {
 
                 let nsec3 = nsec3.clone().into();
                 sign_records(
-                    &iss.origin,
+                    iss.origin,
                     &[nsec3],
                     &iss.keys,
                     iss.inception,
@@ -1253,7 +1239,7 @@ impl WorkSpace<'_> {
 
                 let nsec: Zrd = nsec.clone().into();
                 sign_records(
-                    &iss.origin,
+                    iss.origin,
                     &[nsec],
                     &iss.keys,
                     iss.inception,
@@ -1316,7 +1302,7 @@ impl WorkSpace<'_> {
 
 struct IncrementalSigningState<'zd> {
     /// DNS name of the zone we are signing.
-    origin: Name<Bytes>,
+    origin: &'zd Name<Bytes>,
 
     /// Apex RRsets of the previously signed zone. With the execption of
     /// NSEC, NSEC3 and RRSIG records. Old_apex and old_data are used
@@ -1364,13 +1350,14 @@ struct IncrementalSigningState<'zd> {
 
 impl<'a> IncrementalSigningState<'a> {
     pub fn new(
-        zone: &Zone,
+        config: &crate::config::Config,
+        zone_name: &'a Name<Bytes>,
+        kmip_servers: &Mutex<HashMap<String, SyncConnPool>>,
         policy: &PolicyVersion,
-        center: &Arc<Center>,
         keyset_state: &KeySetState,
-        status: Arc<RwLock<SigningStatusPerZone>>,
+        status: &RwLock<SigningStatusPerZone>,
     ) -> Result<Self, SignerError> {
-        let keys = ZoneSigningKeys::load(center, zone, keyset_state, &status)?;
+        let keys = ZoneSigningKeys::load(config, zone_name, kmip_servers, keyset_state, status)?;
 
         let now = faketime_or_now();
         let now_u32 = Into::<Duration>::into(now.clone()).as_secs() as u32;
@@ -1391,7 +1378,7 @@ impl<'a> IncrementalSigningState<'a> {
         }
         let nsec3param = old_base_nsec3param_to_new_base(&nsec3param);
         Ok(Self {
-            origin: zone.name.clone(),
+            origin: zone_name,
             old_apex: HashMap::new(),
             old_apex_saved: HashMap::new(),
             new_apex: HashMap::new(),
@@ -1413,7 +1400,7 @@ impl<'a> IncrementalSigningState<'a> {
         signed_reader: &'a SignedZoneReader,
     ) -> Result<(), SignerError> {
         // Loop over all records. Records do not have to be sorted.
-        let new_origin = old_base_name_to_revnamebuf(&self.origin);
+        let new_origin = old_base_name_to_revnamebuf(self.origin);
         for record in signed_reader.all_records() {
             match record.data() {
                 NewRecordData::Rrsig(_rrsig) => {
@@ -1445,7 +1432,7 @@ impl<'a> IncrementalSigningState<'a> {
     }
 
     pub fn load_unsigned_diffs(&mut self, diffs: DiffData) -> Result<(), SignerError> {
-        let origin_revnamebuf = old_base_name_to_revnamebuf(&self.origin);
+        let origin_revnamebuf = old_base_name_to_revnamebuf(self.origin);
 
         self.new_apex = self.old_apex.clone();
 
@@ -1516,7 +1503,7 @@ impl<'a> IncrementalSigningState<'a> {
         let mut new_sigs = vec![];
 
         // Iterated over changes.
-        let new_origin = old_base_name_to_revnamebuf(&self.origin);
+        let new_origin = old_base_name_to_revnamebuf(self.origin);
         for (key, change) in self.data.changes_iter() {
             // XXX for compatibility with the full zone signer, always
             // ignore DNSKEY/CDS/CDNSKEY when not at apex.
@@ -1552,7 +1539,7 @@ impl<'a> IncrementalSigningState<'a> {
                     if self.rrsigs.remove(&key).is_some() {
                         let new_rrset: Vec<_> = new.iter().map(|r| (*r).clone().into()).collect();
                         sign_records(
-                            &self.origin,
+                            self.origin,
                             &new_rrset,
                             &self.keys,
                             self.inception,
@@ -1573,7 +1560,7 @@ impl<'a> IncrementalSigningState<'a> {
                 }
             }
         }
-        let new_origin = old_base_name_to_revnamebuf(&self.origin);
+        let new_origin = old_base_name_to_revnamebuf(self.origin);
         for new_rrset in self.new_apex.values_mut() {
             let owner_revnamebuf = RevNameBuf::copy_from(new_rrset[0].owner());
             let owner_boxrevname = owner_revnamebuf.unsized_copy_into();
@@ -1596,7 +1583,7 @@ impl<'a> IncrementalSigningState<'a> {
                     new_rrset.iter().map(|r| (*r).clone().into()).collect();
                 if old_rrset != *new_rrset && self.rrsigs.remove(&key).is_some() {
                     sign_records(
-                        &self.origin,
+                        self.origin,
                         &old_base_new_rrset,
                         &self.keys,
                         self.inception,
@@ -1644,7 +1631,7 @@ impl<'a> IncrementalSigningState<'a> {
         // However, we removing a delegation, the situation is reversed. For now
         // assuming that sorting is not necessary.
 
-        let new_origin = old_base_name_to_revnamebuf(&self.origin);
+        let new_origin = old_base_name_to_revnamebuf(self.origin);
 
         let changes = self.changes.clone();
         for (key, (add, delete)) in &changes {
@@ -1810,7 +1797,7 @@ impl<'a> IncrementalSigningState<'a> {
         // However, when removing a delegation, the situation is reversed.
         // For now assume that sorting is not necessary.
 
-        let new_origin = old_base_name_to_revnamebuf(&self.origin);
+        let new_origin = old_base_name_to_revnamebuf(self.origin);
 
         let opt_out_flag = self.nsec3param.opt_out_flag();
 
@@ -2075,7 +2062,7 @@ impl<'a> IncrementalSigningState<'a> {
         let records: Vec<_> = records.into_iter().map(|r| r.to_record().clone()).collect();
         let records_iter = RecordsIter::new_from_owned(&records);
         let config = GenerateNsecConfig::new();
-        let nsec_records = generate_nsecs(&self.origin, records_iter, &config)
+        let nsec_records = generate_nsecs(self.origin, records_iter, &config)
             .map_err(|e| SignerError::SigningError(format!("new_nsec_chain failed: {e}")))?;
 
         // Collect signatures here.
@@ -2091,7 +2078,7 @@ impl<'a> IncrementalSigningState<'a> {
             let new_record: RegularRecord = record.clone().into();
             self.nsecs.insert_new_record(new_record.clone());
             sign_records(
-                &self.origin,
+                self.origin,
                 &[record],
                 &self.keys,
                 self.inception,
@@ -2112,7 +2099,7 @@ impl<'a> IncrementalSigningState<'a> {
         let old_nsec3param = new_base_nsec3param_to_old_base(&self.nsec3param);
         let config = GenerateNsec3Config::<_, DefaultSorter>::new(old_nsec3param)
             .with_ttl_mode(Nsec3ParamTtlMode::SoaMinimum);
-        let nsec3_records = generate_nsec3s(&self.origin, records_iter, &config)
+        let nsec3_records = generate_nsec3s(self.origin, records_iter, &config)
             .map_err(|e| SignerError::SigningError(format!("generate_nsec3s failed: {e}")))?;
 
         // Collect signatures here.
@@ -2129,7 +2116,7 @@ impl<'a> IncrementalSigningState<'a> {
 
         // Insert in both old and new data.
         sign_records(
-            &self.origin,
+            self.origin,
             &[record],
             &self.keys,
             self.inception,
@@ -2151,7 +2138,7 @@ impl<'a> IncrementalSigningState<'a> {
             let new_record: RegularRecord = record.clone().into();
             self.nsec3s.insert_new_record(new_record.clone());
             sign_records(
-                &self.origin,
+                self.origin,
                 &[record],
                 &self.keys,
                 self.inception,
@@ -3226,10 +3213,10 @@ pub struct LocalState {
 }
 
 impl LocalState {
-    pub fn new(zone: &Arc<Zone>) -> Result<Self, SignerError> {
+    pub fn new(zone: &Arc<Zone>) -> Self {
         let zone_state = zone.read();
 
-        Ok(Self {
+        Self {
             apex_remove: zone_state.apex_remove.clone(),
             apex_extra: zone_state.apex_extra.clone(),
             last_signature_refresh: zone_state.last_signature_refresh.clone(),
@@ -3237,15 +3224,10 @@ impl LocalState {
             key_roll: zone_state.key_roll.clone(),
             previous_serial: zone_state.previous_serial,
             next_min_expiration: zone_state.next_min_expiration,
-        })
+        }
     }
 
-    pub fn save(self, center: &Arc<Center>, zone: &Arc<Zone>) {
-        // TODO: The state is always marked as dirty. We could avoid marking it
-        // as dirty in case we detect a modification has not happened. We should
-        // evaluate whether this is worthwhile.
-        let mut zone_state = zone.write(center);
-
+    pub fn save(self, zone_state: &mut ZoneState) {
         zone_state.apex_remove = self.apex_remove;
         zone_state.apex_extra = self.apex_extra;
         zone_state.last_signature_refresh = self.last_signature_refresh;
@@ -4130,7 +4112,7 @@ fn sign_rtype_set(
             panic!("Expected something for {name}/{rtype}");
         };
         sign_records(
-            &iss.origin,
+            iss.origin,
             &records,
             &iss.keys,
             iss.inception,

--- a/src/signer/keys.rs
+++ b/src/signer/keys.rs
@@ -2,7 +2,8 @@
 
 use core::fmt;
 use std::{
-    sync::{Arc, RwLock},
+    collections::HashMap,
+    sync::{Arc, Mutex, RwLock},
     time::Duration,
 };
 
@@ -19,20 +20,18 @@ use domain::{
 };
 use domain_kmip::{
     ConnectionSettings, KeyUrl,
-    dep::kmip::client::pool::{ConnectionManager, KmipConnError},
+    dep::kmip::client::pool::{ConnectionManager, KmipConnError, SyncConnPool},
 };
 use tracing::{debug, error, warn};
 use url::Url;
 
 use crate::{
-    center::Center,
     signer::status::SigningStatusPerZone,
     units::{
         http_server::KmipServerState,
         key_manager::{KmipClientCredentialsFile, KmipServerCredentialsFileMode},
         zone_signer::KeySetState,
     },
-    zone::Zone,
 };
 
 //----------- ZoneSigningKeys --------------------------------------------------
@@ -58,11 +57,12 @@ impl ZoneSigningKeys {
     #[tracing::instrument(
         level = "debug",
         skip_all,
-        fields(zone = %zone.name),
+        fields(zone = %zone_name),
     )]
     pub fn load(
-        center: &Center,
-        zone: &Zone,
+        config: &crate::config::Config,
+        zone_name: &Name<Bytes>,
+        kmip_servers: &Mutex<HashMap<String, SyncConnPool>>,
         keyset_state: &KeySetState,
         status: &RwLock<SigningStatusPerZone>,
     ) -> Result<Self, Box<LoadError>> {
@@ -98,7 +98,7 @@ impl ZoneSigningKeys {
 
             let keypair = match priv_url.scheme() {
                 "file" => KeyPair::load_from_disk(
-                    zone,
+                    zone_name,
                     priv_url.path().as_ref(),
                     pub_url.path().as_ref(),
                 )?,
@@ -115,14 +115,14 @@ impl ZoneSigningKeys {
                             error,
                         })
                     })?;
-                    KeyPair::load_kmip(center, priv_url, pub_url, status)?
+                    KeyPair::load_kmip(config, kmip_servers, priv_url, pub_url, status)?
                 }
                 _ => {
                     return Err(Box::new(LoadError::UnsupportedScheme { url: pub_url }));
                 }
             };
 
-            let key = SigningKey::new(zone.name.clone(), keypair.dnskey().flags(), keypair);
+            let key = SigningKey::new(zone_name.clone(), keypair.dnskey().flags(), keypair);
 
             debug!("Successfully loaded key '{priv_url}' + '{pub_url}'");
             list.push(key);
@@ -183,7 +183,7 @@ impl SignRaw for KeyPair {
 impl KeyPair {
     /// Load a key-pair from the disk.
     pub fn load_from_disk(
-        zone: &Zone,
+        zone_name: &Name<Bytes>,
         priv_key_path: &Utf8Path,
         pub_key_path: &Utf8Path,
     ) -> Result<Self, Box<LoadError>> {
@@ -202,9 +202,8 @@ impl KeyPair {
                 })
             })?;
 
-        if pub_key.owner() != &zone.name {
+        if pub_key.owner() != zone_name {
             let encoded_owner = pub_key.owner();
-            let zone_name = &zone.name;
             warn!(
                 "The public key at '{pub_key_path}' \
                 encodes the owner name '{encoded_owner}', \
@@ -270,7 +269,8 @@ impl KeyPair {
 impl KeyPair {
     /// Load a KMIP key-pair.
     pub fn load_kmip(
-        center: &Center,
+        config: &crate::config::Config,
+        kmip_servers: &Mutex<HashMap<String, SyncConnPool>>,
         priv_key_url: KeyUrl,
         pub_key_url: KeyUrl,
         status: &RwLock<SigningStatusPerZone>,
@@ -278,7 +278,7 @@ impl KeyPair {
         // TODO: Replace the connection pool if the persisted KMIP server settings
         // were updated more recently than the pool was created.
 
-        let mut kmip_servers = center.signer.kmip_servers.lock().unwrap();
+        let mut kmip_servers = kmip_servers.lock().unwrap();
         let kmip_conn_pool = match kmip_servers.entry(priv_key_url.server_id().to_string()) {
             std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
             std::collections::hash_map::Entry::Vacant(e) => {
@@ -286,10 +286,7 @@ impl KeyPair {
                     format!("Connecting to KMIP server '{}'", priv_key_url.server_id());
 
                 // Try and load the KMIP server settings.
-                let server_state_path = center
-                    .config
-                    .kmip_server_state_dir
-                    .join(priv_key_url.server_id());
+                let server_state_path = config.kmip_server_state_dir.join(priv_key_url.server_id());
                 debug!("Reading KMIP server state from '{server_state_path}'");
                 let f = std::fs::File::open(&server_state_path).map_err(|error| {
                     Box::new(LoadError::UnreadableKmipServerState {
@@ -319,7 +316,7 @@ impl KeyPair {
                 let mut username = None;
                 let mut password = None;
                 if has_credentials {
-                    let creds_path = &center.config.kmip_credentials_store_path;
+                    let creds_path = &config.kmip_credentials_store_path;
                     let creds_file = KmipClientCredentialsFile::new(
                         creds_path.as_std_path(),
                         KmipServerCredentialsFileMode::ReadOnly,

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -29,8 +29,8 @@ use tracing::{debug, error};
 
 use crate::{
     center::Center,
-    policy::SignerSerialPolicy,
-    signer::{queue::SigningPermit, status::SigningStatusPerZone},
+    policy::{PolicyVersion, SignerSerialPolicy},
+    signer::{incremental::LocalState, queue::SigningPermit, status::SigningStatusPerZone},
     units::zone_signer::SignerError,
     zone::{HistoricalEvent, Zone},
     zonedata::SignedZoneBuilder,
@@ -64,17 +64,36 @@ pub mod zone;
 fn sign(
     center: Arc<Center>,
     zone: Arc<Zone>,
+    policy: Arc<PolicyVersion>,
     mut builder: SignedZoneBuilder,
     trigger: SigningTrigger,
     permit: SigningPermit,
     status: Arc<RwLock<SigningStatusPerZone>>,
 ) {
     let start = Instant::now();
+    let mut local_state = LocalState::new(&zone);
+    let kmip_servers = &center.signer.kmip_servers;
 
     let result = if let Some(patcher) = builder.patch() {
-        self::incremental::sign_incrementally(patcher, &zone, &center, trigger, status.clone())
+        self::incremental::sign_incrementally(
+            &center.config,
+            &zone.name,
+            &policy,
+            kmip_servers,
+            patcher,
+            &mut local_state,
+            status.clone(),
+        )
     } else {
-        self::full::sign_zone(&center, &zone, &mut builder, trigger, status.clone())
+        self::full::sign_zone(
+            &center.config,
+            &zone.name,
+            &policy,
+            kmip_servers,
+            &mut builder,
+            &mut local_state,
+            status.clone(),
+        )
     };
 
     let end = Instant::now();
@@ -96,6 +115,15 @@ fn sign(
                 serial = ?soa.rdata.serial,
                 "Generated a new signed instance of the zone"
             );
+
+            handle.state.record_event(
+                HistoricalEvent::SigningSucceeded {
+                    trigger: trigger.into(),
+                },
+                local_state.previous_serial,
+            );
+
+            local_state.save(&mut handle.state);
 
             let built = builder.finish().unwrap_or_else(|_| unreachable!());
             handle.get().finish_signing(built);

--- a/src/signer/zone.rs
+++ b/src/signer/zone.rs
@@ -403,6 +403,7 @@ impl SignerZoneHandle<'_> {
             current_action: "Initiating signing".into(),
             status: ZoneSigningStatus::new(),
         }));
+        let policy = self.state.policy.clone().unwrap();
 
         // The current logging span is nested fairly deep within the logic for
         // initiating signing operations, and does not really matter for the
@@ -412,7 +413,7 @@ impl SignerZoneHandle<'_> {
             let center = self.center.clone();
             let zone = self.zone.clone();
             let status = status.clone();
-            move || super::sign(center, zone, builder, trigger, permit, status)
+            move || super::sign(center, zone, policy, builder, trigger, permit, status)
         });
         self.state.signer.active_signing_status = Some(status);
     }


### PR DESCRIPTION
This should make it easier for us to introduce more complex or thorough tests for signing. We can copy the existing `incremental-signing` integration tests into unit tests, and possibly remove some (not all) of the tested cases from the integration tests.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
