### PR TITLE
docs, hsms: CSV table, Securosys Primus HSM, known quirks

### DIFF
--- a/doc/manual/source/hsms.rst
+++ b/doc/manual/source/hsms.rst
@@ -53,7 +53,7 @@ to :program:`cascade-hsm-bridge`, which executes them against a loaded PKCS#11
 vendor library.
 
 Supported HSMs
-~~~~~~~~~~~~~~
+--------------
 
 In principle any HSM supporting PKCS#11 v2.40 or KMIP 1.2 should be supported.
 To work with an HSM using its PKCS#11 interface, Cascade requires our
@@ -69,23 +69,34 @@ to stress or performance test the interface. The tested HSMs are\:
 
    CardContact, SmartCard-HSM, "Smart Card", PKCS#11, :doc:`view <smartcard-hsm>`
    Fortanix, DSM, Cloud, KMIP,
-   Nitrokey, NetHSM [1]_, "Server, Docker image", PKCS#11, :doc:`view <nethsm>`
+   Nitrokey, NetHSM, "Server, Docker image", PKCS#11, :doc:`view <nethsm>`
    Thales, "Cloud HSM", Cloud, PKCS#11, :doc:`view <thales>`
    Securosys, "Primus HSM, CloudHSM", "Server, Cloud", PKCS#11, `view <https://docs.securosys.com/cascade/overview>`_
    SoftHSM, "SoftHSM v2.6.1", Software, PKCS#11, :doc:`view <softhsm>`
    Yubico, "YubiHSM 2", "USB key", PKCS#11,
-
-.. [1] Username and password must be specified in `p11nethsm.conf` for
-    both the `operator` and `admin` user in order to use the Nitrokey
-    NetHSM PKCS#11 module with Cascade-HSM-Bridge. See the
-    `Nitrokey Documentation <https://docs.nitrokey.com/nethsm/pkcs11-setup#users>`_
-    for more information.
 
 .. Note:: Cascade requires TLS 1.3 for connections to the KMIP server, even
    though KMIP 1.2 requires servers to offer support for old versions of the
    TLS protocol with known security vulnerabilities. For this reason, PyKMIP
    is **NOT** supported by Cascade as it only supports older vulnerable TLS
    versions.
+
+Known quirks
+~~~~~~~~~~~~
+
+Please be aware of the following quirks that you may run into when integrating
+Cascade with the respective HSMs.
+
+* Nitrokey NetHSM:
+
+  * Username and password must be specified in `p11nethsm.conf` for both the
+    `operator` and `admin` user. The admin role is needed so that :program:`cascade-hsm-bridge`
+    can `generate new key pairs <https://docs.nitrokey.com/nethsm/operation#generate-key>`_.
+    See the `Nitrokey documentation <https://docs.nitrokey.com/nethsm/pkcs11-setup#users>`_
+    for more information.
+  * Does `not support <https://github.com/NLnetLabs/cascade/pull/621#issuecomment-4677960984>`_
+    labels (``CKA_LABEL``). As a result, you will not see human-readable labels
+    when listing keys with ``pkcs11-tool``.
 
 Setting up cascade-hsm-bridge
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/manual/source/hsms.rst
+++ b/doc/manual/source/hsms.rst
@@ -59,7 +59,7 @@ In principle any HSM supporting PKCS#11 v2.40 or KMIP 1.2 should be supported.
 To work with an HSM using its PKCS#11 interface, Cascade requires our
 :program:`cascade-hsm-bridge`.
 
-Several HSMs have been tested with Cascade. Our testing was limited to normal
+Several HSMs have been tested with Cascade by the community. Testing was limited to normal
 usage only, not attempting to deliberately cause problems, and not attempting
 to stress or performance test the interface. The tested HSMs are\:
 

--- a/doc/manual/source/hsms.rst
+++ b/doc/manual/source/hsms.rst
@@ -71,6 +71,7 @@ to stress or performance test the interface. The tested HSMs are\:
    Fortanix, DSM, Cloud, KMIP,
    Nitrokey, NetHSM [1]_, "Server, Docker image", PKCS#11, :doc:`view <nethsm>`
    Thales, "Cloud HSM", Cloud, PKCS#11, :doc:`view <thales>`
+   Securosys, "Primus HSM, CloudHSM", "Server, Cloud", PKCS#11, `view <https://docs.securosys.com/cascade/overview>`_
    SoftHSM, "SoftHSM v2.6.1", Software, PKCS#11, :doc:`view <softhsm>`
    Yubico, "YubiHSM 2", "USB key", PKCS#11,
 

--- a/doc/manual/source/hsms.rst
+++ b/doc/manual/source/hsms.rst
@@ -63,19 +63,16 @@ Several HSMs have been tested with Cascade by the community. Testing was limited
 usage only, not attempting to deliberately cause problems, and not attempting
 to stress or performance test the interface. The tested HSMs are\:
 
-.. table:: Supported HSMs
-   :widths: auto
+.. csv-table:: Supported HSMs
+   :header: Vendor, Model, Type, Interface, Guide
+   :widths: auto
 
-   ====================  ======================  =========  =================
-   HSM                   Type                    Interface  Integration guide
-   ====================  ======================  =========  =================
-   Fortanix DSM          Cloud                   KMIP       
-   Thales Cloud HSM      Cldud                   PKCS#11    :doc:`view <thales>`
-   Nitrokey NetHSM [1]_  Hardware, Docker image  PKCS#11    :doc:`view <nethsm>`
-   YubiHSM 2             USB key                 PKCS#11    
-   SoftHSM v2.6.1        Software                PKCS#11    :doc:`view <softhsm>`
-   SmartCard-HSM         Smart Card              PKCS#11    :doc:`view <smartcard-hsm>`
-   ====================  ======================  =========  =================
+   CardContact, SmartCard-HSM, "Smart Card", PKCS#11, :doc:`view <smartcard-hsm>`
+   Fortanix, DSM, Cloud, KMIP,
+   Nitrokey, NetHSM [1]_, "Server, Docker image", PKCS#11, :doc:`view <nethsm>`
+   Thales, "Cloud HSM", Cloud, PKCS#11, :doc:`view <thales>`
+   SoftHSM, "SoftHSM v2.6.1", Software, PKCS#11, :doc:`view <softhsm>`
+   Yubico, "YubiHSM 2", "USB key", PKCS#11,
 
 .. [1] Username and password must be specified in `p11nethsm.conf` for
     both the `operator` and `admin` user in order to use the Nitrokey


### PR DESCRIPTION
This MR edits the `hsms.rst`. The commits all depend on each other, hence a single MR.

See the commit messages for details and explanations. Summary:

- Refactor HSM table to CSV
- Add Securosys Primus HSM + CloudHSM
- Add "Known quirks" section

---

_None of the below apply_

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [ ] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?

- If you are adding/deleting man pages:
  - [ ] Did you update the `man_pages` config in `doc/manual/source/conf.py`?
  - [ ] Did you update the packaged man pages in the `Cargo.toml`?
  - [ ] Did you commit the freshly built man pages?

- If you are modifying man pages:
  - [ ] Did you commit the updated built man pages?
