### PR TITLE
docs: Create test zone in quick start

### DIFF
--- a/doc/manual/source/quick-start.rst
+++ b/doc/manual/source/quick-start.rst
@@ -192,6 +192,21 @@ default policy directory is not writable by the current user.
    cascade template policy | sudo tee /etc/cascade/policies/default.toml
    cascade policy reload
 
+Creating a Test Zone
+--------------------
+
+Create a test zone file and ensure the Cascade daemon has access to it:
+
+.. code-block:: bash
+
+   $ mkdir /etc/cascade/zones
+   $ cat > /etc/cascade/zones/example.com << EOF
+   example.com.    3600    IN      SOA     ns.example.com. username.example.com. 1 86400 7200 2419200 300
+   example.com.            IN      NS      ns
+   ns                      IN      A       192.0.2.1
+   EOF
+   $ chown -R cascade: /etc/cascade/zones
+
 Signing Your First Zone
 -----------------------
 


### PR DESCRIPTION
Instruct users how to create test zone in the quick start. This makes it easier to follow the quick start if you don't have a zone file lying around.

The HSM guides (SoftHSM, SmartCard-HSM, NetHSM) all have a "Sign a Test Zone" section. This shows that there is a user need for this piece of information. We might as well move this up to the generic quick start guide.

---

_None of the below apply_

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [ ] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?

- If you are adding/deleting man pages:
  - [ ] Did you update the `man_pages` config in `doc/manual/source/conf.py`?
  - [ ] Did you update the packaged man pages in the `Cargo.toml`?
  - [ ] Did you commit the freshly built man pages?

- If you are modifying man pages:
  - [ ] Did you commit the updated built man pages?
