### PR TITLE
Cancel reloads of unchanged zones

### DIFF
--- a/crates/zonedata/src/writer.rs
+++ b/crates/zonedata/src/writer.rs
@@ -643,7 +643,7 @@ fn apply_replacement(
 
     next.records.par_sort_unstable();
 
-    if curr.soa.is_some() {
+    if let Some(curr_soa) = &curr.soa {
         let mut removed_records = Vec::new();
         let mut added_records = Vec::new();
 
@@ -662,9 +662,11 @@ fn apply_replacement(
             }
         }
 
+        // Only set the SOA if it changed.
+        let soa_changed = curr_soa != soa;
         Ok(Box::new(DiffData {
-            removed_soa: curr.soa.clone(),
-            added_soa: Some(soa.clone()),
+            removed_soa: soa_changed.then_some(curr_soa.clone()),
+            added_soa: soa_changed.then_some(soa.clone()),
             removed_records,
             added_records,
         }))

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -255,14 +255,7 @@ async fn refresh(
             );
 
             // Cancel the load
-            handle.get().abandon_load(builder);
-
-            handle.state.record_event(
-                HistoricalEvent::LoadingFailed {
-                    reason: err.to_string(),
-                },
-                None,
-            );
+            handle.get().loading_failed(builder, err);
         }
     }
 }

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     common::scheduler::Scheduler,
     loader::zone::EnqueuedRefresh,
     util::AbortOnDrop,
-    zone::{HistoricalEvent, Zone, ZoneByName, ZoneByPtr},
+    zone::{Zone, ZoneByName, ZoneByPtr},
     zonedata::LoadedZoneBuilder,
 };
 
@@ -162,17 +162,23 @@ async fn refresh(
 
     // Finalize the load metrics.
     let start_time = metrics.start.0;
+    debug_assert!(
+        handle
+            .state
+            .loader
+            .active_load_metrics
+            .as_ref()
+            .is_some_and(|x| Arc::ptr_eq(x, &metrics)),
+        "the active load metrics were set when starting the load"
+    );
     handle.state.loader.active_load_metrics = None;
-    handle.state.loader.last_load_metrics = Some(metrics.finish());
-
-    {
-        let loader_metrics = handle.state.loader.last_load_metrics.as_ref().unwrap();
-        // Copy generated loader metrics to prometheus metrics
-        zone.metrics
-            .zone_loaded_last_bytes(loader_metrics.num_loaded_bytes as i64);
-        zone.metrics
-            .zone_loaded_last_records(loader_metrics.num_loaded_records as i64);
-    }
+    let metrics = metrics.finish();
+    // Copy generated loader metrics to prometheus metrics
+    zone.metrics
+        .zone_loaded_last_bytes(metrics.num_loaded_bytes as i64);
+    zone.metrics
+        .zone_loaded_last_records(metrics.num_loaded_records as i64);
+    handle.state.loader.last_load_metrics = Some(metrics);
 
     // Update the SOA refresh timer state.
     //

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -125,7 +125,7 @@ async fn refresh(
 
     // Perform the source-specific reload into the zone contents.
     let result = match source {
-        Source::None => Ok(false),
+        Source::None => Ok(()),
         Source::Zonefile { path } => {
             // Zonefile loading is a synchronous process, so it is executing on
             // its own blocking task. It cannot borrow 'builder', so 'builder'
@@ -139,13 +139,12 @@ async fn refresh(
             })
             .await
             .unwrap();
-            result.map(|()| true).map_err(Into::into)
+            result.map_err(Into::into)
         }
         Source::Server { addr, tsig_key } if force => {
             let tsig_key = tsig_key.as_deref().cloned();
             server::axfr(&zone, &addr, tsig_key, &mut builder, &metrics)
                 .await
-                .map(|()| true)
                 .map_err(Into::into)
         }
         Source::Server { addr, tsig_key } => {
@@ -186,11 +185,7 @@ async fn refresh(
     // (re)loaded by user request.
     if matches!(handle.state.loader.source, Source::Server { .. }) {
         // Load the SOA.
-        let soa = if matches!(result, Ok(true)) {
-            Some(builder.next().unwrap().soa().clone())
-        } else {
-            builder.curr().map(|r| r.soa().clone())
-        };
+        let soa = builder.next().or(builder.curr()).map(|r| r.soa().clone());
 
         let refresh_timer = &mut handle.state.loader.refresh_timer;
         let refresh_monitor = &center.loader.refresh_scheduler;
@@ -216,8 +211,9 @@ async fn refresh(
     );
 
     // Process the result of the reload.
+    let built = builder.diff().is_some_and(|d| !d.is_empty());
     match result {
-        Ok(false) => {
+        Ok(()) if !built => {
             debug!(
                 zone = %zone.name,
                 "The zone is up-to-date"
@@ -227,7 +223,7 @@ async fn refresh(
             handle.get().abandon_load(builder);
         }
 
-        Ok(true) => {
+        Ok(()) => {
             zone.metrics.last_successful_load_duration(duration);
 
             let soa = builder.next().unwrap().soa();

--- a/src/loader/server.rs
+++ b/src/loader/server.rs
@@ -59,8 +59,6 @@ use super::RefreshError;
 /// local copy of this version is not already available, it will be loaded.
 /// Where possible, an incremental zone transfer will be used to communicate
 /// more efficiently.
-///
-/// Returns `true` if a new instance of the zone was loaded.
 #[tracing::instrument(
     level = "trace",
     skip_all,
@@ -72,7 +70,7 @@ pub async fn refresh(
     tsig_key: Option<tsig::Key>,
     builder: &mut LoadedZoneBuilder,
     metrics: &ActiveLoadMetrics,
-) -> Result<bool, RefreshError> {
+) -> Result<(), RefreshError> {
     debug!("Refreshing {:?} from server {addr:?}", zone.name);
 
     if let Some(curr) = builder.curr() {
@@ -81,19 +79,19 @@ pub async fn refresh(
 
         if *curr.soa() == new_soa {
             // The local copy of the zone appears to be up-to-date.
-            return Ok(false);
+            return Ok(());
         }
     }
 
     if builder.curr().is_none() {
         // Fetch the whole zone.
         axfr(zone, addr, tsig_key, builder, metrics).await?;
-
-        return Ok(true);
+        return Ok(());
     };
 
     // Fetch the zone relative to the latest local copy.
-    Ok(ixfr(zone, addr, tsig_key, builder, metrics).await?)
+    ixfr(zone, addr, tsig_key, builder, metrics).await?;
+    Ok(())
 }
 
 //----------- ixfr() -----------------------------------------------------------
@@ -104,8 +102,6 @@ pub async fn refresh(
 /// by the provided SOA record, and the latest version known to the server. The
 /// diff is transformed into a compressed representation of the _local_ version
 /// of the zone.
-///
-/// Returns `true` if a new instance of the zone was loaded.
 #[tracing::instrument(
     level = "trace",
     skip_all,
@@ -117,7 +113,7 @@ pub async fn ixfr(
     tsig_key: Option<tsig::Key>,
     builder: &mut LoadedZoneBuilder,
     metrics: &ActiveLoadMetrics,
-) -> Result<bool, IxfrError> {
+) -> Result<(), IxfrError> {
     debug!("Attempting an IXFR");
 
     let local_soa = builder.curr().unwrap().soa().clone();
@@ -196,7 +192,7 @@ pub async fn ixfr(
         trace!("The server does not support IXFR, falling back to AXFR");
 
         axfr(zone, addr, tsig_key, builder, metrics).await?;
-        return Ok(true);
+        return Ok(());
     }
 
     // Check for common short-circuit cases.
@@ -224,7 +220,7 @@ pub async fn ixfr(
         let serial = Serial::from(soa.serial().into_int());
         if local_soa.rdata.serial == serial {
             // The local copy is up-to-date.
-            return Ok(false);
+            return Ok(());
         } else {
             // The server says the local copy is up-to-date, but it's not.
             return Err(IxfrError::InconsistentUpToDate);
@@ -263,7 +259,7 @@ pub async fn ixfr(
             zone.metrics
                 .inc_xfr_requests_to_upstream_succeeded(XfrType::Ixfr);
 
-            Ok(true)
+            Ok(())
         }
 
         ZoneUpdate::BeginBatchDelete(soa) => {
@@ -301,7 +297,7 @@ pub async fn ixfr(
             zone.metrics
                 .inc_xfr_requests_to_upstream_succeeded(XfrType::Ixfr);
 
-            Ok(true)
+            Ok(())
         }
         _ => unreachable!(),
     }

--- a/src/zone/machine.rs
+++ b/src/zone/machine.rs
@@ -2,6 +2,7 @@ use tracing::{info, trace};
 
 use crate::{
     api::ZoneReviewStatus,
+    loader::RefreshError,
     server::PublicationServer,
     units::zone_signer::SignerError,
     zone::{HistoricalEvent, ZoneHandle},
@@ -178,6 +179,7 @@ impl<'a> ZoneHandle<'a> {
 
 /// # Loading operations
 impl<'a> ZoneHandle<'a> {
+    /// Abandon a load operation (but not due to failure).
     pub(crate) fn abandon_load(&mut self, builder: LoadedZoneBuilder) {
         let (transition, state) = self.state.machine.transition();
 
@@ -191,6 +193,28 @@ impl<'a> ZoneHandle<'a> {
 
         // Abandon the entire upcoming instance.
         self.state.instances.abandon();
+    }
+
+    pub(crate) fn loading_failed(&mut self, builder: LoadedZoneBuilder, err: RefreshError) {
+        let (transition, state) = self.state.machine.transition();
+
+        let ZoneStateMachine::Loading(loaded) = state else {
+            panic!("cannot abandon load in this state");
+        };
+
+        transition.move_to(ZoneStateMachine::Waiting(loaded.abandon_load()));
+
+        self.storage().abandon_load(builder);
+
+        // Abandon the entire upcoming instance.
+        self.state.instances.abandon();
+
+        self.state.record_event(
+            HistoricalEvent::LoadingFailed {
+                reason: err.to_string(),
+            },
+            None,
+        );
     }
 
     pub(crate) fn finish_load(&mut self, built: LoadedZoneBuilt) {


### PR DESCRIPTION
If a reload occurs for a zone loaded from a zonefile or via AXFR, and the new instance of the zone is exactly identical to the old one (i.e. the produced diff is empty), the load would succeed and later parts of Cascade could crash. This PR detects unchanged zones in these scenarios and cancels the loads, preventing such crashes.

Closes #937.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?