### PR TITLE
Limit the conditions for zone removal

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -353,14 +353,14 @@ pub struct ZoneRemoveResult {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub enum ZoneRemoveError {
     NotFound,
-    MidRestoration,
+    NotInMaintenanceMode,
 }
 
 impl fmt::Display for ZoneRemoveError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             Self::NotFound => "no such zone was found",
-            Self::MidRestoration => "the zone is being restored from disk",
+            Self::NotInMaintenanceMode => "the zone is not in maintenance mode",
         })
     }
 }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -354,6 +354,7 @@ pub struct ZoneRemoveResult {
 pub enum ZoneRemoveError {
     NotFound,
     NotInMaintenanceMode,
+    NotPassiveOrHalted,
 }
 
 impl fmt::Display for ZoneRemoveError {
@@ -361,6 +362,7 @@ impl fmt::Display for ZoneRemoveError {
         f.write_str(match self {
             Self::NotFound => "no such zone was found",
             Self::NotInMaintenanceMode => "the zone is not in maintenance mode",
+            Self::NotPassiveOrHalted => "the zone is not in passive/hard-halt state",
         })
     }
 }

--- a/crates/cli/src/commands/zone.rs
+++ b/crates/cli/src/commands/zone.rs
@@ -57,6 +57,8 @@ pub enum ZoneCommand {
     },
 
     /// Remove a zone
+    ///
+    /// The zone must be in maintenance mode.
     #[command(name = "remove")]
     Remove { name: ZoneName },
 

--- a/doc/manual/build/man/cascade-zone.1
+++ b/doc/manual/build/man/cascade-zone.1
@@ -54,7 +54,7 @@ cascade-zone \- Manage zones
 .sp
 \fBcascade\fP \fB[GLOBAL OPTIONS]\fP zone \fI\%history\fP \fB<NAME>\fP
 .sp
-\fBcascade\fP \fB[GLOBAL OPTIONS]\fP zone \fBmaintenance\fP \fB<enable|disable>\fP \fB<NAME>\fP
+\fBcascade\fP \fB[GLOBAL OPTIONS]\fP zone \fI\%maintenance\fP \fB<enable|disable>\fP \fB<NAME>\fP
 .SH DESCRIPTION
 .sp
 Manage Cascade\(aqs zones.
@@ -72,6 +72,9 @@ Add a new zone.
 .TP
 .B remove
 Remove a zone.
+.sp
+Maintenance mode must be enabled (see \fBzone maintenance\fP). The
+zone must be passive (with no ongoing operations) or in a hard\-halt state.
 .sp
 \fBNOTE:\fP
 .INDENT 7.0
@@ -123,6 +126,25 @@ Reset the pipeline for a zone to get it out of a halted state.
 .TP
 .B history
 Get the history of a single zone.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B maintenance
+Enable or disable maintenance mode for the zone.
+.sp
+In maintenance mode, Cascade will not act on the zone autonomously (e.g. to
+load new zone data or refresh signatures). This quiet state is helpful for
+debugging and changing zone configuration.
+.sp
+\fBNOTE:\fP
+.INDENT 7.0
+.INDENT 3.5
+If maintenance mode is enabled while a new instance of the zone
+is being built (i.e. loading, signing, review, etc. is ongoing),
+it will not be canceled; maintenance mode will go into effect once
+the operation completes.
+.UNINDENT
+.UNINDENT
 .UNINDENT
 .SH OPTIONS FOR ZONE ADD
 .INDENT 0.0

--- a/doc/manual/build/man/cascade-zone.1
+++ b/doc/manual/build/man/cascade-zone.1
@@ -73,8 +73,9 @@ Add a new zone.
 .B remove
 Remove a zone.
 .sp
-Maintenance mode must be enabled (see \fBzone maintenance\fP). The
-zone must be passive (with no ongoing operations) or in a hard\-halt state.
+Maintenance mode must be enabled (see \fBzone maintenance\fP). In
+addition, the zone must be passive (with no ongoing operations) or in a
+hard\-halt state.
 .sp
 \fBNOTE:\fP
 .INDENT 7.0

--- a/doc/manual/source/man/cascade-zone.rst
+++ b/doc/manual/source/man/cascade-zone.rst
@@ -50,6 +50,9 @@ Commands
 
    Remove a zone.
 
+   Maintenance mode must be enabled (see :subcmd:`zone maintenance`). The
+   zone must be passive (with no ongoing operations) or in a hard-halt state.
+
    .. note:: Once removed, downstream servers will no longer be able to fetch
              the zone!
 

--- a/doc/manual/source/man/cascade-zone.rst
+++ b/doc/manual/source/man/cascade-zone.rst
@@ -88,6 +88,19 @@ Commands
 
    Get the history of a single zone.
 
+.. subcmd:: maintenance
+
+   Enable or disable maintenance mode for the zone.
+
+   In maintenance mode, Cascade will not act on the zone autonomously (e.g. to
+   load new zone data or refresh signatures). This quiet state is helpful for
+   debugging and changing zone configuration.
+
+   .. note:: If maintenance mode is enabled while a new instance of the zone
+             is being built (i.e. loading, signing, review, etc. is ongoing),
+             it will not be canceled; maintenance mode will go into effect once
+             the operation completes.
+
 Options for :subcmd:`zone add`
 ------------------------------
 

--- a/doc/manual/source/man/cascade-zone.rst
+++ b/doc/manual/source/man/cascade-zone.rst
@@ -50,8 +50,9 @@ Commands
 
    Remove a zone.
 
-   Maintenance mode must be enabled (see :subcmd:`zone maintenance`). The
-   zone must be passive (with no ongoing operations) or in a hard-halt state.
+   Maintenance mode must be enabled (see :subcmd:`zone maintenance`). In
+   addition, the zone must be passive (with no ongoing operations) or in a
+   hard-halt state.
 
    .. note:: Once removed, downstream servers will no longer be able to fetch
              the zone!

--- a/integration-tests/incremental-signing/scripts/tests-change-denial.sh
+++ b/integration-tests/incremental-signing/scripts/tests-change-denial.sh
@@ -67,6 +67,7 @@ do
 			$CASCADE policy reload
 
 			$CASCADE zone reload example
+			$CASCADE zone maintanence enable example
 			for i in 1 2 3 4 5 6 7 8 9 10
 			do
 			    dig @127.0.0.1 -p 8053 example soa |

--- a/integration-tests/incremental-signing/scripts/tests.sh
+++ b/integration-tests/incremental-signing/scripts/tests.sh
@@ -39,6 +39,7 @@ do
 				}
 			cp zones/incremental-signing-test${test}-input2.zone example.in
 			$CASCADE zone reload example
+			$CASCADE zone maintenance enable example
 			for i in 1 2 3 4 5 6 7 8 9 10
 			do
 			    dig @127.0.0.1 -p 8053 example soa |

--- a/integration-tests/review-unsigned-zone2/scripts/tests.sh
+++ b/integration-tests/review-unsigned-zone2/scripts/tests.sh
@@ -9,21 +9,22 @@ do
 	cp zones/test${test}.zone example.in
 	$CASCADE zone add --source $PWD/example.in --policy review-test example --import-csk-file $KEY
 
+	$CASCADE zone maintenance enable example
+
 	serial="$test$test$test$test$test"
 
 	# Wait for the zone to be signed.
 	for i in 1 2 3 4 5 6 7 8 9 10
 	do
-	    dig @127.0.0.1 -p 8053 example soa |
-		grep $serial  && break
-	    echo zone is not signed yet, sleeping
-	    sleep 1
+	  dig @127.0.0.1 -p 8053 example soa |
+      grep $serial && break
+	  echo zone is not signed yet, sleeping
+	  sleep 1
 	done
 	dig @127.0.0.1 -p 8053 example soa |
-	    grep $serial ||
-		{
-		    echo zone is not signed yet, giving up
-		    exit 1
+	  grep $serial || {
+		  echo zone is not signed yet, giving up
+		  exit 1
 		}
 	$CASCADE zone remove example
 done

--- a/integration-tests/tests/persist-zone/action.yml
+++ b/integration-tests/tests/persist-zone/action.yml
@@ -101,6 +101,7 @@ runs:
 
     - name: Delete the zone
       run: |
+        cascade zone maintenance enable i.dont.exist
         cascade zone remove i.dont.exist
 
     # ------------------------------------------------------------------------

--- a/integration-tests/tests/remove-zone/action.yml
+++ b/integration-tests/tests/remove-zone/action.yml
@@ -45,6 +45,9 @@ runs:
           sleep 1
         done
 
+    - name: Enable maintenance mode
+      run: cascade zone maintenance enable example.test
+
     - name: Check zone status
       run: |
         timeout=10 # seconds

--- a/integration-tests/tests/upstream-tsig/action.yml
+++ b/integration-tests/tests/upstream-tsig/action.yml
@@ -37,6 +37,7 @@ runs:
     - name: Add zone without the required TSIG key.
       run: |
         cascade zone add --policy default --source "127.0.0.1:1055" example-tsig.test
+        cascade zone maintenance enable example-tsig.test
 
     - name: Check zone status
       run: |
@@ -71,6 +72,7 @@ runs:
         esac
 
         cascade zone add --policy default --source "127.0.0.1:1055^tsig-key" example-tsig.test
+        cascade zone maintenance enable example-tsig.test
 
     - name: Check zone status
       run: |

--- a/src/center.rs
+++ b/src/center.rs
@@ -265,8 +265,11 @@ pub fn remove_zone(center: &Arc<Center>, name: Name<Bytes>) -> Result<(), ZoneRe
     let ZoneByName(zone) = state.zones.get(&name).ok_or(ZoneRemoveError::NotFound)?;
 
     // TODO(#871): support removing a zone during restoration.
-    if zone.read().storage.is_restoring() {
-        return Err(ZoneRemoveError::MidRestoration);
+    // The zone must be halted or in maintenance mode.
+    if let zone = zone.read()
+        && !(zone.maintenance_mode && (zone.machine.is_waiting() || zone.machine.is_halted()))
+    {
+        return Err(ZoneRemoveError::NotInMaintenanceMode);
     }
 
     let ZoneByName(zone) = state
@@ -518,8 +521,8 @@ pub enum ZoneRemoveError {
     /// No such name could be found.
     NotFound,
 
-    /// The zone is being restored from disk.
-    MidRestoration,
+    /// The zone is not in maintenance mode.
+    NotInMaintenanceMode,
 }
 
 impl std::error::Error for ZoneRemoveError {}
@@ -528,7 +531,7 @@ impl fmt::Display for ZoneRemoveError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             Self::NotFound => "no such zone was found",
-            Self::MidRestoration => "the zone is being restored from disk",
+            Self::NotInMaintenanceMode => "the zone is not in maintenance mode",
         })
     }
 }
@@ -537,7 +540,7 @@ impl From<ZoneRemoveError> for api::ZoneRemoveError {
     fn from(value: ZoneRemoveError) -> Self {
         match value {
             ZoneRemoveError::NotFound => Self::NotFound,
-            ZoneRemoveError::MidRestoration => Self::MidRestoration,
+            ZoneRemoveError::NotInMaintenanceMode => Self::NotInMaintenanceMode,
         }
     }
 }

--- a/src/center.rs
+++ b/src/center.rs
@@ -264,12 +264,13 @@ pub fn remove_zone(center: &Arc<Center>, name: Name<Bytes>) -> Result<(), ZoneRe
 
     let ZoneByName(zone) = state.zones.get(&name).ok_or(ZoneRemoveError::NotFound)?;
 
-    // TODO(#871): support removing a zone during restoration.
-    // The zone must be halted or in maintenance mode.
-    if let zone = zone.read()
-        && !(zone.maintenance_mode && (zone.machine.is_waiting() || zone.machine.is_halted()))
     {
-        return Err(ZoneRemoveError::NotInMaintenanceMode);
+        let zone = zone.read();
+        // The zone must be in maintenance mode, and passive/halted.
+        // TODO(#871): support removing a zone during restoration.
+        if !zone.maintenance_mode || !zone.machine.is_waiting() && !zone.machine.is_halted() {
+            return Err(ZoneRemoveError::NotInMaintenanceMode);
+        }
     }
 
     let ZoneByName(zone) = state

--- a/src/center.rs
+++ b/src/center.rs
@@ -268,8 +268,10 @@ pub fn remove_zone(center: &Arc<Center>, name: Name<Bytes>) -> Result<(), ZoneRe
         let zone = zone.read();
         // The zone must be in maintenance mode, and passive/halted.
         // TODO(#871): support removing a zone during restoration.
-        if !zone.maintenance_mode || !zone.machine.is_waiting() && !zone.machine.is_halted() {
+        if !zone.maintenance_mode {
             return Err(ZoneRemoveError::NotInMaintenanceMode);
+        } else if !zone.machine.is_waiting() && !zone.machine.is_halted() {
+            return Err(ZoneRemoveError::NotPassiveOrHalted);
         }
     }
 
@@ -524,6 +526,9 @@ pub enum ZoneRemoveError {
 
     /// The zone is not in maintenance mode.
     NotInMaintenanceMode,
+
+    /// The zone is not in passive/hard-halt state.
+    NotPassiveOrHalted,
 }
 
 impl std::error::Error for ZoneRemoveError {}
@@ -533,6 +538,7 @@ impl fmt::Display for ZoneRemoveError {
         f.write_str(match self {
             Self::NotFound => "no such zone was found",
             Self::NotInMaintenanceMode => "the zone is not in maintenance mode",
+            Self::NotPassiveOrHalted => "the zone is not in passive/hard-halt state",
         })
     }
 }
@@ -542,6 +548,7 @@ impl From<ZoneRemoveError> for api::ZoneRemoveError {
         match value {
             ZoneRemoveError::NotFound => Self::NotFound,
             ZoneRemoveError::NotInMaintenanceMode => Self::NotInMaintenanceMode,
+            ZoneRemoveError::NotPassiveOrHalted => Self::NotPassiveOrHalted,
         }
     }
 }

--- a/src/center.rs
+++ b/src/center.rs
@@ -519,6 +519,7 @@ impl From<ZoneAddError> for api::ZoneAddError {
 //----------- ZoneRemoveError --------------------------------------------------
 
 /// An error removing a zone.
+#[expect(clippy::enum_variant_names, reason = "listing failure conditions")]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ZoneRemoveError {
     /// No such name could be found.

--- a/src/zone/machine.rs
+++ b/src/zone/machine.rs
@@ -86,6 +86,10 @@ pub enum ZoneStateMachine {
 }
 
 impl ZoneStateMachine {
+    pub fn is_waiting(&self) -> bool {
+        matches!(self, Self::Waiting(_))
+    }
+
     pub fn is_halted(&self) -> bool {
         matches!(
             self,


### PR DESCRIPTION
We don't have a good way to cancel ongoing operations, so if a zone is removed in the middle of an operation, the operation is likely to crash. This PR gates zone removal behind maintenance mode, and requires the zone to be passive or hard-halted.

While updating the documentation, I noticed that `cascade zone maintenance` was missing a section, so I added that too.

Fixes #888.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?

- If you are modifying man pages:
  - [x] Did you commit the updated built man pages?
