### PR TITLE
Specify key roll strategies explicitly rather than using `dnst keyset` defaults.

### DIFF
--- a/doc/manual/source/key-management.rst
+++ b/doc/manual/source/key-management.rst
@@ -100,9 +100,9 @@ Finally, an algorithm roll is similar to a CSK roll, but it is designed in a
 specific way to handle the case where the new key or keys have an algorithm
 that is different from one used by the current signing keys.
 
-Cascade uses the ``double-signature-ksk-roll`` and ``pre-publish-zsk-roll``
-roll types as implemented by the :subcmd:`keyset` subcommand of
-:program:`dnst`.
+Cascade uses the ``double-signature-ksk-roll`` (RFC 7583 Double-KSK) and
+``pre-publish-zsk-roll`` (RFC 7583 Double-Signature) roll types as implemented
+by the :subcmd:`keyset` subcommand of :program:`dnst`.
 
 The KSK and ZSK rolls are completely independent and can run in parallel.
 Consistency checks are performed at the start of a key roll. For example, a

--- a/doc/manual/source/key-management.rst
+++ b/doc/manual/source/key-management.rst
@@ -100,9 +100,9 @@ Finally, an algorithm roll is similar to a CSK roll, but it is designed in a
 specific way to handle the case where the new key or keys have an algorithm
 that is different from one used by the current signing keys.
 
-Cascade uses the ``double-signature-ksk-roll`` (RFC 7583 Double-KSK) and
-``pre-publish-zsk-roll`` (RFC 7583 Double-Signature) roll types as implemented
-by the :subcmd:`keyset` subcommand of :program:`dnst`.
+Cascade uses the ``double-signature-ksk-roll`` (:RFC:`7583` Double-KSK) and
+``pre-publish-zsk-roll`` (:RFC:`7583` Double-Signature) roll types as
+implemented by the :subcmd:`keyset` subcommand of :program:`dnst`.
 
 The KSK and ZSK rolls are completely independent and can run in parallel.
 Consistency checks are performed at the start of a key roll. For example, a

--- a/doc/manual/source/key-management.rst
+++ b/doc/manual/source/key-management.rst
@@ -100,6 +100,10 @@ Finally, an algorithm roll is similar to a CSK roll, but it is designed in a
 specific way to handle the case where the new key or keys have an algorithm
 that is different from one used by the current signing keys.
 
+Cascade uses the ``double-signature-ksk-roll`` and ``pre-publish-zsk-roll``
+roll types as implemented by the :subcmd:`keyset` subcommand of
+:program:`dnst`.
+
 The KSK and ZSK rolls are completely independent and can run in parallel.
 Consistency checks are performed at the start of a key roll. For example, a
 KSK key roll cannot start when another KSK roll is in progress or when a CSK

--- a/src/units/key_manager.rs
+++ b/src/units/key_manager.rs
@@ -928,13 +928,15 @@ fn policy_to_commands(center: &Arc<Center>, policy: &PolicyVersion) -> Vec<Vec<S
         strs!["cds-lifetime", seconds(km.cds_signature_lifetime)],
         strs!["cds-remain-time", seconds(km.cds_remain_time)],
         strs!["ds-algorithm", km.ds_algorithm],
-        strs!["default-ttl".to_string(), km.default_ttl.as_secs(),],
+        strs!["default-ttl", km.default_ttl.as_secs(),],
         strs!["autoremove", km.auto_remove],
         strs![
             "autoremove-delay",
             seconds(km.auto_remove_delay.as_secs() as u32)
         ],
         publication_nameservers_cmd,
+        strs!["ksk-roll-type", "double-signature-ksk-roll"],
+        strs!["zsk-roll-type", "pre-publish-zsk-roll"],
     ]);
     cmds
 }


### PR DESCRIPTION
To protect against unwanted/unexpected changes in `dnst keyset` default behaviour and to avoid requiring Cascade developers to have to check `dnst` documentation and code to determine which key roll strategies are in use.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
