### PR TITLE
Include the correct loaded SOA in the compacted zone file. (fixes #948)

### DIFF
--- a/src/persistence/zone.rs
+++ b/src/persistence/zone.rs
@@ -387,7 +387,7 @@ impl PersistenceState {
             persist_to_file_from_parts(
                 loaded_snapshot_path,
                 None,
-                reader.soa().clone(),
+                reader.loaded().soa().clone(),
                 [].iter(),
                 reader.loaded_records(),
             );


### PR DESCRIPTION
When compacting the zone new loaded and signed snapshots of the zone are written to disk. The code was wrongly including the signed SOA in the loaded snapshot. Once restored the next IXFR request to the upstream correctly used the SOA from the loaded zone but that SOA was actually from the signed copy of the zone.

Normally this would cause an AXFR and everything would continue working.

However, if the upstream and Cascade were both using `data-counter` serial policy, AND the upstream were queried less frequently for updates than new updates were available (e.g. because the upstream was unable to send NOTIFY messages to Cascade so it only fetched when the SOA REFRESH timer expired) then this could cause the requested IXFR serial to refer to a valid diff available at the upstream but for an older serial than the most recent one that Cascade had actually received. This would result in error message 'a patchset could not be applied' which is not very helpful (#951 tracks this issue).

E.g. if the upstream created zone versions with serial numbers 2026081000, 2026081001, 2026081002, 202608101003 then Cascade may have fetched 2026081000 and 2026081002, and produced signed zone serials 2026081000 and 2026081001. If compaction occurred the 2026081001 SOA would wrongly be written to the compacted loaded zone snapshot. On restart of Cascade that would be restored then an IXFR to the upstream with serial 2026081001 would be sent instead of the correct value 2026081002. The resulting received diff for 2026081001->2026081002 would not cleanly apply to the current loaded version of the zone in memory in Cascade.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x ] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
