### PR TITLE
docs: Add CI to check that man pages are committed

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,3 @@ Provide your description here
   - [ ] Did you update the `man_pages` config in `doc/manual/source/conf.py`?
   - [ ] Did you update the packaged man pages in the `Cargo.toml`?
   - [ ] Did you commit the freshly built man pages?
-
-- If you are modifying man pages:
-  - [ ] Did you commit the updated built man pages?

--- a/.github/workflows/check-man-pages.yml
+++ b/.github/workflows/check-man-pages.yml
@@ -1,0 +1,30 @@
+name: check man pages
+
+on:
+  pull_request:
+    paths:
+      - 'doc/manual/source/man/**'
+      - 'doc/manual/Makefile'
+
+jobs:
+  check-man-pages:
+    name: Check man pages are up-to-date
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
+      - name: Build man pages
+        working-directory: doc/manual/
+        run: make man
+
+      - name: Fail if build output differs
+        run: |
+          if ! git diff --quiet -- doc/manual/build/man; then
+            echo "::error::doc/manual/build/man is not up-to-date! Run 'make man' and commit the changed man pages."
+            git diff -- doc/manual/build/man
+            exit 1
+          fi


### PR DESCRIPTION
This PR simplifies the pull request template by automating the "man page modified" check. (The "man page added/removed" case I didn't cover, because I don't want to mess with shell magic right now.)

This PR depends on #979 because it uses "make man", and thus relies on "uv run" being in the Makefile. Hence the Makefile is also in the list of changed paths, to catch Makefile edits that might break this Action.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [ ] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?

- If you are adding/deleting man pages:
  - [ ] Did you update the `man_pages` config in `doc/manual/source/conf.py`?
  - [ ] Did you update the packaged man pages in the `Cargo.toml`?
  - [ ] Did you commit the freshly built man pages?

- If you are modifying man pages:
  - [ ] Did you commit the updated built man pages?
