### PR TITLE
Remove persisted zone content files when a zone is removed. (fixes #889)

### DIFF
--- a/src/center.rs
+++ b/src/center.rs
@@ -278,6 +278,20 @@ pub fn remove_zone(center: &Arc<Center>, name: Name<Bytes>) -> Result<(), ZoneRe
     // The zone might not have made it to these places, but that's not an issue
     // so we just ignore any errors.
 
+    // Note: Persisted zone content files are removed first so that there
+    // is no risk of them being left behind if the process is terminated
+    // after the zone is removed from Cascade state as that would leave the
+    // persisted zone content files behind while it would appear that the
+    // zone had been fully removed. If Cascade is terminated after removal of
+    // persisted zone content files but before the zone had been fully removed
+    // from state Cascade will still know the zone but be unable to serve it,
+    // which would be no worse than operators intended effect of completely
+    // removing the zone, but with the benefit that the operator can see that
+    // zone removal didn't fully complete as expected and leaving them able to
+    // retry the zone removal at a later moment. An alternative could be to
+    // track 'mid-removal' of a zone so that we can detect an incomplete
+    // attempt to remove a zone.
+    PersistenceState::clear(center, &zone);
     LoadedReviewServer::remove_zone(center, &zone);
     SignedReviewServer::remove_zone(center, &zone);
     PublicationServer::remove_zone(center, &zone);
@@ -322,8 +336,6 @@ pub fn remove_zone(center: &Arc<Center>, name: Name<Bytes>) -> Result<(), ZoneRe
     zone_state.record_event(HistoricalEvent::Removed, None);
     std::mem::drop(zone_state);
     crate::zone::save_state_now(center, &zone);
-
-    PersistenceState::clear(center, &zone);
 
     // TODO: Remove the zone state file?
 

--- a/src/center.rs
+++ b/src/center.rs
@@ -17,6 +17,7 @@ use crate::config::RuntimeConfig;
 use crate::loader::Loader;
 use crate::loader::zone::LoaderZoneHandle;
 use crate::metrics::Metrics;
+use crate::persistence::zone::PersistenceState;
 use crate::persistence::{Compacter, Persister, Restorer};
 use crate::server::{LoadedReviewServer, PublicationServer, SignedReviewServer};
 use crate::state::PolicySpec;
@@ -280,6 +281,7 @@ pub fn remove_zone(center: &Arc<Center>, name: Name<Bytes>) -> Result<(), ZoneRe
     LoadedReviewServer::remove_zone(center, &zone);
     SignedReviewServer::remove_zone(center, &zone);
     PublicationServer::remove_zone(center, &zone);
+    PersistenceState::clear(center, &zone);
 
     let mut zone_state = zone.state.write_cleanly();
 

--- a/src/center.rs
+++ b/src/center.rs
@@ -281,7 +281,6 @@ pub fn remove_zone(center: &Arc<Center>, name: Name<Bytes>) -> Result<(), ZoneRe
     LoadedReviewServer::remove_zone(center, &zone);
     SignedReviewServer::remove_zone(center, &zone);
     PublicationServer::remove_zone(center, &zone);
-    PersistenceState::clear(center, &zone);
 
     let mut zone_state = zone.state.write_cleanly();
 
@@ -323,6 +322,8 @@ pub fn remove_zone(center: &Arc<Center>, name: Name<Bytes>) -> Result<(), ZoneRe
     zone_state.record_event(HistoricalEvent::Removed, None);
     std::mem::drop(zone_state);
     crate::zone::save_state_now(center, &zone);
+
+    PersistenceState::clear(center, &zone);
 
     // TODO: Remove the zone state file?
 


### PR DESCRIPTION
- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
