### PR TITLE
Allow omitting NSEC3 opt-out setting in policy

### DIFF
--- a/crates/policy-file/src/v1.rs
+++ b/crates/policy-file/src/v1.rs
@@ -590,7 +590,7 @@ pub enum SignerDenialSpec {
         // but relatively static zones, are encouraged to not use the
         // opt-opt flag and to take advantage of DNSSEC's authenticated
         // denial of existence.
-        #[serde(rename = "opt-out")]
+        #[serde(rename = "opt-out", default)]
         opt_out: bool,
         // Missing fields:
         // - salt


### PR DESCRIPTION
The default is set to `false`, as already stated by the documentation.

Solves #551.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?