### PR TITLE
Debug command to expose the last and next moments that XFR will be attempted.

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -481,6 +481,27 @@ pub struct ZoneStatus {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct ZoneXfrStatus {
+    pub name: ZoneName,
+    pub refresh_timer_state: RefreshTimerState,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum RefreshTimerState {
+    Disabled,
+
+    Refresh {
+        previous: SystemTime,
+        scheduled: SystemTime,
+    },
+
+    Retry {
+        previous: SystemTime,
+        scheduled: SystemTime,
+    },
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct LastPublishedZone {
     pub loaded_serial: Serial,
     pub signed_serial: Serial,

--- a/crates/cli/src/commands/debug.rs
+++ b/crates/cli/src/commands/debug.rs
@@ -1,8 +1,11 @@
 use std::fmt::{Display, Write};
 
+use cascade_api::{ZoneName, ZoneStatusError, ZoneXfrStatus};
+
 use crate::{
     api::{self, ChangeLogging, ChangeLoggingResult, TraceTarget},
     client::CascadeApiClient,
+    commands::zone::to_rfc3339,
 };
 
 #[derive(Clone, Debug, clap::Args)]
@@ -31,6 +34,10 @@ pub enum Command {
         #[arg(long = "trace-targets", value_delimiter = ',')]
         trace_targets: Option<Vec<String>>,
     },
+
+    /// Inspect internal XFR status information.
+    #[command(name = "xfr-status")]
+    XfrStatus { zone: ZoneName },
 }
 
 impl Debug {
@@ -66,6 +73,41 @@ impl Debug {
 
                 print!("{msg}");
                 Ok(())
+            }
+
+            Command::XfrStatus { zone } => {
+                let url = format!("zone/{}/xfr-status", zone);
+                let response: Result<ZoneXfrStatus, ZoneStatusError> =
+                    client.get_json(&url).await?;
+                match response {
+                    Ok(report) => {
+                        println!("zone: {}", report.name);
+                        print!("refresh status: ");
+                        match report.refresh_timer_state {
+                            cascade_api::RefreshTimerState::Disabled => println!("disabled"),
+                            cascade_api::RefreshTimerState::Refresh {
+                                previous,
+                                scheduled,
+                            } => {
+                                let previous = to_rfc3339(previous);
+                                let scheduled = to_rfc3339(scheduled);
+                                println!("refreshing: last={previous}, next={scheduled}");
+                            }
+                            cascade_api::RefreshTimerState::Retry {
+                                previous,
+                                scheduled,
+                            } => {
+                                let previous = to_rfc3339(previous);
+                                let scheduled = to_rfc3339(scheduled);
+                                println!("retrying: last={previous}, next={scheduled}");
+                            }
+                        }
+                        Ok(())
+                    }
+                    Err(ZoneStatusError::ZoneDoesNotExist) => {
+                        Err(format!("zone `{zone}` does not exist"))
+                    }
+                }
             }
         }
     }

--- a/crates/cli/src/commands/debug.rs
+++ b/crates/cli/src/commands/debug.rs
@@ -6,6 +6,7 @@ use crate::{
     api::{self, ChangeLogging, ChangeLoggingResult, TraceTarget},
     client::CascadeApiClient,
     commands::zone::to_rfc3339,
+    println,
 };
 
 #[derive(Clone, Debug, clap::Args)]

--- a/crates/cli/src/commands/zone.rs
+++ b/crates/cli/src/commands/zone.rs
@@ -1056,7 +1056,7 @@ fn to_rfc3339_ago(v: Option<SystemTime>, default: &str) -> String {
     }
 }
 
-fn to_rfc3339(v: SystemTime) -> String {
+pub fn to_rfc3339(v: SystemTime) -> String {
     jiff::Timestamp::try_from(v)
         .unwrap()
         .round(jiff::Unit::Second)

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -5,6 +5,7 @@ use std::future::IntoFuture;
 use std::sync::Arc;
 use std::sync::atomic::Ordering::Relaxed;
 use std::time::Duration;
+use std::time::Instant;
 use std::time::SystemTime;
 
 use axum::Json;
@@ -86,6 +87,7 @@ impl HttpServer {
             .route("/zone/{name}/remove", post(Self::zone_remove))
             .route("/zone/{name}/reset", post(Self::zone_reset))
             .route("/zone/{name}/status", get(Self::zone_status))
+            .route("/zone/{name}/xfr-status", get(Self::zone_xfr_status))
             .route("/zone/{name}/history", get(Self::zone_history))
             .route("/zone/{name}/reload", post(Self::zone_reload))
             .route(
@@ -670,6 +672,48 @@ impl HttpServer {
             halted_reason,
             error,
         })
+    }
+
+    async fn zone_xfr_status(
+        State(state): State<Arc<HttpServer>>,
+        Path(name): Path<Name<Bytes>>,
+    ) -> Json<Result<ZoneXfrStatus, ZoneStatusError>> {
+        let zone = match get_zone(&state.center, &name) {
+            Some(zone) => zone,
+            None => return Json(Err(ZoneStatusError::ZoneDoesNotExist)),
+        };
+        let instant_now = Instant::now();
+        let system_time_now = SystemTime::now();
+        match zone.read().loader.refresh_timer {
+            loader::zone::RefreshTimerState::Disabled => Json(Ok(ZoneXfrStatus {
+                name: zone.name.clone(),
+                refresh_timer_state: RefreshTimerState::Disabled,
+            })),
+            loader::zone::RefreshTimerState::Refresh {
+                previous,
+                scheduled,
+            } => Json(Ok(ZoneXfrStatus {
+                name: zone.name.clone(),
+                refresh_timer_state: RefreshTimerState::Refresh {
+                    previous: system_time_now.checked_sub(previous.elapsed()).unwrap(),
+                    scheduled: system_time_now
+                        .checked_add(scheduled.duration_since(instant_now))
+                        .unwrap(),
+                },
+            })),
+            loader::zone::RefreshTimerState::Retry {
+                previous,
+                scheduled,
+            } => Json(Ok(ZoneXfrStatus {
+                name: zone.name.clone(),
+                refresh_timer_state: RefreshTimerState::Retry {
+                    previous: system_time_now.checked_sub(previous.elapsed()).unwrap(),
+                    scheduled: system_time_now
+                        .checked_add(scheduled.duration_since(instant_now))
+                        .unwrap(),
+                },
+            })),
+        }
     }
 
     async fn zone_history(


### PR DESCRIPTION
This is something that keeps bugging me: I can't tell from Cascade when it is going to try an upstream XFR next, and whether that will be a normal attempt or a retry.

I don't think this is something a user should ever need to normally care about, so I wondered about exposing it via a debug command, hence this PR.

I have not put any effort into styling the output at this point as I want to know first if anyone else sees value in this.

I would also like to extend this to show the set of available IXFR diffs in memory that can be served to downstream clients.

Example output:

```
$ ./cascade debug xfr-status example.com
zone: example.com
refresh status: refreshing: last=2026-08-12T10:22:58Z, next=2026-08-12T11:22:58Z
```

Another way to approach this could be to expose this via metrics, e.g. last refresh time and whether or not the last refresh was successful or not.

It could also just be shown as part of `zone status` but we're trying to keep that fairly minimal. It could also be added to `zone status --detailed` but I think we should keep that to things operators really need to know, and this feels more like diagnostics in case of an unexpected problem or an aid when debugging/testing.

Yet another idea: perhaps this should be considered part of the missing information we want to show about "what is going to happen next" for a zone?

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?

- If you are modifying man pages:
  - [ ] Did you commit the updated built man pages?
