### PR TITLE
Include DNSSEC records in the loaded zone when compacting. (fixes #960)

### DIFF
--- a/src/persistence/zone.rs
+++ b/src/persistence/zone.rs
@@ -389,7 +389,7 @@ impl PersistenceState {
                 None,
                 reader.loaded().soa().clone(),
                 [].iter(),
-                reader.loaded_records(),
+                reader.loaded().regular_records().iter(),
             );
 
             debug!(


### PR DESCRIPTION
Tested manually with the signed upstream case that originally caused me to create #960.

This PR does NOT extend the integration tests to cover the signed upstream -> compact -> restart -> restore -> IXFR update case which this fixes as I wanted to first unblock the latest release. I'll create a separate tracking issue for extending the tests to cover this case.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?
