### PR TITLE
FIX: Off-by-one error when restoring signed diffs (fixes #956).

### DIFF
--- a/src/persistence/restore.rs
+++ b/src/persistence/restore.rs
@@ -41,14 +41,14 @@ pub fn restore_loaded(
     restorer: &mut LoadedZoneRestorer,
 ) -> io::Result<bool> {
     let diff_infos;
-    let first_diff_to_apply_on_restore;
+    let restore_base_idx;
 
     // Use a block so that we don't hold the zone state lock longer than
     // necessary.
     {
         let state = zone.read();
         diff_infos = state.persistence.loaded_diffs.diffs().clone();
-        first_diff_to_apply_on_restore = state
+        restore_base_idx = state
             .persistence
             .loaded_diffs
             .first_diff_to_apply_on_restore();
@@ -60,7 +60,7 @@ pub fn restore_loaded(
     };
 
     info!("Restoring persisted loaded data for zone '{}'", zone.name);
-    trace!("Restoring from loaded diffs: {diff_infos:?}");
+    trace!("Restoring from loaded diffs: restore_base_idx={restore_base_idx}, {diff_infos:?}");
 
     // Determine the paths to read from. Each zone is persisted as an AXFR
     // plus zero or more IXFRs. The restorer takes a base path ending in an
@@ -96,9 +96,9 @@ pub fn restore_loaded(
     for (idx, diff_info) in diff_infos_iter.enumerate() {
         // Note: idx is zero-based but as we skipped over the first entry (the
         // snapshot) we need to add one to get a correct index.
-        let (start_serial, end_serial) = if (idx + 1) < first_diff_to_apply_on_restore {
+        let (start_serial, end_serial) = if (idx + 1) < restore_base_idx {
             trace!(
-                "Building standalone IXFR diff #{idx} from '{}'",
+                "Building standalone loaded IXFR diff #{idx} from '{}'",
                 diff_info.path().display()
             );
             let mut diff = Box::new(DiffData::new());
@@ -211,7 +211,7 @@ pub fn restore_signed(
     };
 
     info!("Restoring persisted signed data for zone '{}'", zone.name);
-    trace!("Restoring from signed diffs: {diff_infos:?}",);
+    trace!("Restoring from signed diffs: restore_base_idx={restore_base_idx}, {diff_infos:?}",);
 
     // Determine the paths to read from. Each zone is persisted as an AXFR
     // plus zero or more IXFRs. The restorer takes a base path ending in an
@@ -253,9 +253,11 @@ pub fn restore_signed(
     // last compaction event but still need to be loaded into memory to serve
     // in IXFR responses.
     for (idx, diff_info) in diff_infos_iter.enumerate() {
-        let (start_serial, end_serial) = if idx < restore_base_idx {
+        // Note: idx is zero-based but as we skipped over the first entry (the
+        // snapshot) we need to add one to get a correct index.
+        let (start_serial, end_serial) = if (idx + 1) < restore_base_idx {
             trace!(
-                "Building standalone IXFR diff #{idx} from '{}'",
+                "Building standalone signed IXFR diff #{idx} from '{}'",
                 diff_info.path().display()
             );
             let mut diff = Box::new(DiffData::new());

--- a/src/persistence/zone.rs
+++ b/src/persistence/zone.rs
@@ -717,7 +717,7 @@ impl PersistedDiffManager {
     pub fn clear(&mut self) {
         self.diff_infos.clear();
         self.next_uniqifier = 0;
-        self.first_diff_to_apply_on_restore = 0;
+        self.first_diff_to_apply_on_restore = 1;
     }
 
     pub fn is_empty(&self) -> bool {


### PR DESCRIPTION
Discovered in #957 while investigating #956.

This is actually two separate off-by-one bugs:

- `PersistedDiffManager::clear()` wrongly resets the state to 0 instead of 1.
- `restore_signed()` wrongly tested against `idx` instead of `idx + 1` (as was correctly done in `restore_loaded()` and even had an explanatory comment.

Fixing the broken `clear()` logic causes the `persist-zone` integration test to fail.
Fixing `restore_signed()` causes the integration test to pass again.
With both fixes applied #956 is no longer reproduceable.

This PR also normalizes the naming of the variables used by `restore_loaded()` and `restore_signed()` and makes logging when restoring a "standalone" IXFR diff note whether that is a loaded diff or a signed diff that is being restored.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
