### PR TITLE
Simplify zone data storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +297,7 @@ dependencies = [
  "domain-kmip",
  "foldhash",
  "futures-util",
+ "hashbrown 0.17.1",
  "hostname",
  "idna_adapter",
  "jiff",
@@ -799,7 +806,10 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
+ "rayon",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,6 +185,9 @@ hostname = "0.4.1"
 # organization.
 prometheus-client = "0.24.0"
 
+# `hashbrown` provides fast hash tables, with good support for Rayon.
+hashbrown = { version = "0.17", features = ["rayon"] }
+
 # `idna`, which provides internationalized domain names, is pulled in by `url`.
 # It adds a significant number of dependencies. But Cascade only uses pure-ASCII
 # URLs, so IDN support is unnecessary. `url` does not offer a way to disable

--- a/src/contents/apply.rs
+++ b/src/contents/apply.rs
@@ -1,0 +1,402 @@
+//! Applying changes to zone data.
+
+use std::iter::Peekable;
+
+use cascade_zonedata::{RegularRecord, SoaRecord};
+
+use super::{InstanceDiff, LoadedInstanceData, SignedInstanceData};
+
+//----------- LoadedInstanceData -----------------------------------------------
+
+impl LoadedInstanceData {
+    /// Whether a diff can be applied to this.
+    ///
+    /// ## Errors
+    ///
+    /// Fails if the diff is inconsistent with `self`, and returns an error
+    /// describing the inconsistency.
+    pub fn can_apply_diff(&self, diff: &InstanceDiff) -> Result<(), Inconsistency> {
+        if let Some(removed_soa) = &diff.removed_soa
+            && *removed_soa != self.soa
+        {
+            return Err(Inconsistency::RemoveWrongSoa {
+                base: self.soa.clone(),
+                removing: removed_soa.clone(),
+            });
+        } else if let None = &diff.removed_soa
+            && let Some(added_soa) = &diff.added_soa
+        {
+            return Err(Inconsistency::AddExistingSoa {
+                base: self.soa.clone(),
+                adding: added_soa.clone(),
+            });
+        }
+
+        for [o, r, a] in merge([&self.records, &diff.removed_records, &diff.added_records]) {
+            match [o, r, a] {
+                [None, None, None] => unreachable!(),
+
+                [_, Some(_), Some(_)] => panic!("A diff adds and removes the same record"),
+
+                [None, Some(removing), _] => {
+                    return Err(Inconsistency::RemoveNonexistent {
+                        removing: Box::new(removing.clone()),
+                    });
+                }
+
+                [Some(_), _, Some(adding)] => {
+                    return Err(Inconsistency::AddExisting {
+                        adding: Box::new(adding.clone()),
+                    });
+                }
+
+                // Regular cases.
+                [Some(_), None, None] | [None, None, Some(_)] | [Some(_), Some(_), None] => {}
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Apply a diff.
+    ///
+    /// ## Errors
+    ///
+    /// Fails if the diff is inconsistent with `self`, and returns an error
+    /// describing the inconsistency. [`Self::can_apply()`] returns exactly the
+    /// same error, without borrowing `self` mutably.
+    pub fn apply_diff(&mut self, diff: &InstanceDiff) -> Result<(), Inconsistency> {
+        if let Some(removed_soa) = &diff.removed_soa
+            && *removed_soa != self.soa
+        {
+            return Err(Inconsistency::RemoveWrongSoa {
+                base: self.soa.clone(),
+                removing: removed_soa.clone(),
+            });
+        } else if let None = &diff.removed_soa
+            && let Some(added_soa) = &diff.added_soa
+        {
+            return Err(Inconsistency::AddExistingSoa {
+                base: self.soa.clone(),
+                adding: added_soa.clone(),
+            });
+        }
+
+        if let Some(added_soa) = &diff.added_soa {
+            self.soa = added_soa.clone();
+        }
+
+        let mut records = Vec::new();
+        for [o, r, a] in merge([&self.records, &diff.removed_records, &diff.added_records]) {
+            match [o, r, a] {
+                [None, None, None] => unreachable!(),
+
+                [_, Some(_), Some(_)] => panic!("A diff adds and removes the same record"),
+
+                [None, Some(removing), _] => {
+                    return Err(Inconsistency::RemoveNonexistent {
+                        removing: Box::new(removing.clone()),
+                    });
+                }
+
+                [Some(_), _, Some(adding)] => {
+                    return Err(Inconsistency::AddExisting {
+                        adding: Box::new(adding.clone()),
+                    });
+                }
+
+                // Carry a record through.
+                [Some(r), None, None] => records.push(r.clone()),
+
+                // Add a new record.
+                [None, None, Some(r)] => records.push(r.clone()),
+
+                // Remove an existing record.
+                [Some(_), Some(_), None] => {}
+            }
+        }
+
+        Ok(())
+    }
+}
+
+//----------- SignedInstanceData -----------------------------------------------
+
+impl SignedInstanceData {
+    /// Whether a diff can be applied to this.
+    ///
+    /// ## Errors
+    ///
+    /// Fails if the diff is inconsistent with `self`, and returns an error
+    /// describing the inconsistency.
+    pub fn can_apply_diff(&self, diff: &InstanceDiff) -> Result<(), Inconsistency> {
+        if let Some(removed_soa) = &diff.removed_soa
+            && *removed_soa != self.soa
+        {
+            return Err(Inconsistency::RemoveWrongSoa {
+                base: self.soa.clone(),
+                removing: removed_soa.clone(),
+            });
+        } else if let None = &diff.removed_soa
+            && let Some(added_soa) = &diff.added_soa
+        {
+            return Err(Inconsistency::AddExistingSoa {
+                base: self.soa.clone(),
+                adding: added_soa.clone(),
+            });
+        }
+
+        for [o, r, a] in merge([&self.records, &diff.removed_records, &diff.added_records]) {
+            match [o, r, a] {
+                [None, None, None] => unreachable!(),
+
+                [_, Some(_), Some(_)] => panic!("A diff adds and removes the same record"),
+
+                [None, Some(removing), _] => {
+                    return Err(Inconsistency::RemoveNonexistent {
+                        removing: Box::new(removing.clone()),
+                    });
+                }
+
+                [Some(_), _, Some(adding)] => {
+                    return Err(Inconsistency::AddExisting {
+                        adding: Box::new(adding.clone()),
+                    });
+                }
+
+                // Regular cases.
+                [Some(_), None, None] | [None, None, Some(_)] | [Some(_), Some(_), None] => {}
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Apply a diff.
+    ///
+    /// ## Errors
+    ///
+    /// Fails if the diff is inconsistent with `self`, and returns an error
+    /// describing the inconsistency. [`Self::can_apply()`] returns exactly the
+    /// same error, without borrowing `self` mutably.
+    pub fn apply_diff(&mut self, diff: &InstanceDiff) -> Result<(), Inconsistency> {
+        if let Some(removed_soa) = &diff.removed_soa
+            && *removed_soa != self.soa
+        {
+            return Err(Inconsistency::RemoveWrongSoa {
+                base: self.soa.clone(),
+                removing: removed_soa.clone(),
+            });
+        } else if let None = &diff.removed_soa
+            && let Some(added_soa) = &diff.added_soa
+        {
+            return Err(Inconsistency::AddExistingSoa {
+                base: self.soa.clone(),
+                adding: added_soa.clone(),
+            });
+        }
+
+        if let Some(added_soa) = &diff.added_soa {
+            self.soa = added_soa.clone();
+        }
+
+        let mut records = Vec::new();
+        for [o, r, a] in merge([&self.records, &diff.removed_records, &diff.added_records]) {
+            match [o, r, a] {
+                [None, None, None] => unreachable!(),
+
+                [_, Some(_), Some(_)] => panic!("A diff adds and removes the same record"),
+
+                [None, Some(removing), _] => {
+                    return Err(Inconsistency::RemoveNonexistent {
+                        removing: Box::new(removing.clone()),
+                    });
+                }
+
+                [Some(_), _, Some(adding)] => {
+                    return Err(Inconsistency::AddExisting {
+                        adding: Box::new(adding.clone()),
+                    });
+                }
+
+                // Carry a record through.
+                [Some(r), None, None] => records.push(r.clone()),
+
+                // Add a new record.
+                [None, None, Some(r)] => records.push(r.clone()),
+
+                // Remove an existing record.
+                [Some(_), Some(_), None] => {}
+            }
+        }
+        self.records = records;
+
+        Ok(())
+    }
+}
+
+//----------- InstanceDiff -----------------------------------------------------
+
+impl InstanceDiff {
+    /// Compose two diffs together.
+    ///
+    /// A new diff, equivalent to `self` followed by `diff`, is returned.
+    ///
+    /// ## Errors
+    ///
+    /// Fails if the diffs are inconsistent, and returns an error
+    /// describing the inconsistency.
+    pub fn compose(&self, diff: &Self) -> Result<Self, Inconsistency> {
+        let (removed_soa, added_soa) = match [
+            &self.removed_soa,
+            &self.added_soa,
+            &diff.removed_soa,
+            &diff.added_soa,
+        ] {
+            [Some(_), None, Some(r), _] => {
+                return Err(Inconsistency::RemoveNonexistentSoa {
+                    removing: r.clone(),
+                });
+            }
+
+            [_, Some(a), Some(r), _] if a != r => {
+                return Err(Inconsistency::RemoveWrongSoa {
+                    base: a.clone(),
+                    removing: r.clone(),
+                });
+            }
+
+            [_, Some(a), None, Some(b)] => {
+                return Err(Inconsistency::AddExistingSoa {
+                    base: a.clone(),
+                    adding: b.clone(),
+                });
+            }
+
+            // Join the diffs.
+            [r, Some(_), Some(_), a] | [r, None, None, a] => (r.clone(), a.clone()),
+
+            // Ignore an empty diff.
+            [r, a, None, None] | [None, None, r, a] => (r.clone(), a.clone()),
+        };
+
+        let mut removed_records = Vec::new();
+        let mut added_records = Vec::new();
+        for [ar, aa, br, ba] in merge([
+            &self.removed_records,
+            &self.added_records,
+            &diff.removed_records,
+            &diff.added_records,
+        ]) {
+            match [ar, aa, br, ba] {
+                [None, None, None, None] => unreachable!(),
+
+                [Some(_), Some(_), _, _] | [_, _, Some(_), Some(_)] => {
+                    panic!("A diff adds and removes the same record");
+                }
+
+                [None, Some(_), None, Some(a)] => {
+                    return Err(Inconsistency::AddExisting {
+                        adding: Box::new(a.clone()),
+                    });
+                }
+
+                [Some(_), None, Some(r), None] => {
+                    return Err(Inconsistency::RemoveNonexistent {
+                        removing: Box::new(r.clone()),
+                    });
+                }
+
+                // Carry forward unchanged diffs.
+                [None, Some(r), None, None] | [None, None, None, Some(r)] => {
+                    added_records.push(r.clone());
+                }
+                [Some(r), None, None, None] | [None, None, Some(r), None] => {
+                    removed_records.push(r.clone());
+                }
+
+                // Add a removed record.
+                [Some(_), None, None, Some(_)] => {}
+
+                // Remove an added record.
+                [None, Some(_), Some(_), None] => {}
+            }
+        }
+
+        Ok(Self {
+            removed_soa,
+            added_soa,
+            removed_records,
+            added_records,
+        })
+    }
+}
+
+//----------- merge() ----------------------------------------------------------
+
+/// Merge sorted iterators.
+fn merge<T: Ord, I: IntoIterator<Item = T>, const N: usize>(
+    iters: [I; N],
+) -> impl Iterator<Item = [Option<T>; N]> {
+    struct Merge<T: Ord, I: Iterator<Item = T>, const N: usize>([Peekable<I>; N]);
+
+    impl<T: Ord, I: Iterator<Item = T>, const N: usize> Iterator for Merge<T, I, N> {
+        type Item = [Option<T>; N];
+
+        fn next(&mut self) -> Option<Self::Item> {
+            let set = self.0.each_mut().map(|e| e.peek());
+            let min = set.iter().cloned().flatten().min()?;
+            let used = set.map(|e| e == Some(min));
+            let mut index = 0usize;
+            Some(self.0.each_mut().map(|i| {
+                let used = used[index];
+                index += 1;
+                i.next_if(|_| used)
+            }))
+        }
+    }
+
+    Merge(iters.map(|i| i.into_iter().peekable()))
+}
+
+//----------- Inconsistency ----------------------------------------------------
+
+/// A zone/diff is inconsistent with a diff.
+#[derive(Clone, Debug)]
+pub enum Inconsistency {
+    /// A SOA record was removed when none existed.
+    RemoveNonexistentSoa {
+        /// The SOA record to be removed.
+        removing: Box<SoaRecord>,
+    },
+
+    /// The wrong SOA record was removed.
+    RemoveWrongSoa {
+        /// The base SOA record.
+        base: Box<SoaRecord>,
+
+        /// The SOA record to be removed.
+        removing: Box<SoaRecord>,
+    },
+
+    /// A SOA record was added but one already existed.
+    AddExistingSoa {
+        /// The base SOA record.
+        base: Box<SoaRecord>,
+
+        /// The SOA record to be removed.
+        adding: Box<SoaRecord>,
+    },
+
+    /// A nonexistent record was removed.
+    RemoveNonexistent {
+        /// The record to be removed.
+        removing: Box<RegularRecord>,
+    },
+
+    /// An existing record was added.
+    AddExisting {
+        /// The record to be added.
+        adding: Box<RegularRecord>,
+    },
+}

--- a/src/contents/data.rs
+++ b/src/contents/data.rs
@@ -1,0 +1,38 @@
+//! The raw storage for zone data.
+
+use cascade_zonedata::{RegularRecord, SoaRecord};
+
+//----------- LoadedInstanceData -----------------------------------------------
+
+/// A loaded instance of a zone.
+pub struct LoadedInstanceData {
+    /// The SOA record.
+    pub soa: Box<SoaRecord>,
+
+    /// All records.
+    ///
+    /// Records are sorted in DNSSEC canonical order. The SOA record **is**
+    /// included.
+    pub records: Vec<RegularRecord>,
+}
+
+//----------- SignedInstanceData -----------------------------------------------
+
+/// A signed instance of a zone.
+///
+/// This is relative to a [`LoadedInstanceData`]; it serves as a layer on top
+/// that adds and removes records.
+pub struct SignedInstanceData {
+    /// The SOA record.
+    ///
+    /// This overrides the SOA record of the loaded instance.
+    pub soa: Box<SoaRecord>,
+
+    /// All generated records.
+    ///
+    /// These records are added during signing.
+    ///
+    /// Records are sorted in DNSSEC canonical order. The SOA record **is**
+    /// included.
+    pub records: Vec<RegularRecord>,
+}

--- a/src/contents/data.rs
+++ b/src/contents/data.rs
@@ -1,6 +1,11 @@
 //! The raw storage for zone data.
 
 use cascade_zonedata::{RegularRecord, SoaRecord};
+use domain::new::base::{RClass, RType};
+use rayon::{
+    iter::{IntoParallelRefIterator, ParallelIterator},
+    slice::ParallelSlice,
+};
 
 //----------- LoadedInstanceData -----------------------------------------------
 
@@ -14,6 +19,58 @@ pub struct LoadedInstanceData {
     /// Records are sorted in DNSSEC canonical order. The SOA record **is**
     /// included.
     pub records: Vec<RegularRecord>,
+}
+
+impl LoadedInstanceData {
+    /// Check invariants.
+    pub fn check_invariants(&self) {
+        let origin = &*self.soa.rname;
+        assert_eq!(self.soa.rtype, RType::SOA);
+        assert_eq!(self.soa.rclass, RClass::IN);
+
+        assert_eq!(
+            self.records
+                .par_iter()
+                .filter(|&r| r.rtype == RType::SOA && *r.rname == *origin)
+                .collect::<Vec<_>>(),
+            vec![&RegularRecord::from((*self.soa).clone())],
+            "`self.records` must contain `self.soa` and no other apex SOA records"
+        );
+
+        self.records.par_iter().for_each(|r| {
+            assert!(
+                r.rname.as_bytes().starts_with(self.soa.rname.as_bytes()),
+                "{r:?} falls outside the zone origin {origin:?}"
+            );
+            assert_eq!(r.rclass, RClass::IN);
+        });
+
+        assert_eq!(
+            self.records
+                .par_array_windows::<2>()
+                .find_any(|&[a, b]| a > b),
+            None,
+            "`self.records` must be sorted"
+        );
+
+        assert_eq!(
+            self.records
+                .par_array_windows::<2>()
+                .find_any(|&[a, b]| a == b),
+            None,
+            "`self.records` must not contain duplicates"
+        );
+
+        assert_eq!(
+            self.records
+                .par_array_windows::<2>()
+                .find_any(|&[a, b]| (&a.rname, a.rtype) == (&b.rname, b.rtype)
+                    && a.rtype != RType::RRSIG
+                    && a.ttl != b.ttl),
+            None,
+            "Non-RRSIG RRsets in `self.records` must have consistent TTLs",
+        );
+    }
 }
 
 //----------- SignedInstanceData -----------------------------------------------
@@ -35,4 +92,56 @@ pub struct SignedInstanceData {
     /// Records are sorted in DNSSEC canonical order. The SOA record **is**
     /// included.
     pub records: Vec<RegularRecord>,
+}
+
+impl SignedInstanceData {
+    /// Check invariants.
+    pub fn check_invariants(&self) {
+        let origin = &*self.soa.rname;
+        assert_eq!(self.soa.rtype, RType::SOA);
+        assert_eq!(self.soa.rclass, RClass::IN);
+
+        assert_eq!(
+            self.records
+                .par_iter()
+                .filter(|&r| r.rtype == RType::SOA && *r.rname == *origin)
+                .collect::<Vec<_>>(),
+            vec![&RegularRecord::from((*self.soa).clone())],
+            "`self.records` must contain `self.soa` and no other apex SOA records"
+        );
+
+        self.records.par_iter().for_each(|r| {
+            assert!(
+                r.rname.as_bytes().starts_with(self.soa.rname.as_bytes()),
+                "{r:?} falls outside the zone origin {origin:?}"
+            );
+            assert_eq!(r.rclass, RClass::IN);
+        });
+
+        assert_eq!(
+            self.records
+                .par_array_windows::<2>()
+                .find_any(|&[a, b]| a > b),
+            None,
+            "`self.records` must be sorted"
+        );
+
+        assert_eq!(
+            self.records
+                .par_array_windows::<2>()
+                .find_any(|&[a, b]| a == b),
+            None,
+            "`self.records` must not contain duplicates"
+        );
+
+        assert_eq!(
+            self.records
+                .par_array_windows::<2>()
+                .find_any(|&[a, b]| (&a.rname, a.rtype) == (&b.rname, b.rtype)
+                    && a.rtype != RType::RRSIG
+                    && a.ttl != b.ttl),
+            None,
+            "Non-RRSIG RRsets in `self.records` must have consistent TTLs",
+        );
+    }
 }

--- a/src/contents/diff.rs
+++ b/src/contents/diff.rs
@@ -1,0 +1,222 @@
+//! Differences between instances.
+
+use std::iter::FusedIterator;
+
+use domain::new::base::{RClass, RType, name::RevName};
+
+use cascade_zonedata::{RegularRecord, SoaRecord, is_signing};
+
+//----------- InstanceDiff -----------------------------------------------------
+
+/// The difference between two instances of a zone.
+///
+/// [`InstanceDiff`] is relative to two zones, a base and a target; it tracks
+/// the steps necessary (in terms of records to remove and add) to transform the
+/// base into the target. It is used for both unsigned and signed instances.
+///
+/// [`InstanceDiff`] can be used to store the data for an old zone (where it
+/// is the base, and the next newer zone is the target). This is perfect for
+/// serving IXFR requests.
+#[derive(Clone, Default)]
+pub struct InstanceDiff {
+    /// The SOA record to remove.
+    ///
+    /// This record is present in the base, but not in the target.
+    pub removed_soa: Option<Box<SoaRecord>>,
+
+    /// The SOA record found in the target.
+    ///
+    /// This record is present in the target, but not in the base.
+    pub added_soa: Option<Box<SoaRecord>>,
+
+    /// Removed regular records.
+    ///
+    /// These records are present in the base, but not in the target. They
+    /// **also** include the removed SOA record. They are sorted in DNSSEC
+    /// canonical order.
+    pub removed_records: Vec<RegularRecord>,
+
+    /// Added regular records.
+    ///
+    /// These records are present in the target, but not in the base. They
+    /// **also** include the added SOA record. They are sorted in DNSSEC
+    /// canonical order.
+    pub added_records: Vec<RegularRecord>,
+}
+
+impl InstanceDiff {
+    /// Construct a new, empty [`DiffData`].
+    pub const fn new() -> Self {
+        Self {
+            removed_soa: None,
+            added_soa: None,
+            removed_records: Vec::new(),
+            added_records: Vec::new(),
+        }
+    }
+
+    /// Whether this diff is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.removed_soa.is_none()
+            && self.added_soa.is_none()
+            && self.removed_records.is_empty()
+            && self.added_records.is_empty()
+    }
+}
+
+impl InstanceDiff {
+    /// Iterate over the removed non-SOA records.
+    pub fn removed_non_soa<'a>(&'a self, origin: &'a RevName) -> RecordsIter<'a> {
+        RecordsIter {
+            iter: self.removed_records.iter(),
+            pending_soa_filter: self.removed_soa.is_some(),
+            origin,
+        }
+    }
+
+    /// Iterate over the added non-SOA records.
+    pub fn added_non_soa<'a>(&'a self, origin: &'a RevName) -> RecordsIter<'a> {
+        RecordsIter {
+            iter: self.added_records.iter(),
+            pending_soa_filter: self.added_soa.is_some(),
+            origin,
+        }
+    }
+
+    /// Iterate over the *unsigned* removed non-SOA records.
+    pub fn unsigned_removed_non_soa<'a>(&'a self, origin: &'a RevName) -> UnsignedRecordsIter<'a> {
+        UnsignedRecordsIter {
+            iter: self.removed_records.iter(),
+            pending_soa_filter: self.removed_soa.is_some(),
+            origin,
+        }
+    }
+
+    /// Iterate over the *unsigned* added non-SOA records.
+    pub fn unsigned_added_non_soa<'a>(&'a self, origin: &'a RevName) -> UnsignedRecordsIter<'a> {
+        UnsignedRecordsIter {
+            iter: self.added_records.iter(),
+            pending_soa_filter: self.added_soa.is_some(),
+            origin,
+        }
+    }
+}
+
+//----------- RecordsIter ------------------------------------------------------
+
+/// Added or removed records from a [`DiffData`].
+pub struct RecordsIter<'d> {
+    /// The underlying iterator.
+    iter: core::slice::Iter<'d, RegularRecord>,
+
+    /// Whether a SOA record needs to be filtered out.
+    pending_soa_filter: bool,
+
+    /// The zone origin.
+    ///
+    /// Only used if `pending_soa_filter` is true.
+    origin: &'d RevName,
+}
+
+impl<'d> Iterator for RecordsIter<'d> {
+    type Item = &'d RegularRecord;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let record = self.iter.next()?;
+
+        // Filter out a SOA record as needed.
+        if self.pending_soa_filter && record.rtype == RType::SOA && *record.rname == *self.origin {
+            self.pending_soa_filter = false;
+            return self.iter.next();
+        }
+
+        Some(record)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len(), Some(self.len()))
+    }
+}
+
+impl DoubleEndedIterator for RecordsIter<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let record = self.iter.next_back()?;
+
+        // Filter out a SOA record as needed.
+        if self.pending_soa_filter && record.rtype == RType::SOA && *record.rname == *self.origin {
+            self.pending_soa_filter = false;
+            return self.iter.next_back();
+        }
+
+        Some(record)
+    }
+}
+
+impl ExactSizeIterator for RecordsIter<'_> {
+    fn len(&self) -> usize {
+        self.iter
+            .len()
+            .checked_sub(self.pending_soa_filter as usize)
+            .expect("`pending_soa_filter` is set but `iter` is empty")
+    }
+}
+
+impl FusedIterator for RecordsIter<'_> {}
+
+//----------- UnsignedRecordsIter ----------------------------------------------
+
+/// Added or removed *unsigned* records from a [`DiffData`].
+pub struct UnsignedRecordsIter<'d> {
+    /// The underlying iterator.
+    iter: core::slice::Iter<'d, RegularRecord>,
+
+    /// Whether a SOA record needs to be filtered out.
+    pending_soa_filter: bool,
+
+    /// The zone origin.
+    ///
+    /// Only used if `pending_soa_filter` is true.
+    origin: &'d RevName,
+}
+
+impl<'d> Iterator for UnsignedRecordsIter<'d> {
+    type Item = &'d RegularRecord;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let record = loop {
+            let record = self.iter.next()?;
+            if !is_signing(record.rtype, || *record.rname == *self.origin) {
+                break record;
+            }
+        };
+
+        // Filter out a SOA record as needed.
+        if self.pending_soa_filter && record.rtype == RType::SOA && *record.rname == *self.origin {
+            self.pending_soa_filter = false;
+            return self.next();
+        }
+
+        Some(record)
+    }
+}
+
+impl DoubleEndedIterator for UnsignedRecordsIter<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let record = loop {
+            let record = self.iter.next_back()?;
+            if !is_signing(record.rtype, || *record.rname == *self.origin) {
+                break record;
+            }
+        };
+
+        // Filter out a SOA record as needed.
+        if self.pending_soa_filter && record.rtype == RType::SOA && *record.rname == *self.origin {
+            self.pending_soa_filter = false;
+            return self.next_back();
+        }
+
+        Some(record)
+    }
+}
+
+impl FusedIterator for UnsignedRecordsIter<'_> {}

--- a/src/contents/diff.rs
+++ b/src/contents/diff.rs
@@ -5,6 +5,10 @@ use std::iter::FusedIterator;
 use domain::new::base::{RClass, RType, name::RevName};
 
 use cascade_zonedata::{RegularRecord, SoaRecord, is_signing};
+use rayon::{
+    iter::{IntoParallelRefIterator, ParallelIterator},
+    slice::ParallelSlice,
+};
 
 //----------- InstanceDiff -----------------------------------------------------
 
@@ -42,6 +46,81 @@ pub struct InstanceDiff {
     /// **also** include the added SOA record. They are sorted in DNSSEC
     /// canonical order.
     pub added_records: Vec<RegularRecord>,
+}
+
+impl InstanceDiff {
+    /// Check invariants.
+    pub fn check_invariants(&self, origin: &RevName) {
+        for (prefix, soa, records) in [
+            ("removed_", &self.removed_soa, &self.removed_records),
+            ("added_", &self.added_soa, &self.added_records),
+        ] {
+            if let Some(soa) = soa {
+                assert_eq!(*soa.rname, *origin);
+                assert_eq!(soa.rtype, RType::SOA);
+                assert_eq!(soa.rclass, RClass::IN);
+            }
+
+            assert_eq!(
+                records
+                    .par_iter()
+                    .filter(|&r| r.rtype == RType::SOA && *r.rname == *origin)
+                    .cloned()
+                    .collect::<Vec<_>>(),
+                soa.iter()
+                    .map(|r| RegularRecord::from((**r).clone()))
+                    .collect::<Vec<_>>(),
+                "`self.{prefix}records` must contain `self.{prefix}soa` and no other apex SOA records"
+            );
+
+            self.removed_records.par_iter().for_each(|r| {
+                assert!(
+                    r.rname.as_bytes().starts_with(origin.as_bytes()),
+                    "{r:?} falls outside the zone origin {origin:?}"
+                );
+                assert_eq!(r.rclass, RClass::IN);
+            });
+
+            assert_eq!(
+                records.par_array_windows::<2>().find_any(|&[a, b]| a > b),
+                None,
+                "`self.{prefix}records` must be sorted"
+            );
+
+            assert_eq!(
+                records.par_array_windows::<2>().find_any(|&[a, b]| a == b),
+                None,
+                "`self.{prefix}records` must not contain duplicates"
+            );
+
+            assert_eq!(
+                records
+                    .par_array_windows::<2>()
+                    .find_any(|&[a, b]| (&a.rname, a.rtype) == (&b.rname, b.rtype)
+                        && a.rtype != RType::RRSIG
+                        && a.ttl != b.ttl),
+                None,
+                "Non-RRSIG RRsets in `self.{prefix}records` must have consistent TTLs",
+            );
+        }
+
+        let removed = self
+            .removed_records
+            .par_iter()
+            .collect::<hashbrown::HashSet<_>>();
+        let added = self
+            .added_records
+            .par_iter()
+            .collect::<hashbrown::HashSet<_>>();
+        assert_eq!(
+            removed
+                .par_intersection(&added)
+                .copied()
+                .collect::<Vec<_>>(),
+            &[] as &[&RegularRecord],
+            "`self.removed_records` and `self.added_records` must be disjoint"
+        );
+    }
 }
 
 impl InstanceDiff {

--- a/src/contents/mod.rs
+++ b/src/contents/mod.rs
@@ -2,3 +2,6 @@
 
 mod data;
 pub use data::{LoadedInstanceData, SignedInstanceData};
+
+mod diff;
+pub use diff::InstanceDiff;

--- a/src/contents/mod.rs
+++ b/src/contents/mod.rs
@@ -5,3 +5,6 @@ pub use data::{LoadedInstanceData, SignedInstanceData};
 
 mod diff;
 pub use diff::InstanceDiff;
+
+mod reader;
+pub use reader::{LoadedZoneReader, SignedZoneReader};

--- a/src/contents/mod.rs
+++ b/src/contents/mod.rs
@@ -1,0 +1,1 @@
+//! Storage for zone contents.

--- a/src/contents/mod.rs
+++ b/src/contents/mod.rs
@@ -8,3 +8,6 @@ pub use diff::InstanceDiff;
 
 mod reader;
 pub use reader::{LoadedZoneReader, SignedZoneReader};
+
+mod apply;
+pub use apply::Inconsistency;

--- a/src/contents/mod.rs
+++ b/src/contents/mod.rs
@@ -1,1 +1,4 @@
 //! Storage for zone contents.
+
+mod data;
+pub use data::{LoadedInstanceData, SignedInstanceData};

--- a/src/contents/reader.rs
+++ b/src/contents/reader.rs
@@ -1,0 +1,134 @@
+//! Reading zone data.
+
+use cascade_zonedata::{RegularRecord, SoaRecord, is_signing};
+use domain::new::base::name::RevName;
+
+use super::{LoadedInstanceData, SignedInstanceData};
+
+//----------- LoadedZoneReader -------------------------------------------------
+
+/// A reader for a loaded instance of a zone.
+///
+/// [`LoadedZoneReader`] offers efficient access to the records of a loaded
+/// instance of a zone (whether it is the current authoritative instance or a
+/// prepared, upcoming one). This instance primarily consists of unsigned data.
+pub struct LoadedZoneReader<'d> {
+    /// The instance being accessed.
+    pub instance: &'d LoadedInstanceData,
+}
+
+impl LoadedZoneReader<'_> {
+    /// Check invariants.
+    pub fn check_invariants(&self) {
+        self.instance.check_invariants();
+    }
+}
+
+impl<'d> LoadedZoneReader<'d> {
+    /// The zone origin.
+    pub fn origin(&self) -> &'d RevName {
+        &self.instance.soa.rname
+    }
+
+    /// The SOA record.
+    pub fn soa(&self) -> &'d SoaRecord {
+        &self.instance.soa
+    }
+
+    /// Regular records in the zone.
+    ///
+    /// Records are sorted in DNSSEC canonical order. The SOA record **is**
+    /// included.
+    pub const fn regular_records(&self) -> &'d [RegularRecord] {
+        self.instance.records.as_slice()
+    }
+
+    /// The unsigned records in the zone.
+    ///
+    /// DNSSEC related records that would be produced by Cascade's signer (e.g.
+    /// RRSIGs, NSEC/NSEC3, etc.) are stripped. The records are sorted in DNSSEC
+    /// canonical order. The SOA record **is** included.
+    pub fn unsigned_records(&self) -> impl Iterator<Item = &'d RegularRecord> + Send + use<'d> {
+        // Filter out records that would be generated during signing.
+        let origin = self.origin();
+        self.instance
+            .records
+            .iter()
+            .filter(|&r| !is_signing(r.rtype, || *r.rname == *origin))
+    }
+}
+
+//----------- SignedZoneReader -------------------------------------------------
+
+/// A reader for the signed component of an instance of a zone.
+///
+/// [`SignedZoneReader`] offers efficient access to the records of a signed
+/// instance of a zone (whether it is the current authoritative instance or a
+/// prepared, upcoming one). This instance primarily consists of signature data.
+pub struct SignedZoneReader<'d> {
+    /// The loaded instance being accessed.
+    pub loaded_instance: &'d LoadedInstanceData,
+
+    /// The signed instance being accessed.
+    pub signed_instance: &'d SignedInstanceData,
+}
+
+impl SignedZoneReader<'_> {
+    /// Check invariants.
+    pub fn check_invariants(&self) {
+        self.loaded_instance.check_invariants();
+        self.signed_instance.check_invariants();
+
+        assert_eq!(
+            self.loaded_instance.soa.rname, self.signed_instance.soa.rname,
+            "The loaded and signed instance must have the same origin"
+        );
+    }
+}
+
+impl<'d> SignedZoneReader<'d> {
+    /// The zone origin.
+    pub fn origin(&self) -> &'d RevName {
+        &self.signed_instance.soa.rname
+    }
+
+    /// The SOA record.
+    pub fn soa(&self) -> &'d SoaRecord {
+        &self.signed_instance.soa
+    }
+
+    /// All records generated during signing.
+    ///
+    /// Records are sorted in DNSSEC canonical order. The SOA record **is**
+    /// included.
+    pub const fn generated_records(&self) -> &'d [RegularRecord] {
+        self.signed_instance.records.as_slice()
+    }
+
+    /// The underlying loaded instance.
+    pub const fn loaded(&self) -> LoadedZoneReader<'d> {
+        LoadedZoneReader {
+            instance: self.loaded_instance,
+        }
+    }
+
+    /// Records from the loaded instance of the zone.
+    ///
+    /// Records are sorted in DNSSEC canonical order. Only records also present
+    /// in the signed instance are included (the loaded SOA record, and loaded
+    /// DNSKEY, RRSIG, CDS, CDNSKEY, ZONEMD records are excluded).
+    pub fn loaded_records(&self) -> impl Iterator<Item = &'d RegularRecord> + Send + use<'d> {
+        let soa = self.soa();
+        self.loaded()
+            .unsigned_records()
+            .filter(|&r| r.rname != soa.rname || r.rtype != soa.rtype)
+    }
+
+    /// All records in the zone.
+    ///
+    /// Records are **unsorted**. The SOA record (of the signed instance) **is**
+    /// included; unsigned records from the loaded instance **are** included.
+    pub fn all_records(&self) -> impl Iterator<Item = &'d RegularRecord> + Send + use<'d> {
+        self.generated_records().iter().chain(self.loaded_records())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ use cascade_zonedata as zonedata;
 
 mod center;
 mod common;
+mod contents;
 mod daemon;
 mod loader;
 mod log;


### PR DESCRIPTION
This PR replaces the `cascade_zonedata` subcrate with a much simpler implementation in `cascaded::contents`. It removes the `ZoneDataStorage` state machine and relies on the zone state machine to drive everything. It removes `*Replacer` and `*Patcher` and replaces them with direct manipulation of instance data and diffs. It splits `InstanceData` into a loaded and a signed variant in preparation for data structure improvements.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [ ] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?