### PR TITLE
FIX: Don't abort XFR transfers if the response buffer is full. (fixes #799)

### DIFF
--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -90,7 +90,7 @@ mod compat {
         base::{Message, MessageBuilder, iana::Rcode},
         net::server::{
             message::Request,
-            service::{CallResult, Service, ServiceResult},
+            service::{CallResult, Service, ServiceFeedback, ServiceResult},
         },
         new::{
             base::{name::Name, wire::ParseBytesZC},
@@ -384,12 +384,28 @@ mod compat {
                 Some(CallResult::new(response))
             });
 
+            // Enable transaction mode so that the connection handler will
+            // block if we try to enqueue more messages than the response
+            // buffer can hold, which can happen if the responses cannot be
+            // sent to the client fast enough, rather than abort with a queue
+            // full error.
+            if tx
+                .send(ServiceFeedback::BeginTransaction.into())
+                .await
+                .is_err()
+            {
+                // The channel has closed; stop.
+                return;
+            }
+
             for message in messages {
                 if tx.send(message).await.is_err() {
                     // The channel has closed; stop.
                     break;
                 }
             }
+
+            let _ = tx.send(ServiceFeedback::EndTransaction.into()).await;
         });
 
         let stream = futures::stream::poll_fn(move |cx| rx.poll_recv(cx).map(|m| m.map(Ok)));
@@ -703,12 +719,28 @@ mod compat {
                 Some(CallResult::new(response))
             });
 
+            // Enable transaction mode so that the connection handler will
+            // block if we try to enqueue more messages than the response
+            // buffer can hold, which can happen if the responses cannot be
+            // sent to the client fast enough, rather than abort with a queue
+            // full error.
+            if tx
+                .send(ServiceFeedback::BeginTransaction.into())
+                .await
+                .is_err()
+            {
+                // The channel has closed; stop.
+                return;
+            }
+
             for message in messages {
                 if tx.send(message).await.is_err() {
                     // The channel has closed; stop.
                     break;
                 }
             }
+
+            let _ = tx.send(ServiceFeedback::EndTransaction.into()).await;
         });
 
         let stream = futures::stream::poll_fn(move |cx| rx.poll_recv(cx).map(|m| m.map(Ok)));


### PR DESCRIPTION
Signal the response streaming code to start and end a '[transaction](https://docs.rs/domain/latest/domain/net/server/service/enum.ServiceFeedback.html#variant.BeginTransaction)'.

Normally the response streaming code assumes responses are small thus should fit in the response buffer. When sending a response larger than the buffer if the messages cannot be sent faster than the buffer fills up the response streaming code will abort.

Starting a transaction tells the response streaming code NOT to abort if the buffer is full but instead to wait for more messages until the end of the transaction is signaled.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
