### PR TITLE
HSM related documentation fixes (resolves #488).

### DIFF
--- a/doc/manual/source/nethsm.rst
+++ b/doc/manual/source/nethsm.rst
@@ -299,7 +299,7 @@ the host application.
 
 .. code-block:: bash
 
-   # sed -i -e 's|^lib_path = .\+|lib_path = "/usr/lib/x86_64-linux-gnu/nethsm-pkcs11.so"|' /etc/cascade-hsm-bridge/config.toml
+   # sed -i -e 's|^#lib-path = .\+|lib-path = "/usr/lib/x86_64-linux-gnu/nethsm-pkcs11.so"|' /etc/cascade-hsm-bridge/config.toml
    # systemctl start cascade-hsm-bridge
 
 Create a Cascade Policy that uses your HSM

--- a/doc/manual/source/smartcard-hsm.rst
+++ b/doc/manual/source/smartcard-hsm.rst
@@ -102,7 +102,7 @@ application.
 
 .. code-block:: bash
 
-   # sed -i -e 's|^lib_path = .\+|lib_path = "/usr/lib/x86_64-linux-gnu/opensc-pkcs11.so"|' /etc/cascade-hsm-bridge/config.toml
+   # sed -i -e 's|^#lib-path = .\+|lib-path = "/usr/lib/x86_64-linux-gnu/opensc-pkcs11.so"|' /etc/cascade-hsm-bridge/config.toml
    # systemctl start cascade-hsm-bridge
 
 Create a Cascade Policy that uses your HSM

--- a/doc/manual/source/softhsm.rst
+++ b/doc/manual/source/softhsm.rst
@@ -34,8 +34,8 @@ that :program:`cascade-hsm-bridge` runs as read-write access to the
 
 .. code-block:: bash
 
-   # sed -i -e 's|^lib_path = .\+|lib_path = "/usr/lib/softhsm/libsofthsm2.so"|' /etc/cascade-hsm-bridge/config.toml
-   # chown -R cascade-hsm-bridge: /var/lib/softhsm
+   # sed -i -e 's|^#lib-path = .\+|lib-path = "/usr/lib/softhsm/libsofthsm2.so"|' /etc/cascade-hsm-bridge/config.toml
+   # usermod -G softhsm cascade-hsm-bridge
    # systemctl start cascade-hsm-bridge
 
 Create a Cascade Policy that uses SoftHSM

--- a/doc/manual/source/thales.rst
+++ b/doc/manual/source/thales.rst
@@ -196,7 +196,7 @@ Installing and Configuring :program:`cascade-hsm-bridge`
 
     .. code-block:: bash
 
-       $ sed -i -e 's|^lib_path =.\+|lib_path = "/usr/local/dpodclient/libs/64/libCryptoki2.so"|' /etc/cascade-hsm-bridge/config.toml
+       $ sed -i -e 's|^#lib-path =.\+|lib-path = "/usr/local/dpodclient/libs/64/libCryptoki2.so"|' /etc/cascade-hsm-bridge/config.toml
        $ sed -i -e 's|addr = .\+|addr = "0.0.0.0"|' /etc/cascade-hsm-bridge/config.toml
 
 15. Now run :program:`cascade-hsm-bridge` and send its logs to the terminal
@@ -219,7 +219,7 @@ connect to the Luna Cloud HSM, but the ``pkcs11-tool -O`` command
 we used above proved that the PKCS#11 module is able to connect and
 so :program:`cascade-hsm-bridge` can as well. To demonstrate that,
 however, you will need to setup Cascade to use this running instance of
-:program:`kmip2pksc11`.
+:program:`cascade-hsm-bridge`.
 
 Using :program:`cascade-hsm-bridge` to connect Cascade to the Thales HSM
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- Fix outdated references to `lib_path` in the Cascade-HSM-Bridge configuration file since its config was normalized to be more like that of Cascade.
- Guide users to add `cascade-hsm-bridge` to the `softhsm` group instead of changing SoftHSM directories to be accessible to Cascade-HSM-Bridge as that requires knowing all places to which access must be granted.
- Fix an outdated reference to `kmip2pkcs11` which was missed because it was typo'd as `kmip2pksc11`.
