### PR TITLE
docs: Add warnings that KMIP client/server cert arguments are stubs

### DIFF
--- a/doc/manual/build/man/cascade-hsm.1
+++ b/doc/manual/build/man/cascade-hsm.1
@@ -140,6 +140,14 @@ password set here will be used as the PKCS#11 PIN to login with.
 .B \-\-client\-cert <CLIENT_CERT_PATH>
 Optional path to a TLS certificate to authenticate to the KMIP server
 with. The file will be read and sent to the server.
+.sp
+\fBWARNING:\fP
+.INDENT 7.0
+.INDENT 3.5
+This argument \X'tty: link https://github.com/NLnetLabs/cascade/issues/982'\fI\%is not yet used\fP\X'tty: link'
+by Cascade.
+.UNINDENT
+.UNINDENT
 .UNINDENT
 .INDENT 0.0
 .TP
@@ -149,6 +157,14 @@ THe file will be read and sent to the server.
 .sp
 The private key is needed to be able to prove to the KMIP server that
 you are the owner of the provided TLS client certificate.
+.sp
+\fBWARNING:\fP
+.INDENT 7.0
+.INDENT 3.5
+This argument \X'tty: link https://github.com/NLnetLabs/cascade/issues/982'\fI\%is not yet used\fP\X'tty: link'
+by Cascade.
+.UNINDENT
+.UNINDENT
 .UNINDENT
 .SS Server Certificate Verification:
 .INDENT 0.0
@@ -164,11 +180,27 @@ certificate, e.g. in a test environment.
 .TP
 .B \-\-server\-cert <SERVER_CERT_PATH>
 Optional path to a TLS PEM certificate for the server.
+.sp
+\fBWARNING:\fP
+.INDENT 7.0
+.INDENT 3.5
+This argument \X'tty: link https://github.com/NLnetLabs/cascade/issues/982'\fI\%is not yet used\fP\X'tty: link'
+by Cascade.
+.UNINDENT
+.UNINDENT
 .UNINDENT
 .INDENT 0.0
 .TP
 .B \-\-ca\-cert <CA_CERT_PATH>
 Optional path to a TLS PEM certificate for a Certificate Authority.
+.sp
+\fBWARNING:\fP
+.INDENT 7.0
+.INDENT 3.5
+This argument \X'tty: link https://github.com/NLnetLabs/cascade/issues/982'\fI\%is not yet used\fP\X'tty: link'
+by Cascade.
+.UNINDENT
+.UNINDENT
 .UNINDENT
 .SS Client Limits:
 .INDENT 0.0

--- a/doc/manual/source/man/cascade-hsm.rst
+++ b/doc/manual/source/man/cascade-hsm.rst
@@ -124,6 +124,10 @@ Client Certificate Authentication:
           Optional path to a TLS certificate to authenticate to the KMIP server
           with. The file will be read and sent to the server.
 
+          .. warning::
+             This argument `is not yet used <https://github.com/NLnetLabs/cascade/issues/982>`_
+             by Cascade.
+
 .. option:: --client-key <CLIENT_KEY_PATH>
 
           Optional path to a private key for client certificate authentication.
@@ -131,6 +135,10 @@ Client Certificate Authentication:
 
           The private key is needed to be able to prove to the KMIP server that
           you are the owner of the provided TLS client certificate.
+
+          .. warning::
+             This argument `is not yet used <https://github.com/NLnetLabs/cascade/issues/982>`_
+             by Cascade.
 
 Server Certificate Verification:
 ++++++++++++++++++++++++++++++++
@@ -147,9 +155,17 @@ Server Certificate Verification:
 
           Optional path to a TLS PEM certificate for the server.
 
+          .. warning::
+             This argument `is not yet used <https://github.com/NLnetLabs/cascade/issues/982>`_
+             by Cascade.
+
 .. option:: --ca-cert <CA_CERT_PATH>
 
           Optional path to a TLS PEM certificate for a Certificate Authority.
+
+          .. warning::
+             This argument `is not yet used <https://github.com/NLnetLabs/cascade/issues/982>`_
+             by Cascade.
 
 Client Limits:
 ++++++++++++++


### PR DESCRIPTION
See https://github.com/NLnetLabs/cascade/issues/982

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [ ] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?

- If you are adding/deleting man pages:
  - [ ] Did you update the `man_pages` config in `doc/manual/source/conf.py`?
  - [ ] Did you update the packaged man pages in the `Cargo.toml`?
  - [ ] Did you commit the freshly built man pages?

- If you are modifying man pages:
  - [x] Did you commit the updated built man pages?
