### PR TITLE
[cli] `tsig add` read TSIG keys from file only

### DIFF
--- a/crates/cli/src/commands/tsig.rs
+++ b/crates/cli/src/commands/tsig.rs
@@ -24,16 +24,15 @@ pub enum TsigCommand {
     /// Add a TSIG key
     #[command(name = "add")]
     Add {
-        /// Path to the file.
+        /// Path to the file containing the TSIG key.
+        ///
+        /// The file format is specified by `--format`.
         path: Utf8PathBuf,
 
-        /// Format used in the file.
+        /// Format used in the TSIG file.
         ///
-        /// The file isn't parsed as a real YAML file, therefore not all
-        /// features are allowed.
-        ///
-        /// The same goes for the BIND format.
-        #[arg(long, default_value_t=TsigFileFormat::Yaml, ignore_case=true, required = false)]
+        /// The NSD and Knot formats are not parsed with full YAML compliance.
+        #[arg(long, default_value_t=TsigFileFormat::Nsd, ignore_case=true, required=false)]
         format: TsigFileFormat,
     },
 
@@ -47,33 +46,34 @@ pub enum TsigCommand {
 }
 
 impl Tsig {
-    pub async fn tsig_add(
+    pub fn tsig_add(
         path: Utf8PathBuf,
         format: TsigFileFormat,
     ) -> Result<(TsigKeyName, TsigAlgorithm, String), String> {
         let content = std::fs::read_to_string(&path)
-            .map_err(|e| format!("Failed to read TSIG file '{path}' as '{format}' format: {e}"))?;
+            .map_err(|e| format!("Failed to read TSIG file '{path}' in '{format}' format: {e}"))?;
 
         let (tsig_name_raw, tsig_alg_raw, tsig_secret) = parse_tsig(&content, format)?;
 
         let tsig_alg = TsigAlgorithm::from_str(&tsig_alg_raw, true).map_err(|_| {
             format!(
-                "Unable to parse {} possible values are {:?}",
+                "Unable to parse algorithm '{}'; possible values are {:?}",
                 tsig_alg_raw,
-                TsigAlgorithm::value_variants()
+                all_possible_values::<TsigAlgorithm>()
             )
         })?;
 
         let tsig_name = TsigKeyName::from_str(&tsig_name_raw)
-            .map_err(|err| format!("Invalid TSIG key name: {err}"))?;
+            .map_err(|err| format!("Invalid TSIG key name '{tsig_name_raw}': {err}"))?;
 
         Ok((tsig_name, tsig_alg, tsig_secret))
     }
+
     pub async fn execute(self, client: CascadeApiClient) -> Result<(), String> {
         match self.command {
             // Add a TSIG key to Cascade.
             TsigCommand::Add { path, format } => {
-                let (tsig_name, tsig_alg, tsig_secret) = Tsig::tsig_add(path, format).await?;
+                let (tsig_name, tsig_alg, tsig_secret) = Tsig::tsig_add(path, format)?;
 
                 // Send a TSIG add message to the Cascade HTTP API.
                 let res: Result<TsigAddResult, TsigAddError> = client
@@ -193,6 +193,7 @@ impl Tsig {
 
 /// The TSIG key algorithms supported by Cascade.
 #[derive(Clone, Debug, clap::ValueEnum)]
+#[clap(rename_all = "kebab")]
 pub enum TsigAlgorithm {
     HmacSha1,
     HmacSha256,
@@ -215,25 +216,67 @@ impl From<TsigAlgorithm> for crate::api::TsigAlgorithm {
 
 #[derive(Clone, Debug, PartialEq, clap::ValueEnum)]
 pub enum TsigFileFormat {
-    Yaml,
+    /// NSD TSIG Documentation
+    /// <https://nsd.docs.nlnetlabs.nl/en/latest/running/using-tsig.html>
+    ///
+    /// ```text
+    /// key:
+    ///   name: "sec1_key"
+    ///   algorithm: hmac-sha256
+    ///   secret: "B22jiD30pKL541XsOZ28y+NxbcIRoGqnumH2SFC8QDE="
+    /// ```
+    ///
+    /// Note: Changed algorithm because the original is not supported.
+    Nsd,
+    /// BIND TSIG Documentation
+    /// <https://bind9.readthedocs.io/en/stable/reference.html#namedconf-statement-key>
+    ///
+    /// ```text
+    /// key <string> {
+    ///     algorithm <string>;
+    ///     secret <string>;
+    /// };
+    /// ```
     Bind,
+    /// Knot TSIG Documentation
+    /// <https://www.knot-dns.cz/docs/latest/html/reference.html#key-section>
+    ///
+    /// ```text
+    /// key:
+    ///  - id: DNAME
+    ///    algorithm: ALGORITHM
+    ///    secret: BASE64
+    /// ```
+    Knot,
 }
 
 impl fmt::Display for TsigFileFormat {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TsigFileFormat::Yaml => write!(f, "YAML"),
-            TsigFileFormat::Bind => write!(f, "BIND"),
+            TsigFileFormat::Bind => write!(f, "bind"),
+            TsigFileFormat::Knot => write!(f, "knot"),
+            TsigFileFormat::Nsd => write!(f, "nsd"),
         }
     }
 }
 impl TsigFileFormat {
-    fn keywords(&self) -> (&'static str, &'static str, &'static str) {
+    fn keywords(&self) -> (&'static str, &'static str, &'static str, &'static str) {
         match self {
-            TsigFileFormat::Bind => ("key", "algorithm", "secret"),
-            TsigFileFormat::Yaml => ("name", "algorithm", "secret"),
+            TsigFileFormat::Bind => ("key", "algorithm", "secret", "//"),
+            TsigFileFormat::Knot => ("id", "algorithm", "secret", "#"),
+            TsigFileFormat::Nsd => ("name", "algorithm", "secret", "#"),
         }
     }
+}
+
+// Used to print all possible values the enum could have in case of
+// unrecognised value.
+fn all_possible_values<E: ValueEnum>() -> Vec<String> {
+    E::value_variants()
+        .iter()
+        .filter_map(|v| v.to_possible_value())
+        .map(|v| v.get_name().to_string())
+        .collect::<Vec<_>>()
 }
 
 // Parse TSIG key values from a file.
@@ -245,9 +288,14 @@ impl TsigFileFormat {
 //
 // The keywords depend on the format used.
 fn parse_tsig(content: &str, format: TsigFileFormat) -> Result<(String, String, String), String> {
+    // Used to split on whitespaces, a line doesn't contain '\n'.
     fn is_whitespace(c: char) -> bool {
         c == ' ' || c == '\t'
     }
+
+    // Split on the first whitespace. It assumes that the first part is key
+    // and the second part is value. The value is cleaned up by removing
+    // whitespaces, comments and extracting only the relevant characters.
     fn value_cleanup(line: &str, format: &TsigFileFormat) -> Result<String, String> {
         let mut output = String::new();
         let mut in_quote = false;
@@ -258,8 +306,13 @@ fn parse_tsig(content: &str, format: TsigFileFormat) -> Result<(String, String, 
 
         for character in value.trim().chars() {
             match character {
-                c if is_whitespace(c) => break,
-                c if format == &TsigFileFormat::Bind && c == ';' => break,
+                c if is_whitespace(c) => {
+                    if !in_quote {
+                        // Break if the whitespace is not in a quote.
+                        break;
+                    }
+                }
+                ';' if format == &TsigFileFormat::Bind => break,
                 '"' => {
                     if in_quote {
                         // End of quotation reached.
@@ -280,6 +333,24 @@ fn parse_tsig(content: &str, format: TsigFileFormat) -> Result<(String, String, 
         Ok(output)
     }
 
+    // Check if the matched line is something that was matched before.
+    fn matched_line(
+        keyword: &str,
+        cur_value: &Option<String>,
+        line: &str,
+        format: &TsigFileFormat,
+    ) -> Result<String, String> {
+        let new_value = value_cleanup(line, format)?;
+
+        if let Some(cur_value_innner) = cur_value {
+            return Err(format!(
+                "Encountered keyword '{keyword}' again. \
+                Value '{cur_value_innner}' would be overwritten by '{new_value}'."
+            ));
+        }
+        Ok(new_value)
+    }
+
     let lines = content.trim().lines();
 
     let mut name: Option<String> = None;
@@ -288,11 +359,39 @@ fn parse_tsig(content: &str, format: TsigFileFormat) -> Result<(String, String, 
 
     let keywords = format.keywords();
     for line in lines {
-        match line.trim() {
-            line if line.starts_with(keywords.0) => name = Some(value_cleanup(line, &format)?),
-            line if line.starts_with(keywords.1) => algorithm = Some(value_cleanup(line, &format)?),
-            line if line.starts_with(keywords.2) => secret = Some(value_cleanup(line, &format)?),
-            _ => (),
+        // Remove the whitespaces around the content.
+        let mut line_trimmed = line.trim();
+
+        // If the format is Knot there might be a '- ' at the beginning.
+        if matches!(format, TsigFileFormat::Knot) {
+            line_trimmed = line_trimmed.trim_start_matches('-').trim();
+        }
+
+        match line_trimmed {
+            line_name if line_name.starts_with(keywords.0) => {
+                name = Some(matched_line(keywords.0, &name, line_name, &format)?);
+            }
+            line_algo if line_algo.starts_with(keywords.1) => {
+                algorithm = Some(matched_line(keywords.1, &algorithm, line_algo, &format)?);
+            }
+            line_secret if line_secret.starts_with(keywords.2) => {
+                secret = Some(matched_line(keywords.2, &secret, line_secret, &format)?);
+            }
+
+            // Comments will be ignored according to the format.
+            line_comment if line_comment.starts_with(keywords.3) => (),
+
+            // The following lines will be ignored. There is no distinction
+            // made between either formats.
+            line_ignore if line_ignore.starts_with("---") => (),
+            line_ignore if line_ignore.starts_with("key:") => (),
+            line_ignore if line_ignore.starts_with("tsig-key:") => (),
+            line_ignore if line_ignore.starts_with("};") => (),
+            "" => (),
+            ";" => (),
+            "}" => (),
+
+            line_unknown => return Err(format!("Encountered unexpected line '{line_unknown}'")),
         }
     }
 
@@ -330,28 +429,43 @@ mod tests {
         assert_eq!(tsig_cmd.command, tsig_expected);
     }
 
+    /// --- Command line parsing tests.
+
     #[test]
     fn parse_tsig_add_command_1() {
         validate_arguments(
             &["tsig", "add", "file.key"],
             TsigCommand::Add {
                 path: "file.key".into(),
-                format: TsigFileFormat::Yaml,
+                format: TsigFileFormat::Nsd,
             },
         );
     }
+
     #[test]
     fn parse_tsig_add_command_2() {
         validate_arguments(
-            &["tsig", "add", "file.key", "--format=yamL"],
+            &["tsig", "add", "file.key", "--format=nsD"],
             TsigCommand::Add {
                 path: "file.key".into(),
-                format: TsigFileFormat::Yaml,
+                format: TsigFileFormat::Nsd,
             },
         );
     }
+
     #[test]
     fn parse_tsig_add_command_3() {
+        validate_arguments(
+            &["tsig", "add", "file.key", "--format=knoT"],
+            TsigCommand::Add {
+                path: "file.key".into(),
+                format: TsigFileFormat::Knot,
+            },
+        );
+    }
+
+    #[test]
+    fn parse_tsig_add_command_4() {
         validate_arguments(
             &["tsig", "add", "file.key", "--format=binD"],
             TsigCommand::Add {
@@ -361,27 +475,53 @@ mod tests {
         );
     }
 
+    /// --- File parsing tests in different formats.
+
     #[test]
-    fn parse_tsig_yaml_invalid_1() {
-        let result = parse_tsig("name:", TsigFileFormat::Yaml).unwrap_err();
+    fn parse_tsig_nsd_invalid_1() {
+        let result = parse_tsig("name:", TsigFileFormat::Nsd).unwrap_err();
         assert!(result.contains("split on whitespace"), "{}", result);
     }
 
     #[test]
-    fn parse_tsig_yaml_invalid_2() {
-        let result = parse_tsig("name: ", TsigFileFormat::Yaml).unwrap_err();
+    fn parse_tsig_nsd_invalid_2() {
+        let result = parse_tsig("name: ", TsigFileFormat::Nsd).unwrap_err();
         assert!(result.contains("split on whitespace"), "{}", result);
     }
 
     #[test]
-    fn parse_tsig_yaml_invalid_3() {
-        let result = parse_tsig("name: f", TsigFileFormat::Yaml).unwrap_err();
+    fn parse_tsig_nsd_invalid_3() {
+        let result = parse_tsig("name: f", TsigFileFormat::Nsd).unwrap_err();
         assert!(result.contains("parse all three values"), "{}", result);
     }
+    #[test]
+    fn parse_tsig_nsd_invalid_4() {
+        let result = parse_tsig("name: f\nname: g", TsigFileFormat::Nsd).unwrap_err();
+        assert!(
+            result.contains(
+                "Encountered keyword 'name' again. Value 'f' would be overwritten by 'g'."
+            ),
+            "{}",
+            result
+        );
+    }
 
     #[test]
-    fn parse_tsig_yaml_minimal() {
-        let result = parse_tsig("name f\nalgorithm: f\nsecret: f", TsigFileFormat::Yaml).unwrap();
+    fn parse_tsig_nsd_minimal() {
+        let result = parse_tsig("name f\nalgorithm: f\nsecret: f", TsigFileFormat::Nsd).unwrap();
+        assert_eq!(result, ("f".into(), "f".into(), "f".into()));
+    }
+
+    #[test]
+    fn parse_tsig_nsd_space_in_value() {
+        let result =
+            parse_tsig("name f\nalgorithm: f\nsecret: \"f s\"", TsigFileFormat::Nsd).unwrap();
+        assert_eq!(result, ("f".into(), "f".into(), "f s".into()));
+    }
+
+    #[test]
+    fn parse_tsig_knot_minimal() {
+        let result = parse_tsig("id f\nalgorithm f\nsecret f", TsigFileFormat::Knot).unwrap();
         assert_eq!(result, ("f".into(), "f".into(), "f".into()));
     }
 
@@ -391,18 +531,19 @@ mod tests {
         assert_eq!(result, ("f".into(), "f".into(), "f".into()));
     }
 
+    /// --- Example snippets from tools and documentation.
+
     #[test]
-    fn parse_tsig_yaml_format() {
+    fn parse_tsig_nsd_format() {
         let content = r#"---
 # this is a comment
 # test.key:hmac-sha256:B22jiD30pKL541XsOZ28y+NxbcIRoGqnumH2SFC8QDE=
 tsig-key: # could also be called key
     name: test.key #name doesn't matter
-algorithm: hmac-sha256
-
+    algorithm: hmac-sha256
     secret: "B22jiD30pKL541XsOZ28y+NxbcIRoGqnumH2SFC8QDE=""#;
 
-        let result = parse_tsig(content, TsigFileFormat::Yaml);
+        let result = parse_tsig(content, TsigFileFormat::Nsd);
         assert_eq!(
             result,
             Ok((
@@ -414,6 +555,22 @@ algorithm: hmac-sha256
     }
 
     #[test]
+    fn parse_tsig_knot_format() {
+        let content = r#"---
+# DNAME:ALGORITHM:BASE64
+key:
+  - id: DNAME
+    algorithm: ALGORITHM
+    secret: BASE64"#;
+
+        let result = parse_tsig(content, TsigFileFormat::Knot);
+        assert_eq!(
+            result,
+            Ok(("DNAME".into(), "ALGORITHM".into(), "BASE64".into(),))
+        );
+    }
+
+    #[test]
     fn parse_tsig_bind_format() {
         let content = r#"
 // this is a comment
@@ -421,7 +578,8 @@ algorithm: hmac-sha256
 key "tsig-key" { //name doesn't matter
 algorithm hmac-sha256;
 
-    secret "TwdyUE7Q5w6Jd/A1dmreYqINEyQWtWUAVb6p4pCQ3JI=";};"#;
+    secret "TwdyUE7Q5w6Jd/A1dmreYqINEyQWtWUAVb6p4pCQ3JI=";
+};"#;
 
         let result = parse_tsig(content, TsigFileFormat::Bind);
         assert_eq!(

--- a/crates/cli/src/commands/tsig.rs
+++ b/crates/cli/src/commands/tsig.rs
@@ -1,3 +1,5 @@
+use clap::ValueEnum;
+use core::fmt;
 use std::str::FromStr;
 
 use camino::Utf8PathBuf;
@@ -16,38 +18,23 @@ pub struct Tsig {
 }
 
 #[derive(Clone, Debug, clap::Subcommand)]
+#[cfg_attr(test, derive(PartialEq))]
 #[allow(clippy::large_enum_variant)]
 pub enum TsigCommand {
     /// Add a TSIG key
     #[command(name = "add")]
     Add {
-        /// The name of the TSIG key to add.
-        ///
-        /// Can also be in the form `[algorithm:]keyname:secret`.
-        name: String,
+        /// Path to the file.
+        path: Utf8PathBuf,
 
-        /// The TSIG algorithm to use.
+        /// Format used in the file.
         ///
-        /// Can be omitted if provided as part of the name.
-        /// Required if `[SECRET]` is provided.
+        /// The file isn't parsed as a real YAML file, therefore not all
+        /// features are allowed.
         ///
-        /// Must be one of:
-        ///   hmac-sha1
-        ///   hmac-sha256
-        ///   hmac-sha384
-        ///   hmac-sha512
-        #[arg(requires = "secret")]
-        alg: Option<TsigAlgorithm>,
-
-        /// Base64 encoded secret key material.
-        ///
-        /// Can be omitted if provided as part of the name.
-        /// Required if `[ALG]` is provided.
-        ///
-        /// Can also be a path to a file containing the Base64 encoded secret
-        /// key material.
-        #[arg(requires = "alg")]
-        secret: Option<String>,
+        /// The same goes for the BIND format.
+        #[arg(long, default_value_t=TsigFileFormat::Yaml, ignore_case=true, required = false)]
+        format: TsigFileFormat,
     },
 
     /// Remove a TSIG key
@@ -60,82 +47,42 @@ pub enum TsigCommand {
 }
 
 impl Tsig {
+    pub async fn tsig_add(
+        path: Utf8PathBuf,
+        format: TsigFileFormat,
+    ) -> Result<(TsigKeyName, TsigAlgorithm, String), String> {
+        let content = std::fs::read_to_string(&path)
+            .map_err(|e| format!("Failed to read TSIG file '{path}' as '{format}' format: {e}"))?;
+
+        let (tsig_name_raw, tsig_alg_raw, tsig_secret) = parse_tsig(&content, format)?;
+
+        let tsig_alg = TsigAlgorithm::from_str(&tsig_alg_raw, true).map_err(|_| {
+            format!(
+                "Unable to parse {} possible values are {:?}",
+                tsig_alg_raw,
+                TsigAlgorithm::value_variants()
+            )
+        })?;
+
+        let tsig_name = TsigKeyName::from_str(&tsig_name_raw)
+            .map_err(|err| format!("Invalid TSIG key name: {err}"))?;
+
+        Ok((tsig_name, tsig_alg, tsig_secret))
+    }
     pub async fn execute(self, client: CascadeApiClient) -> Result<(), String> {
         match self.command {
             // Add a TSIG key to Cascade.
-            TsigCommand::Add { name, alg, secret } => {
-                let (name, alg, secret) = match (alg, secret) {
-                    // No separate algorithm or secret argument values
-                    // were provided, instead they must be extracted
-                    // from the name string which should be in the form
-                    // [algorithm]:keyname:secret.
-                    (None, None) => {
-                        let parts: Vec<&str> = name.split(':').collect();
-                        match parts.as_slice() {
-                            // The algorithm was provided.
-                            [alg_part, name_part, secret_part] => {
-                                let alg = TsigAlgorithm::from_str(alg_part)?;
-                                let name = name_part.to_string();
-                                let secret = secret_part.to_string();
-                                (name, alg, secret)
-                            }
-
-                            // The algorithm was not provided, use the default.
-                            [name_part, secret_part] => {
-                                let alg = TsigAlgorithm::HmacSha256;
-                                let name = name_part.to_string();
-                                let secret = secret_part.to_string();
-                                (name, alg, secret)
-                            }
-
-                            // The name value was not in the expected format.
-                            _ => {
-                                return Err(
-                                    "Invalid TSIG key format, should be: [algorithm]:keyname:secret"
-                                        .to_string(),
-                                );
-                            }
-                        }
-                    }
-
-                    // Separate name, algorithm and secret argument values
-                    // were provided.
-                    (Some(alg), Some(secret)) => {
-                        let path = Utf8PathBuf::from_str(&secret).unwrap();
-                        if path.exists() {
-                            // Assume that the secret is contained in the
-                            // specified file.
-                            let secret = std::fs::read_to_string(&path)
-                                .map_err(|err| {
-                                    format!("Failed to read TSIG key file '{path}': {err}")
-                                })?
-                                .trim()
-                                .to_string();
-                            (name, alg, secret)
-                        } else {
-                            // Assume that the secret was provided directly.
-                            (name, alg, secret)
-                        }
-                    }
-
-                    // An unsupported combination of arguments was provided
-                    // but this should not be possible due to the Clap
-                    // attributes that we used.
-                    _ => unreachable!("Excluded via Clap 'requires' rules"),
-                };
-
-                // Parse the TSIG key name as a domain name.
-                let tsig_key_name = TsigKeyName::from_str(&name)
-                    .map_err(|err| format!("Invalid TSIG key name: {err}"))?;
+            TsigCommand::Add { path, format } => {
+                let (tsig_name, tsig_alg, tsig_secret) = Tsig::tsig_add(path, format).await?;
 
                 // Send a TSIG add message to the Cascade HTTP API.
                 let res: Result<TsigAddResult, TsigAddError> = client
                     .post_json_with(
                         "tsig/add",
                         &crate::api::TsigAdd {
-                            name: tsig_key_name,
-                            alg: alg.into(),
-                            secret,
+                            name: tsig_name.clone(),
+                            alg: tsig_alg.into(),
+                            secret: tsig_secret,
                         },
                     )
                     .await?;
@@ -144,12 +91,11 @@ impl Tsig {
                 match res {
                     // Success, the key was added!
                     Ok(TsigAddResult) => {
-                        println!("Added TSIG key '{name}'");
+                        println!("Added TSIG key '{tsig_name}'");
                         Ok(())
                     }
-
                     // Failure, something went wrong.
-                    Err(err) => Err(format!("Failed to add TSIG key '{name}': {err}")),
+                    Err(err) => Err(format!("Failed to add TSIG key '{tsig_name}': {err}")),
                 }
             }
 
@@ -254,20 +200,6 @@ pub enum TsigAlgorithm {
     HmacSha512,
 }
 
-impl FromStr for TsigAlgorithm {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "hmac-sha1" => Ok(TsigAlgorithm::HmacSha1),
-            "hmac-sha256" => Ok(TsigAlgorithm::HmacSha256),
-            "hmac-sha384" => Ok(TsigAlgorithm::HmacSha384),
-            "hmac-sha512" => Ok(TsigAlgorithm::HmacSha512),
-            other => Err(format!("'{other}' is not a supported TSIG algorithm")),
-        }
-    }
-}
-
 impl From<TsigAlgorithm> for crate::api::TsigAlgorithm {
     fn from(alg: TsigAlgorithm) -> Self {
         match alg {
@@ -276,5 +208,229 @@ impl From<TsigAlgorithm> for crate::api::TsigAlgorithm {
             TsigAlgorithm::HmacSha384 => cascade_api::TsigAlgorithm::HmacSha384,
             TsigAlgorithm::HmacSha512 => cascade_api::TsigAlgorithm::HmacSha512,
         }
+    }
+}
+
+//------------ TsigFileFormat ------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq, clap::ValueEnum)]
+pub enum TsigFileFormat {
+    Yaml,
+    Bind,
+}
+
+impl fmt::Display for TsigFileFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TsigFileFormat::Yaml => write!(f, "YAML"),
+            TsigFileFormat::Bind => write!(f, "BIND"),
+        }
+    }
+}
+impl TsigFileFormat {
+    fn keywords(&self) -> (&'static str, &'static str, &'static str) {
+        match self {
+            TsigFileFormat::Bind => ("key", "algorithm", "secret"),
+            TsigFileFormat::Yaml => ("name", "algorithm", "secret"),
+        }
+    }
+}
+
+// Parse TSIG key values from a file.
+//
+// The function searches for the certain keywords, each at the beginning of
+// the line - ignoring whitespaces. The line is then split on the first
+// whitespace and first consecutive sequence of non-whitespace characters is
+// taken as the value. Quotes lead to a preemptive match on the value.
+//
+// The keywords depend on the format used.
+fn parse_tsig(content: &str, format: TsigFileFormat) -> Result<(String, String, String), String> {
+    fn is_whitespace(c: char) -> bool {
+        c == ' ' || c == '\t'
+    }
+    fn value_cleanup(line: &str, format: &TsigFileFormat) -> Result<String, String> {
+        let mut output = String::new();
+        let mut in_quote = false;
+
+        let (key, value) = line
+            .split_once(is_whitespace)
+            .ok_or::<String>(format!("Unable to split on whitespace for line '{line}'"))?;
+
+        for character in value.trim().chars() {
+            match character {
+                c if is_whitespace(c) => break,
+                c if format == &TsigFileFormat::Bind && c == ';' => break,
+                '"' => {
+                    if in_quote {
+                        // End of quotation reached.
+                        break;
+                    }
+                    // Now inside of quotes, only go until the end of the quote.
+                    in_quote = true;
+                    continue;
+                }
+                _ => (),
+            }
+
+            output.push(character);
+        }
+        if output.is_empty() {
+            return Err(format!("Value is empty for keyword '{key}'!"));
+        };
+        Ok(output)
+    }
+
+    let lines = content.trim().lines();
+
+    let mut name: Option<String> = None;
+    let mut algorithm: Option<String> = None;
+    let mut secret: Option<String> = None;
+
+    let keywords = format.keywords();
+    for line in lines {
+        match line.trim() {
+            line if line.starts_with(keywords.0) => name = Some(value_cleanup(line, &format)?),
+            line if line.starts_with(keywords.1) => algorithm = Some(value_cleanup(line, &format)?),
+            line if line.starts_with(keywords.2) => secret = Some(value_cleanup(line, &format)?),
+            _ => (),
+        }
+    }
+
+    match (name, algorithm, secret) {
+        (Some(n), Some(a), Some(s)) => Ok((n, a, s)),
+        _ => Err("Unable to parse all three values.".into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use clap::Parser;
+
+    use crate::{
+        args::Args,
+        commands::{Command::Tsig, tsig::TsigCommand},
+    };
+    /// Parse against the binary name only, so tests read as plain argument lists.
+    #[track_caller]
+    fn parse(args: &[&str]) -> Result<Args, clap::Error> {
+        Args::try_parse_from(std::iter::once("cascade").chain(args.iter().copied()))
+    }
+
+    /// Validate TSIG command values parsed from command line arguments.
+    #[track_caller]
+    fn validate_arguments(cli: &[&str], tsig_expected: TsigCommand) {
+        let cli = parse(cli).unwrap();
+        let tsig_cmd = match cli.command {
+            Tsig(tsig) => tsig,
+            other => panic!("Wrong command parsed. {other:?}"),
+        };
+
+        assert_eq!(tsig_cmd.command, tsig_expected);
+    }
+
+    #[test]
+    fn parse_tsig_add_command_1() {
+        validate_arguments(
+            &["tsig", "add", "file.key"],
+            TsigCommand::Add {
+                path: "file.key".into(),
+                format: TsigFileFormat::Yaml,
+            },
+        );
+    }
+    #[test]
+    fn parse_tsig_add_command_2() {
+        validate_arguments(
+            &["tsig", "add", "file.key", "--format=yamL"],
+            TsigCommand::Add {
+                path: "file.key".into(),
+                format: TsigFileFormat::Yaml,
+            },
+        );
+    }
+    #[test]
+    fn parse_tsig_add_command_3() {
+        validate_arguments(
+            &["tsig", "add", "file.key", "--format=binD"],
+            TsigCommand::Add {
+                path: "file.key".into(),
+                format: TsigFileFormat::Bind,
+            },
+        );
+    }
+
+    #[test]
+    fn parse_tsig_yaml_invalid_1() {
+        let result = parse_tsig("name:", TsigFileFormat::Yaml).unwrap_err();
+        assert!(result.contains("split on whitespace"), "{}", result);
+    }
+
+    #[test]
+    fn parse_tsig_yaml_invalid_2() {
+        let result = parse_tsig("name: ", TsigFileFormat::Yaml).unwrap_err();
+        assert!(result.contains("split on whitespace"), "{}", result);
+    }
+
+    #[test]
+    fn parse_tsig_yaml_invalid_3() {
+        let result = parse_tsig("name: f", TsigFileFormat::Yaml).unwrap_err();
+        assert!(result.contains("parse all three values"), "{}", result);
+    }
+
+    #[test]
+    fn parse_tsig_yaml_minimal() {
+        let result = parse_tsig("name f\nalgorithm: f\nsecret: f", TsigFileFormat::Yaml).unwrap();
+        assert_eq!(result, ("f".into(), "f".into(), "f".into()));
+    }
+
+    #[test]
+    fn parse_tsig_bind_minimal() {
+        let result = parse_tsig("key f\nalgorithm f\nsecret f", TsigFileFormat::Bind).unwrap();
+        assert_eq!(result, ("f".into(), "f".into(), "f".into()));
+    }
+
+    #[test]
+    fn parse_tsig_yaml_format() {
+        let content = r#"---
+# this is a comment
+# test.key:hmac-sha256:B22jiD30pKL541XsOZ28y+NxbcIRoGqnumH2SFC8QDE=
+tsig-key: # could also be called key
+    name: test.key #name doesn't matter
+algorithm: hmac-sha256
+
+    secret: "B22jiD30pKL541XsOZ28y+NxbcIRoGqnumH2SFC8QDE=""#;
+
+        let result = parse_tsig(content, TsigFileFormat::Yaml);
+        assert_eq!(
+            result,
+            Ok((
+                "test.key".into(),
+                "hmac-sha256".into(),
+                "B22jiD30pKL541XsOZ28y+NxbcIRoGqnumH2SFC8QDE=".into(),
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_tsig_bind_format() {
+        let content = r#"
+// this is a comment
+// test.key:hmac-sha256:B22jiD30pKL541XsOZ28y+NxbcIRoGqnumH2SFC8QDE=
+key "tsig-key" { //name doesn't matter
+algorithm hmac-sha256;
+
+    secret "TwdyUE7Q5w6Jd/A1dmreYqINEyQWtWUAVb6p4pCQ3JI=";};"#;
+
+        let result = parse_tsig(content, TsigFileFormat::Bind);
+        assert_eq!(
+            result,
+            Ok((
+                "tsig-key".into(),
+                "hmac-sha256".into(),
+                "TwdyUE7Q5w6Jd/A1dmreYqINEyQWtWUAVb6p4pCQ3JI=".into(),
+            ))
+        );
     }
 }

--- a/doc/manual/source/man/cascade-tsig.rst
+++ b/doc/manual/source/man/cascade-tsig.rst
@@ -8,7 +8,7 @@ Synopsis
 
 :program:`cascade` ``[GLOBAL OPTIONS]`` tsig ``<COMMAND>``
 
-:program:`cascade` ``[GLOBAL OPTIONS]`` tsig :subcmd:`add` ``<TSIG_KEY_NAME>`` ``<ALGORITHM>`` ``<SECRET>``
+:program:`cascade` ``[GLOBAL OPTIONS]`` tsig :subcmd:`add` ``<PATH>``
 
 :program:`cascade` ``[GLOBAL OPTIONS]`` tsig :subcmd:`list`
 
@@ -55,40 +55,40 @@ Commands
 Arguments for :subcmd:`tsig add`
 --------------------------------
 
-.. option:: <TSIG_KEY_NAME>
-.. option:: [<ALGORITHM>:]<TSIG_KEY_NAME>:<SECRET>
+.. option:: <PATH>
 
-   The name of the TSIG key to add, or a complete TSIG key specification.
+   Path to the file containing the TSIG key.
 
-   TSIG key names must be valid domain names.
+   The file format is specified by ``--format``.
 
-   A complete TSIG key specification consists of an optional algorithm
-   (default ``hmac-sha256``), a key name and the secret key material. When a
-   complete TSIG key specification is supplied, supplying the ``<ALGORITHM>``
-   and ``<SECRET>`` arguments as well will result in an error.
+   Regardless of the file format the file must contain all the following
+   values exactly once.
 
-   Secret key material must be the correct length for the specified algorithm
-   and must be encoded using the :RFC:`4648` Base64 encoding.
+   The name of the key to add, TSIG key names must be valid domain names.
 
-   .. warning:: Secret key material supplied via a command-line argument may
-                be visible to other processes running on the same computer as
-                the Cascade CLI.
-
-.. option:: <ALGORITHM>
-
-   The TSIG algorithm of the specified TSIG key. Can be one of: ``hmac-sha1``,
+   The algorithm of the specified TSIG key. Can be one of: ``hmac-sha1``,
    ``hmac-sha256``, ``hmac-sha384`` or ``hmac-sha512``.
 
-.. option:: <SECRET>
+   The secret key material must be the correct length for the specified algorithm
+   and must be encoded using the :RFC:`4648` Base64 encoding.
 
-   :RFC:`4648` Base64 encoded secret key material. The number of bytes prior
-   to encoding must be correct for the specified ``<ALGORITHM>``.
+.. option:: --format <FORMAT>
 
-   Can also be a path to a file containing the Base64 encoded secret material.
+   Format used in the TSIG file.
 
-   .. note:: Secret key material supplied via a command-line argument may be
-             visible to other processes running on the same computer as the
-             Cascade CLI. Consider supplying a file name instead.
+   The **NSD** and **Knot** formats are not parsed with full YAML compliance.
+
+   Possible values:
+
+   - **nsd**:  `NSD TSIG Documentation`_
+   - **bind**: `BIND TSIG Documentation`_
+   - **knot**: `Knot TSIG Documentation`_
+
+   [default: nsd]
+
+   .. _NSD TSIG Documentation: https://nsd.docs.nlnetlabs.nl/en/latest/running/using-tsig.html
+   .. _BIND TSIG Documentation: https://bind9.readthedocs.io/en/stable/reference.html#namedconf-statement-key
+   .. _Knot TSIG Documentation: https://www.knot-dns.cz/docs/latest/html/reference.html#key-section
 
 See Also
 --------

--- a/integration-tests/system-tests.yml
+++ b/integration-tests/system-tests.yml
@@ -270,7 +270,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        key-source: [cmdline, file]
+        key-source-format: [nsd, bind, knot]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/set-build-profile
@@ -279,7 +279,7 @@ jobs:
       - uses: ./integration-tests/tests/upstream-tsig
         with:
           log-level: ${{ inputs.log-level }}
-          key-source: ${{ matrix.key-source }}
+          key-source-format: ${{ matrix.key-source-format }}
 
   downstream-tsig:
     name: Using TSIG with downstream nameservers.

--- a/integration-tests/tests/downstream-tsig/action.yml
+++ b/integration-tests/tests/downstream-tsig/action.yml
@@ -98,6 +98,16 @@ runs:
         text        TXT "Hello World!"
         EOF
 
+    - name: Prepare tsig-key file.
+      run: |
+        # Prepare the tsig key.
+        cat >tsig-key.yaml <<EOL
+        key:
+          name: "tsig-key"
+          algorithm: hmac-sha256
+          secret: "COzoVsYQmXeXiyq1Quhp0bbVnMyxjPxsaGSoIWR98i0="
+        EOL
+
     - name: Add a custom policy
       run: |
         POLICY_DIR=$(integration-tests/scripts/get-default-path.sh policy-dir)
@@ -109,7 +119,8 @@ runs:
           echo 'send-notify-to = ["${{ inputs.send-notify-to }}"]' >> "${POLICY_DIR}/restricted.toml"
         fi
         if [[ "${{ inputs.provide-xfr-to}}" == *"^tsig-key"* || "${{ inputs.send-notify-to }}" == *"^tsig-key"* ]]; then
-          cascade tsig add tsig-key hmac-sha256 "COzoVsYQmXeXiyq1Quhp0bbVnMyxjPxsaGSoIWR98i0="
+          # The --format=nsd is default.
+          cascade tsig add tsig-key.yaml
         fi
         cascade policy reload
 

--- a/integration-tests/tests/upstream-tsig/action.yml
+++ b/integration-tests/tests/upstream-tsig/action.yml
@@ -18,13 +18,14 @@ inputs:
       - info
       - debug
       - trace
-  key-source:
-    description: Where to take the TSIG key from.
+  key-source-format:
+    description: Determine format used to read the file from.
     required: true
     type: choice
     options:
-      - cmdline
-      - file
+      - nsd
+      - bind
+      - knot
       - none
 runs:
   using: "composite"
@@ -56,17 +57,50 @@ runs:
         done
         exit 0
 
+    - name: Prepare tsig-key file (NSD format).
+      run: |
+        # Prepare the tsig key.
+        cat >tsig-key.nsd.yaml <<EOL
+        key:
+          name: "tsig-key"
+          algorithm: hmac-sha256
+          secret: "COzoVsYQmXeXiyq1Quhp0bbVnMyxjPxsaGSoIWR98i0="
+        EOL
+
+    - name: Prepare tsig-key file (BIND format).
+      run: |
+        # Prepare the tsig key.
+        cat >tsig-key.bind <<EOL
+        key "tsig-key" {
+            algorithm hmac-sha256;
+            secret "COzoVsYQmXeXiyq1Quhp0bbVnMyxjPxsaGSoIWR98i0=";
+        };
+        EOL
+
+    - name: Prepare tsig-key file (KNOT format).
+      run: |
+        # Prepare the tsig key.
+        cat >tsig-key.knot.yaml <<EOL
+        # hmac-sha256:tsig-key:COzoVsYQmXeXiyq1Quhp0bbVnMyxjPxsaGSoIWR98i0=
+        key:
+          - id: tsig-key
+            algorithm: hmac-sha256
+            secret: COzoVsYQmXeXiyq1Quhp0bbVnMyxjPxsaGSoIWR98i0=
+        EOL
+
     - name: Remove and re-add the zone with the required TSIG key.
       run: |
         cascade zone remove example-tsig.test
-        
-        case "${{ inputs.key-source }}" in
-          "cmdline")
-            cascade tsig add tsig-key hmac-sha256 "COzoVsYQmXeXiyq1Quhp0bbVnMyxjPxsaGSoIWR98i0="
+
+        case "${{ inputs.key-source-format }}" in
+          "nsd")
+            cascade tsig add tsig-key.nsd.yaml
             ;;
-          "file")
-            echo -n "COzoVsYQmXeXiyq1Quhp0bbVnMyxjPxsaGSoIWR98i0=" >/tmp/tsig.key
-            cascade tsig add tsig-key hmac-sha256 /tmp/tsig.key
+          "bind")
+            cascade tsig add tsig-key.bind --format=bind
+            ;;
+          "knot")
+            cascade tsig add tsig-key.knot.yaml --format=knot
             ;;
         esac
 


### PR DESCRIPTION
The cli should promote best practices, therefore the ability to add TSIG keys visible over the cli should not be possible. Additionally the cli UX should be unified with the other commands throughout the cli.

- minimal dependencies
- explicit command interface (no file format guessing)
- yaml'ish file is default because it is also supported by `nsd/unbound` and can be read/written by a lot of tools through yaml.
- `dnst` might support the generation of tsig keys in the yaml'ish format aswell

```rust
$ cat key.yaml
tsig-key:
       name: test.key
       algorithm: hmac-sha256
       secret: "B22jiD30pKL541XsOZ28y+NxbcIRoGqnumH2SFC8QDE="
$ cascade tsig add key.yaml
...
$ cat key.bind
key "tsig-key" {
        algorithm hmac-sha256;
        secret "pmUZPN18Id5O6ejGwp28YL0d3qa6AQ5X891TXD/iITM=";
};
$ cascade tsig add key.yaml
...
```

## References

resolves #898 *"Drop support for supplying TSIG secret on the CLI, support NSD/Unbound's TSIG config snippet format"*
resolves #709 *"TSIG secret can also be a path to a file, but what's the formula?"*
resolves #706 *"Possible enhancement: cascade tsig add from BIND-compatible TSIG key files"*
resolves #609 *"Is Base64 encoded TSIG secret key material passed to tsig add ambiguous?"*


---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?

- If you are adding/deleting man pages:
  - [ ] Did you update the `man_pages` config in `doc/manual/source/conf.py`?
  - [ ] Did you update the packaged man pages in the `Cargo.toml`?
  - [ ] Did you commit the freshly built man pages?

- If you are modifying man pages:
  - [ ] Did you commit the updated built man pages?
