### PR TITLE
[persistence] Correctly restore SOAs for standalone diffs

### DIFF
--- a/src/persistence/restore.rs
+++ b/src/persistence/restore.rs
@@ -581,9 +581,15 @@ fn apply_ixfr_event_to_signed_data(patcher: &mut SignedZonePatcher<'_>, event: I
 
 fn apply_ixfr_event_to_diff_data(diff: &mut Box<DiffData>, event: IxfrEvent) {
     match event {
-        IxfrEvent::Remove(r) if r.rtype == RType::SOA => diff.removed_soa = Some(r.into()),
+        IxfrEvent::Remove(r) if r.rtype == RType::SOA => {
+            diff.removed_records.push(r.clone());
+            diff.removed_soa = Some(r.into());
+        }
         IxfrEvent::Remove(r) => diff.removed_records.push(r),
-        IxfrEvent::Add(r) if r.rtype == RType::SOA => diff.added_soa = Some(r.into()),
+        IxfrEvent::Add(r) if r.rtype == RType::SOA => {
+            diff.added_records.push(r.clone());
+            diff.added_soa = Some(r.into());
+        }
         IxfrEvent::Add(r) => diff.added_records.push(r),
         IxfrEvent::EndOfUpdate => {}
     }


### PR DESCRIPTION
Should fix #953.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?