### PR TITLE
Upgrade to Ploutos v10.

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   package:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v9
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v10
     with:
       package_build_rules: pkg/rules/packages-to-build.yml
       package_test_scripts_path: pkg/test-scripts/test-<package>.sh


### PR DESCRIPTION
Ploutos v10 which includes a fix for possible failure GH after Sep 16 2026.

A passing workflow run can be seen here: https://github.com/NLnetLabs/cascade/actions/runs/32963935650