### PR TITLE
Fix crash zone reload

### DIFF
--- a/src/signer/incremental.rs
+++ b/src/signer/incremental.rs
@@ -55,7 +55,9 @@ use crate::units::zone_signer::{
     KeySetState, MinTimestamp, PassThroughMode, SignerError, faketime_or_now,
 };
 use crate::zone::{Zone, ZoneState};
-use crate::zonedata::{DiffData, RegularRecord, SignedZonePatcher, SignedZoneReader, SoaRecord};
+use crate::zonedata::{
+    DiffData, LoadedZoneReader, RegularRecord, SignedZonePatcher, SignedZoneReader, SoaRecord,
+};
 
 pub fn sign_incrementally(
     config: &crate::config::Config,
@@ -145,7 +147,10 @@ pub fn sign_incrementally(
 
     if load_unsigned {
         let start = Instant::now();
-        iss.load_unsigned_diffs(ws.patch.unsigned_diff().expect("should be there"))?;
+        iss.load_unsigned_diffs(
+            ws.patch.unsigned_diff().expect("should be there"),
+            ws.patch.curr_loaded().expect("should be there"),
+        )?;
         debug!("loading new unsigned diffs took {:?}", start.elapsed());
     } else {
         // Re-use the signed data.
@@ -1431,7 +1436,11 @@ impl<'a> IncrementalSigningState<'a> {
         Ok(())
     }
 
-    pub fn load_unsigned_diffs(&mut self, diffs: DiffData) -> Result<(), SignerError> {
+    pub fn load_unsigned_diffs(
+        &mut self,
+        diffs: DiffData,
+        curr_loaded: LoadedZoneReader,
+    ) -> Result<(), SignerError> {
         let origin_revnamebuf = old_base_name_to_revnamebuf(self.origin);
 
         self.new_apex = self.old_apex.clone();
@@ -1476,6 +1485,13 @@ impl<'a> IncrementalSigningState<'a> {
             } else {
                 self.data.add_record(record);
             }
+        }
+
+        if self.new_apex.contains_key(&NewRtype::SOA) {
+            // There was no change in the SOA. Try to get the SOA directly
+            // from the loaded zone.
+            self.new_apex
+                .insert(NewRtype::SOA, vec![curr_loaded.soa().clone().into()]);
         }
 
         // Save a copy of the loaded new_apex to create a diff later.

--- a/src/signer/incremental.rs
+++ b/src/signer/incremental.rs
@@ -1487,12 +1487,11 @@ impl<'a> IncrementalSigningState<'a> {
             }
         }
 
-        if self.new_apex.contains_key(&NewRtype::SOA) {
-            // There was no change in the SOA. Try to get the SOA directly
-            // from the loaded zone.
-            self.new_apex
-                .insert(NewRtype::SOA, vec![curr_loaded.soa().clone().into()]);
-        }
+        // If there was no change in the SOA, then get the SOA directly
+        // from the loaded zone.
+        self.new_apex
+            .entry(NewRtype::SOA)
+            .or_insert_with(|| vec![curr_loaded.soa().clone().into()]);
 
         // Save a copy of the loaded new_apex to create a diff later.
         for (k, v) in &self.new_apex {


### PR DESCRIPTION
This fixes a crash in the incremental signer when a new unsigned zone has the same SOA record as the previous unsigned zone.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
