### PR TITLE
Fix RST syntax mistake.

### DIFF
--- a/doc/manual/source/quick-start.rst
+++ b/doc/manual/source/quick-start.rst
@@ -130,7 +130,7 @@ no zones:
 
    $ cascade zone list
 
-.. Note:: The program:`cascade` CLI connects via HTTPS to the
+.. Note:: The :program:`cascade` CLI connects via HTTPS to the
    :program:`cascaded` daemon. By default it connects to 127.0.0.1:4539.
    You can override this by passing ``--server <IP>:<PORT>`` or by defining
    an environment variable ``CASCADE_DAEMON="<IP>:<PORT>"`` to connect to a


### PR DESCRIPTION
Prevents rendering as "program:cascade" instead of "cascade".