### PR TITLE
docs: Improve dev experience

### DIFF
--- a/doc/manual/.gitignore
+++ b/doc/manual/.gitignore
@@ -1,3 +1,4 @@
 build/doctrees/
 build/man/_static/
 build/html/
+build/live/

--- a/doc/manual/Makefile
+++ b/doc/manual/Makefile
@@ -3,17 +3,31 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
+SPHINXBUILD   = uv run sphinx-build
 SPHINXPROJ    = CascadeUserManual
 SOURCEDIR     = source
 BUILDDIR      = build
 BUILD_DATE    = "Jan 01, 2026"
 
+SPHINXAUTOBUILD     = uv run sphinx-autobuild
+SPHINXAUTOBUILDOPTS =
+AUTOBUILDDIR        = build/live
+
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help deps update-deps live Makefile
+
+deps:
+	uv sync --group livehtml
+
+update-deps:
+	uv lock
+	uv export --format requirements.txt > requirements.txt
+
+live: deps
+	@$(SPHINXAUTOBUILD) $(SPHINXAUTOBUILDOPTS) "$(SOURCEDIR)" "$(AUTOBUILDDIR)" $(SPHINXOPTS) $(O)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/doc/manual/README.md
+++ b/doc/manual/README.md
@@ -11,3 +11,16 @@ guidance.
 
 [European Commission’s English Style Guide]:
     https://ec.europa.eu/info/sites/info/files/styleguide_english_dgt_en.pdf
+
+## Usage
+
+First, [install uv](https://docs.astral.sh/uv/getting-started/installation/).
+Then:
+
+```sh
+# Development server with hot reloading
+make live
+
+# Static HTML build
+make html
+```

--- a/doc/manual/pyproject.toml
+++ b/doc/manual/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "cascade-manual"
 version = "0.1.0"
-description = "Building the Cascade manual"
+description = "The official Cascade user manual"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
@@ -13,4 +13,11 @@ dependencies = [
     "sphinx-tabs>=3.4.7",
     "sphinx>=8.1.3",
     "toml>=0.10.2",
+]
+
+[dependency-groups]
+# Separate group, so that devs can install it but it doesn't go into
+# requirements.txt (which is used by the ReadTheDocs build).
+livehtml = [
+    "sphinx-autobuild>=2025.8.25",
 ]


### PR DESCRIPTION
Improve dev experience:

- Hot reloading with sphinx-autobuild
- More make targets for common actions
- Document main make targets in README for new contributors

If this change is acceptable, I can make a similar PR for the docs of cascade-hsm-bridge.

Also, consider updating/regenerating the requirements.txt and uv.lock. I deliberately omitted this from the PR, so that a maintainer can do it (as a more trusted source of the lockfile update).

---

_None of the below apply_

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [ ] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?

- If you are adding/deleting man pages:
  - [ ] Did you update the `man_pages` config in `doc/manual/source/conf.py`?
  - [ ] Did you update the packaged man pages in the `Cargo.toml`?
  - [ ] Did you commit the freshly built man pages?

- If you are modifying man pages:
  - [ ] Did you commit the updated built man pages?
