### PR TITLE
FIX: Don't store references to non-existing loaded IXFR diffs. (fixes #917)

### DIFF
--- a/src/persistence/zone.rs
+++ b/src/persistence/zone.rs
@@ -895,9 +895,19 @@ impl IxfrZoneDiffs {
         // necessary information to do so.
     }
 
-    pub fn store_signed_diff(&mut self, loaded_serial: Option<Serial>, diff: Arc<DiffData>) {
+    pub fn store_signed_diff(&mut self, mut loaded_serial: Option<Serial>, diff: Arc<DiffData>) {
         let from_serial = diff.removed_soa.as_ref().map(|s| s.rdata.serial).unwrap();
         let to_serial = diff.added_soa.as_ref().map(|s| s.rdata.serial).unwrap();
+
+        // Do we actually have a diff from the given removed loaded SOA
+        // serial? We won't have one if the loaded zone has never changed.
+        if let Some(serial) = loaded_serial {
+            if !self.loaded_diffs.contains_key(&serial.get()) {
+                // Don't store a reference to a loaded diff that we don't have.
+                loaded_serial = None;
+            }
+        }
+
         let related_diff = RelatedSignedDiff::new(diff, loaded_serial);
         let old = self.signed_diffs.insert(from_serial.into(), related_diff);
         log_stored_diff("signed", old.is_some(), from_serial, to_serial);

--- a/src/persistence/zone.rs
+++ b/src/persistence/zone.rs
@@ -901,11 +901,11 @@ impl IxfrZoneDiffs {
 
         // Do we actually have a diff from the given removed loaded SOA
         // serial? We won't have one if the loaded zone has never changed.
-        if let Some(serial) = loaded_serial {
-            if !self.loaded_diffs.contains_key(&serial.get()) {
-                // Don't store a reference to a loaded diff that we don't have.
-                loaded_serial = None;
-            }
+        if let Some(serial) = loaded_serial
+            && !self.loaded_diffs.contains_key(&serial.get())
+        {
+            // Don't store a reference to a loaded diff that we don't have.
+            loaded_serial = None;
         }
 
         let related_diff = RelatedSignedDiff::new(diff, loaded_serial);


### PR DESCRIPTION
In #917 a reload of an unmodified input zone causes Cascade to store the signed diff in-memory with a reference to a non-existing loaded diff. On subsequent IXFR request by a client that provides the previous signed SOA serial (as that is the latest version it has and it wants the newly signed version) Cascade panics because it cannot find the non-existing related loaded diff.

This PR prevents that problem by only storing a reference to a loaded diff if such a loaded diff actually exists.

Tested manually successfully as a patch against v0.1.0-beta5 by doing:

```
$ git checkout v0.1.0-beta5
$ git cherry-pick adbec610e5f9fc342ccf0c077b22e93eacc1a659
$ cargo build
$ target/debug/cascaded --config /home/ximon/src/cascade/cascade-tmp/cascade.conf --state /tmp/cascade/state.db --log-level trace &
$ target/debug/cascade --server 127.0.0.1:2006 template policy > /tmp/cascade/policies/default.toml
$ target/debug/cascade --server 127.0.0.1:2006 policy reload
$ target/debug/cascade --server 127.0.0.1:2006 zone add --source /home/ximon/src/cascade/cascade-tmp2/example.com.zone --policy default example.com
$ target/debug/cascade --server 127.0.0.1:2006 zone status example.com
$ target/debug/cascade --server 127.0.0.1:2006 zone reload example.com
$ dig +noall +answer @127.0.0.1 -p 2005 -t IXFR=2026073100 example.com
example.com.            2000    IN      SOA     ns.example.com. some\.bloke.example.com. 2026073101 86400 3500 3212 22
example.com.            2000    IN      SOA     ns.example.com. some\.bloke.example.com. 2026073100 86400 3500 3212 22
example.com.            2000    IN      RRSIG   SOA 13 2 2000 20260814122602 20260730122602 48975 example.com. i9PyiJg+GM4v9MorhiY0ifT7YuIsndo9BaSZaxdaRWobiocK5UXmJ+k4 LRvJORexMZgZS6D98xPJvuYaPUpbAw==
example.com.            2000    IN      SOA     ns.example.com. some\.bloke.example.com. 2026073101 86400 3500 3212 22
example.com.            2000    IN      RRSIG   SOA 13 2 2000 20260814122605 20260730122605 48975 example.com. yJjgGmd/DMSfAUfVLNxYqe7agMsqHGN9NfW8Kh2shV7inbmZWiLCJ4Nl 9KW1ihL9BWMmc2UaOO8tIdgsvCq4iw==
example.com.            2000    IN      SOA     ns.example.com. some\.bloke.example.com. 2026073101 86400 3500 3212 22
```

However, that same manual procedure FAILS with this PR against current Cascade `main` due to a seemingly unrelated error elsewhere in the code:

```
$ target/debug/cascade --server 127.0.0.1:2006 zone reload example.com
Success: Sent zone reload command for example.com

thread 'cascade-worker' (3980458) panicked at src/signer/incremental.rs:1202:61:
SOA should exist
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
[1]+  Exit 101                   target/debug/cascaded --config /home/ximon/src/cascade/cascade-tmp/cascade.conf --state /tmp/cascade/state.db --log-level trace
```

I have NOT (yet?) extended the integration tests to cover this "reload unchanged zone and query IXFR for the updated signed zone" scenaro.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
