### PR TITLE
Don't use the state directory as the home directory. (fixes #464)

### DIFF
--- a/pkg/debian/postinst
+++ b/pkg/debian/postinst
@@ -13,7 +13,7 @@ create_user() {
     # and to prevent adduser failing due to the missing argument/to have
     # consistent behaviour in the case of the older O/S versions.
     # See: https://lists.debian.org/debian-lint-maint/2025/08/msg00042.html
-    adduser --system --group ${USER_ID} --home /nonexistent
+    adduser --system --group ${USER_ID} --home /nonexistent --no-create-home
 }
 
 case "$1" in

--- a/pkg/debian/postinst
+++ b/pkg/debian/postinst
@@ -5,26 +5,15 @@ USER_ID="cascade"
 create_user() {
     if id ${USER_ID} > /dev/null 2>&1; then return; fi
 
-    # Set the VERSION_CODENAME environment variable that describes which O/S
-    # version we are running on.
-    . /etc/os-release
-
-    case ${VERSION_CODENAME} in
-        bullseye|jammy)
-            # Newer versions of Debian/Ubuntu use /nonexistent as the home
-            # directory by default, and don't actually create it. However,
-            # the version of Lintian in these older Debian/Ubuntu versions
-            # requires --home to be specified when calling adduser with
-            # --system so we explicitly set home to /nonexistent in these
-            # cases. The older O/S versions that don't default --home include
-            # that we package Cascade for include Debian Bullseye and Ubuntu
-            # Jammy so these are the versions we handle separately.
-            adduser --system --group ${USER_ID} --home /nonexistent
-            ;;
-        *)
-            adduser --system --group ${USER_ID}
-            ;;
-    esac
+    # Newer versions of Debian/Ubuntu adduser use /nonexistent as the home
+    # directory by default, and don't actually create it. However, the version
+    # of Lintian in these older Debian/Ubuntu versions requires --home to be
+    # specified when calling adduser with --system so we explicitly set home
+    # to /nonexistent to prevent Lintian complaining in the newer O/S versions
+    # and to prevent adduser failing due to the missing argument/to have
+    # consistent behaviour in the case of the older O/S versions.
+    # See: https://lists.debian.org/debian-lint-maint/2025/08/msg00042.html
+    adduser --system --group ${USER_ID} --home /nonexistent
 }
 
 case "$1" in

--- a/pkg/debian/postinst
+++ b/pkg/debian/postinst
@@ -4,7 +4,27 @@ USER_ID="cascade"
 
 create_user() {
     if id ${USER_ID} > /dev/null 2>&1; then return; fi
-    adduser --system --group ${USER_ID}
+
+    # Set the VERSION_CODENAME environment variable that describes which O/S
+    # version we are running on.
+    . /etc/os-release
+
+    case ${VERSION_CODENAME} in
+        bullseye|jammy)
+            # Newer versions of Debian/Ubuntu use /nonexistent as the home
+            # directory by default, and don't actually create it. However,
+            # the version of Lintian in these older Debian/Ubuntu versions
+            # requires --home to be specified when calling adduser with
+            # --system so we explicitly set home to /nonexistent in these
+            # cases. The older O/S versions that don't default --home include
+            # that we package Cascade for include Debian Bullseye and Ubuntu
+            # Jammy so these are the versions we handle separately.
+            adduser --system --group ${USER_ID} --home /nonexistent
+            ;;
+        *)
+            adduser --system --group ${USER_ID}
+            ;;
+    esac
 }
 
 case "$1" in

--- a/pkg/debian/postinst
+++ b/pkg/debian/postinst
@@ -4,7 +4,7 @@ USER_ID="cascade"
 
 create_user() {
     if id ${USER_ID} > /dev/null 2>&1; then return; fi
-    adduser --system --home /var/lib/${USER_ID} --group ${USER_ID}
+    adduser --system --group ${USER_ID}
 }
 
 case "$1" in

--- a/pkg/rpm/scriptlets.toml
+++ b/pkg/rpm/scriptlets.toml
@@ -14,7 +14,7 @@ if [ $1 -eq 1 ] ; then
     if ! id ${USER_ID} > /dev/null 2>&1; then
         # According to the CentOS 7 useradd man page:
         # --user-group causes a group by the same name as the user to be created
-        useradd --system --user-group ${USER_ID} --home-dir /var/lib/${USER_ID} --create-home
+        useradd --system --user-group ${USER_ID}
     fi
 
     mkdir -p /etc/cascade/policies

--- a/pkg/rpm/scriptlets.toml
+++ b/pkg/rpm/scriptlets.toml
@@ -14,7 +14,8 @@ if [ $1 -eq 1 ] ; then
     if ! id ${USER_ID} > /dev/null 2>&1; then
         # According to the CentOS 7 useradd man page:
         # --user-group causes a group by the same name as the user to be created
-        useradd --system --user-group ${USER_ID}
+        # -M prevents the creation of a home directory for the user.
+        useradd --system --user-group ${USER_ID} -M
     fi
 
     mkdir -p /etc/cascade/policies

--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -38,10 +38,13 @@ include:
     systemd_service_unit_file: pkg/common/cascade.s*
     rpm_rpmlint_check_filters: bad-manual-page-folder
 
-  # Lintian is wrong on Ubuntu Noble to require --home when invoking adduser with --system.
+  # Lintian is wrong on Ubuntu Noble and Debian Bookworm to require --home when invoking adduser with --system.
   # See: https://lists.debian.org/debian-lint-maint/2025/08/msg00042.html
+  - image: 'debian:bookworm'
+    deb_extra_lintian_args: "--suppress-tags maintainer-script-lacks-home-in-adduser"
+
   - image: 'ubuntu:noble'
-    deb_extra_lintian_args: "--suppress-tags maintainer-script-lacks-home-in-adduser"    
+    deb_extra_lintian_args: "--suppress-tags maintainer-script-lacks-home-in-adduser"
 
 # 'mode' is not used by the package building workflow job, but is used by the package testing workflow job.
 # Ploutos will not include this key when using this matrix definition to generate package building matrix

--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -38,6 +38,11 @@ include:
     systemd_service_unit_file: pkg/common/cascade.s*
     rpm_rpmlint_check_filters: bad-manual-page-folder
 
+  # Lintian is wrong on Ubuntu Noble to require --home when invoking adduser with --system.
+  # See: https://lists.debian.org/debian-lint-maint/2025/08/msg00042.html
+  - image: 'ubuntu:noble'
+    deb_extra_lintian_args: "--suppress-tags maintainer-script-lacks-home-in-adduser"    
+
 # 'mode' is not used by the package building workflow job, but is used by the package testing workflow job.
 # Ploutos will not include this key when using this matrix definition to generate package building matrix
 # permutations but will use it when generating package testing permutations.

--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -38,14 +38,6 @@ include:
     systemd_service_unit_file: pkg/common/cascade.s*
     rpm_rpmlint_check_filters: bad-manual-page-folder
 
-  # Lintian is wrong on Ubuntu Noble and Debian Bookworm to require --home when invoking adduser with --system.
-  # See: https://lists.debian.org/debian-lint-maint/2025/08/msg00042.html
-  - image: 'debian:bookworm'
-    deb_extra_lintian_args: "--suppress-tags maintainer-script-lacks-home-in-adduser"
-
-  - image: 'ubuntu:noble'
-    deb_extra_lintian_args: "--suppress-tags maintainer-script-lacks-home-in-adduser"
-
 # 'mode' is not used by the package building workflow job, but is used by the package testing workflow job.
 # Ploutos will not include this key when using this matrix definition to generate package building matrix
 # permutations but will use it when generating package testing permutations.


### PR DESCRIPTION
This prevents the error "Failed to set up special execution directory in /var/lib: No such file or directory", reported in #464.

Tested by manually packaging in an Ubuntu Noble VM and installing the package with `apt` and seeing that the systemd service is able to start without any problems and interact with the `cascade` CLI command.

The packaging workflow doesn't yet succeed, I'll mark this PR as ready to review when it does.