### PR TITLE
Replace `cascaded --state` with `state-file =` in `config.toml`

### DIFF
--- a/crates/cfg/src/args.rs
+++ b/crates/cfg/src/args.rs
@@ -13,9 +13,6 @@ use super::{Config, LogLevel, LogTarget};
 /// Configuration-related command-line arguments.
 #[derive(Clone, Debug)]
 pub struct ArgsSpec {
-    /// The global state file to use.
-    pub state: Option<Box<Utf8Path>>,
-
     /// The configuration file to load.
     pub config: Option<Box<Utf8Path>>,
 
@@ -40,14 +37,6 @@ impl ArgsSpec {
                 .long("check-config")
                 .action(clap::ArgAction::SetTrue)
                 .help("Check the configuration and exit"),
-            Arg::new("state")
-                .long("state")
-                .value_name("PATH")
-                .value_parser(ValueParser::new(
-                    PathBufValueParser::new().try_map(Utf8PathBuf::try_from),
-                ))
-                .value_hint(ValueHint::FilePath)
-                .help("The global state file to use"),
             Arg::new("config")
                 .short('c')
                 .long("config")
@@ -79,9 +68,6 @@ impl ArgsSpec {
     /// Process parsed command-line arguments.
     pub fn process(matches: &ArgMatches) -> Self {
         Self {
-            state: matches
-                .get_one::<Utf8PathBuf>("state")
-                .map(|p| p.as_path().into()),
             config: matches
                 .get_one::<Utf8PathBuf>("config")
                 .map(|p| p.as_path().into()),
@@ -94,7 +80,6 @@ impl ArgsSpec {
     /// Merge this into a [`Config`].
     pub fn merge(self, config: &mut Config) {
         let daemon = &mut config.daemon;
-        daemon.state_file.args = self.state;
         daemon.logging.level.args = self.log_level;
         daemon.logging.target.args = self.log_target.map(|t| t.build());
         daemon.config_file.args = self.config;

--- a/crates/cfg/src/env.rs
+++ b/crates/cfg/src/env.rs
@@ -11,9 +11,6 @@ use super::{Config, LogLevel, LogTarget};
 /// Configuration-related environment variables.
 #[derive(Clone, Debug)]
 pub struct EnvSpec {
-    /// The state file to load.
-    pub state: Option<Box<Utf8Path>>,
-
     /// The configuration file to load.
     pub config: Option<Box<Utf8Path>>,
 
@@ -35,9 +32,6 @@ impl EnvSpec {
                 .map(|value| value.into_string().map_err(|_| EnvError::NonUtf8 { var }))
                 .transpose()
         }
-
-        let state =
-            var("CASCADE_STATE_PATH")?.map(|path| Utf8PathBuf::from(path).into_boxed_path());
 
         let config =
             var("CASCADE_CONFIG_PATH")?.map(|path| Utf8PathBuf::from(path).into_boxed_path());
@@ -62,7 +56,6 @@ impl EnvSpec {
             .map(|value| value.split(",").map(|s| s.into()).collect());
 
         Ok(Self {
-            state,
             config,
             log_level,
             log_target,
@@ -73,7 +66,6 @@ impl EnvSpec {
     /// Merge this into a [`Config`].
     pub fn merge(self, config: &mut Config) {
         let daemon = &mut config.daemon;
-        daemon.state_file.env = self.state;
         daemon.logging.level.env = self.log_level;
         daemon.logging.target.env = self.log_target.map(|t| t.build());
         daemon.logging.trace_targets.env = self.log_trace_targets;

--- a/crates/cfg/src/file/v1.rs
+++ b/crates/cfg/src/file/v1.rs
@@ -16,6 +16,10 @@ use crate::{
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields, default)]
 pub struct Spec {
+    /// The path to the global state file.
+    #[serde(default = "Spec::state_file_default")]
+    pub state_file: Box<Utf8Path>,
+
     /// The directory storing policy files.
     #[serde(default = "Spec::policy_dir_default")]
     pub policy_dir: Box<Utf8Path>,
@@ -64,6 +68,7 @@ pub struct Spec {
 impl Spec {
     /// Parse from this specification.
     pub fn parse_into(self, config: &mut Config) {
+        config.state_file = self.state_file;
         config.policy_dir = self.policy_dir;
         config.zone_state_dir = self.zone_state_dir;
         config.tsig_store_path = self.tsig_store_path;
@@ -84,6 +89,7 @@ impl Spec {
 impl Default for Spec {
     fn default() -> Self {
         Self {
+            state_file: Self::state_file_default(),
             policy_dir: Self::policy_dir_default(),
             zone_state_dir: Self::zone_state_dir_default(),
             tsig_store_path: Self::tsig_store_path_default(),
@@ -101,6 +107,11 @@ impl Default for Spec {
 }
 
 impl Spec {
+    /// The default value for `state_file`.
+    fn state_file_default() -> Box<Utf8Path> {
+        "/var/lib/cascade/state.db".into()
+    }
+
     /// The default value for `policy_dir`.
     fn policy_dir_default() -> Box<Utf8Path> {
         "/etc/cascade/policies".into()

--- a/crates/cfg/src/lib.rs
+++ b/crates/cfg/src/lib.rs
@@ -25,6 +25,9 @@ pub mod file;
 /// Cascade is running.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Config {
+    /// The path to the global state file.
+    pub state_file: Box<Utf8Path>,
+
     /// The directory storing policy files.
     pub policy_dir: Box<Utf8Path>,
 
@@ -67,6 +70,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            state_file: "/var/lib/cascade/state.db".into(),
             policy_dir: "/etc/cascade/policies".into(),
             zone_state_dir: "/var/lib/cascade/zone-state".into(),
             tsig_store_path: "/var/lib/cascade/tsig-keys.db".into(),
@@ -146,9 +150,6 @@ impl Default for RemoteControlConfig {
 /// Daemon-related configuration for Cascade.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DaemonConfig {
-    /// The location of the state file.
-    pub state_file: Setting<Box<Utf8Path>>,
-
     /// Logging configuration.
     pub logging: LoggingConfig,
 
@@ -171,7 +172,6 @@ pub struct DaemonConfig {
 impl Default for DaemonConfig {
     fn default() -> Self {
         Self {
-            state_file: Setting::new("/var/lib/cascade/state.db".into()),
             logging: LoggingConfig::default(),
             config_file: Setting::new("/etc/cascade/config.toml".into()),
             daemonize: Setting::new(false),

--- a/doc/manual/build/man/cascaded-config.toml.5
+++ b/doc/manual/build/man/cascaded-config.toml.5
@@ -49,6 +49,7 @@ require a restart of the server.
 .sp
 .EX
 version = \(dqv1\(dq
+state\-file = \(dq/var/lib/cascade/state.db\(dq
 policy\-dir = \(dq/etc/cascade/policies\(dq
 zone\-state\-dir = \(dq/var/lib/cascade/zone\-state\(dq
 tsig\-store\-path = \(dq/var/lib/cascade/tsig\-keys.db\(dq
@@ -96,6 +97,15 @@ future and Cascade may drop support for older versions over time.
 .IP \(bu 2
 \fBv1\fP: This format.
 .UNINDENT
+.UNINDENT
+.INDENT 0.0
+.TP
+.B state\-file = \(dq/var/lib/cascade/state.db\(dq
+The path to the global state file.
+.sp
+Cascade stores information like the known policies and zones here. This file
+should not be modified manually, but it can be backed up and restored in the
+event of filesystem corruption.
 .UNINDENT
 .INDENT 0.0
 .TP

--- a/doc/manual/build/man/cascaded.1
+++ b/doc/manual/build/man/cascaded.1
@@ -49,11 +49,6 @@ is valid, or code 1 if the configuration is invalid.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B \-\-state <PATH>
-The global state file to use.
-.UNINDENT
-.INDENT 0.0
-.TP
 .B \-c, \-\-config <PATH>
 The configuration file to load. Defaults to
 \fB/etc/cascade/config.toml\fP\&.
@@ -104,6 +99,9 @@ Default Cascade config file
 .TP
 .B /etc/cascade/policies
 Default policies directory
+.TP
+.B /var/lib/cascade/state.db
+Default path for the global state file
 .TP
 .B /var/lib/cascade/zone\-state
 Default zone state directory

--- a/doc/manual/source/man/cascaded-config.toml.rst
+++ b/doc/manual/source/man/cascaded-config.toml.rst
@@ -17,6 +17,7 @@ Example
 .. code-block:: text
 
     version = "v1"
+    state-file = "/var/lib/cascade/state.db"
     policy-dir = "/etc/cascade/policies"
     zone-state-dir = "/var/lib/cascade/zone-state"
     tsig-store-path = "/var/lib/cascade/tsig-keys.db"
@@ -63,6 +64,14 @@ Global Options
    future and Cascade may drop support for older versions over time.
 
    - ``v1``: This format.
+
+.. option:: state-file = "/var/lib/cascade/state.db"
+
+   The path to the global state file.
+
+   Cascade stores information like the known policies and zones here. This file
+   should not be modified manually, but it can be backed up and restored in the
+   event of filesystem corruption.
 
 .. option:: policy-dir = "/etc/cascade/policies"
 

--- a/doc/manual/source/man/cascaded.rst
+++ b/doc/manual/source/man/cascaded.rst
@@ -23,10 +23,6 @@ Options
           Check the configuration and exit with code 0 if the configuration
           is valid, or code 1 if the configuration is invalid.
 
-.. option:: --state <PATH>
-
-          The global state file to use.
-
 .. option:: -c, --config <PATH>
 
           The configuration file to load. Defaults to
@@ -73,6 +69,9 @@ Files
 
 /etc/cascade/policies
     Default policies directory
+
+/var/lib/cascade/state.db
+    Default path for the global state file
 
 /var/lib/cascade/zone-state
     Default zone state directory

--- a/doc/manual/source/quick-start.rst
+++ b/doc/manual/source/quick-start.rst
@@ -107,7 +107,7 @@ systemd features should be used instead.
 
         .. code-block:: bash
 
-            cascaded --config /etc/cascade/config.toml --state /var/lib/cascade/state.db
+            cascaded --config /etc/cascade/config.toml
 
 Interacting with Cascade
 ------------------------

--- a/etc/config.system.toml
+++ b/etc/config.system.toml
@@ -7,6 +7,7 @@
 
 version = "v1"
 
+state-file = "/var/lib/cascade/state.db"
 policy-dir = "/etc/cascade/policies"
 zone-state-dir = "/var/lib/cascade/zone-state"
 tsig-store-path = "/var/lib/cascade/tsig-keys.db"

--- a/etc/config.template.toml
+++ b/etc/config.template.toml
@@ -15,6 +15,13 @@
 version = "v1"
 
 
+# The path to the global state file.
+#
+# Cascade stores information like the known policies and zones here. This file
+# should not be modified manually, but it can be backed up and restored in the
+# event of filesystem corruption.
+state-file = "/var/lib/cascade/state.db"
+
 # The directory storing zone policies.
 #
 # Zone policies are user-managed files configuring groups of zones.  You can

--- a/integration-tests/.github/actions/setup-and-start-cascade/action.yml
+++ b/integration-tests/.github/actions/setup-and-start-cascade/action.yml
@@ -44,10 +44,10 @@ runs:
       cascade template config | \
         "${GITHUB_WORKSPACE}/integration-tests/scripts/sed-config-dirs.sh" "${CASCADE_DIR}" "${LOG_LEVEL}" | tee "${CASCADE_DIR}/config.toml" >/dev/null
       cascade template policy > "${CASCADE_DIR}/policies/default.toml"
-      cascaded --config "${CASCADE_DIR}/config.toml" --state "${CASCADE_DIR}/state.db" --daemonize &>"${CASCADE_DIR}/cascade-startup.log"
+      cascaded --config "${CASCADE_DIR}/config.toml" --daemonize &>"${CASCADE_DIR}/cascade-startup.log"
 
       ## Leaving the non-daemonize invocation here for future reference
-      # nohup cascaded --config "${CASCADE_DIR}/config.toml" --state "${CASCADE_DIR}/state.db" &>"${CASCADE_DIR}/cascade-startup.log" &
+      # nohup cascaded --config "${CASCADE_DIR}/config.toml" &>"${CASCADE_DIR}/cascade-startup.log" &
       # # Apparently, if the script finishes before the background task has been
       # # fully started, bash will still kill it on exit. Therefore, we wait
       # # a little bit until cascade is running.

--- a/integration-tests/scripts/common.sh
+++ b/integration-tests/scripts/common.sh
@@ -8,7 +8,7 @@ function get-cascade-config-option() {
     config.toml)
       echo "${_base_dir}/config.toml"
       ;;
-    state.db)
+    state-file)
       echo "${_base_dir}/state.db"
       ;;
     policy-dir)

--- a/integration-tests/scripts/get-default-path.sh
+++ b/integration-tests/scripts/get-default-path.sh
@@ -23,7 +23,7 @@ variable, which is therefore used by this script.
 Arguments:
   item            One of:
                     - config.toml
-                    - state.db
+                    - state-file
                     - policy-dir
                     - zone-state-dir
                     - tsig-store-path

--- a/integration-tests/scripts/sed-config-dirs.sh
+++ b/integration-tests/scripts/sed-config-dirs.sh
@@ -50,7 +50,9 @@ fi
 
 source "$(dirname "$0")/common.sh"
 
-sed -e "s_^policy-dir.*_policy-dir = \"$(get-cascade-config-option "${_base_dir}" "policy-dir")\"_" \
+sed \
+  -e "s_^state-file.*_state-file = \"$(get-cascade-config-option "${_base_dir}" "state-file")\"_" \
+  -e "s_^policy-dir.*_policy-dir = \"$(get-cascade-config-option "${_base_dir}" "policy-dir")\"_" \
   -e "s_^zone-state-dir.*_zone-state-dir = \"$(get-cascade-config-option "${_base_dir}" "zone-state-dir")\"_" \
   -e "s_^tsig-store-path.*_tsig-store-path = \"$(get-cascade-config-option "${_base_dir}" "tsig-store-path")\"_" \
   -e "s_^kmip-credentials-store-path.*_kmip-credentials-store-path = \"$(get-cascade-config-option "${_base_dir}" "kmip-credentials-store-path")\"_" \

--- a/integration-tests/tests/persist-then-reject/action.yml
+++ b/integration-tests/tests/persist-then-reject/action.yml
@@ -150,7 +150,7 @@ runs:
     - name: Restart Cascade
       run: |
         CASCADE_DIR=${{ github.workspace }}/cascade-dir
-        cascaded --config "${CASCADE_DIR}/config.toml" --state "${CASCADE_DIR}/state.db" --daemonize &>"${CASCADE_DIR}/cascade-startup.log" 
+        cascaded --config "${CASCADE_DIR}/config.toml" --daemonize &>"${CASCADE_DIR}/cascade-startup.log" 
 
     - name: Wait for Cascade to become healthy
       run: |

--- a/integration-tests/tests/persist-zone/action.yml
+++ b/integration-tests/tests/persist-zone/action.yml
@@ -72,7 +72,7 @@ runs:
     - name: Restart Cascade
       run: |
         CASCADE_DIR=${{ github.workspace }}/cascade-dir
-        cascaded --config "${CASCADE_DIR}/config.toml" --state "${CASCADE_DIR}/state.db" --daemonize &>"${CASCADE_DIR}/cascade-startup.log" 
+        cascaded --config "${CASCADE_DIR}/config.toml" --daemonize &>"${CASCADE_DIR}/cascade-startup.log" 
 
     - name: Wait for Cascade to become healthy
       run: |
@@ -168,7 +168,7 @@ runs:
     - name: Start Cascade again
       run: |
         CASCADE_DIR=${{ github.workspace }}/cascade-dir
-        cascaded --config "${CASCADE_DIR}/config.toml" --state "${CASCADE_DIR}/state.db" --daemonize &>"${CASCADE_DIR}/cascade-startup.log"      
+        cascaded --config "${CASCADE_DIR}/config.toml" --daemonize &>"${CASCADE_DIR}/cascade-startup.log"      
 
     - name: Wait for Cascade to become healthy again
       run: |
@@ -248,7 +248,7 @@ runs:
     - name: Start Cascade a 3rd time
       run: |
         CASCADE_DIR=${{ github.workspace }}/cascade-dir
-        cascaded --config "${CASCADE_DIR}/config.toml" --state "${CASCADE_DIR}/state.db" --daemonize &>"${CASCADE_DIR}/cascade-startup.log"      
+        cascaded --config "${CASCADE_DIR}/config.toml" --daemonize &>"${CASCADE_DIR}/cascade-startup.log"      
 
     - name: Wait for Cascade to become healthy a 3rd time
       run: |
@@ -514,7 +514,7 @@ runs:
     - name: 6 Start Cascade a 4th time
       run: |
         CASCADE_DIR=${{ github.workspace }}/cascade-dir
-        cascaded --config "${CASCADE_DIR}/config.toml" --state "${CASCADE_DIR}/state.db" --daemonize &>"${CASCADE_DIR}/cascade-startup.log"      
+        cascaded --config "${CASCADE_DIR}/config.toml" --daemonize &>"${CASCADE_DIR}/cascade-startup.log"      
 
     - name: 6 Wait for Cascade to become healthy a 4th time
       run: |
@@ -686,7 +686,7 @@ runs:
     - name: 8 Start Cascade again
       run: |
         CASCADE_DIR=${{ github.workspace }}/cascade-dir
-        cascaded --config "${CASCADE_DIR}/config.toml" --state "${CASCADE_DIR}/state.db" --daemonize &>"${CASCADE_DIR}/cascade-startup.log"      
+        cascaded --config "${CASCADE_DIR}/config.toml" --daemonize &>"${CASCADE_DIR}/cascade-startup.log"      
 
     - name: 8 Wait for Cascade to become healthy again
       run: |
@@ -783,7 +783,7 @@ runs:
     - name: 9 Start Cascade again
       run: |
         CASCADE_DIR=${{ github.workspace }}/cascade-dir
-        cascaded --config "${CASCADE_DIR}/config.toml" --state "${CASCADE_DIR}/state.db" --daemonize &>"${CASCADE_DIR}/cascade-startup.log"      
+        cascaded --config "${CASCADE_DIR}/config.toml" --daemonize &>"${CASCADE_DIR}/cascade-startup.log"      
 
     - name: 9 Wait for Cascade to become healthy again
       run: |

--- a/pkg/common/cascade.service
+++ b/pkg/common/cascade.service
@@ -4,7 +4,7 @@ Documentation=man:cascade(1)
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/cascaded --state=/var/lib/cascade/state.db --config=/etc/cascade/config.toml
+ExecStart=/usr/bin/cascaded --config=/etc/cascade/config.toml
 Type=exec
 Restart=on-failure
 User=cascade

--- a/src/center.rs
+++ b/src/center.rs
@@ -425,8 +425,7 @@ impl State {
         policies: &mut foldhash::HashMap<Box<str>, PolicySpec>,
         hsms: &mut foldhash::HashMap<Box<str>, HsmSpec>,
     ) -> io::Result<Self> {
-        let path = config.daemon.state_file.value();
-        let spec = crate::state::Spec::load(path)?;
+        let spec = crate::state::Spec::load(&config.state_file)?;
 
         Ok(spec.parse(zones, policies, hsms))
     }
@@ -458,7 +457,7 @@ impl State {
                     return;
                 };
 
-                path = center.config.daemon.state_file.value().clone();
+                path = center.config.state_file.clone();
                 spec = crate::state::Spec::build(&state);
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,7 @@ fn main() -> ExitCode {
         Ok(mut state) => {
             info!(
                 "Loaded the global state file (from '{}')",
-                config.daemon.state_file.value()
+                config.state_file
             );
 
             // Load the TSIG store file.
@@ -189,14 +189,14 @@ fn main() -> ExitCode {
             if err.kind() != io::ErrorKind::NotFound {
                 error!(
                     "State file '{}' could not be read: {err}",
-                    config.daemon.state_file.value()
+                    config.state_file
                 );
                 return ExitCode::FAILURE;
             }
 
             info!(
                 "State file '{}' did not exist; starting from scratch",
-                config.daemon.state_file.value()
+                config.state_file
             );
 
             // Create required subdirectories (and their parents) if they don't

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -36,7 +36,7 @@ pub fn save_now(center: &Center) {
     };
 
     // Save the global state.
-    let path = center.config.daemon.state_file.value();
+    let path = &center.config.state_file;
     match spec.save(path) {
         Ok(()) => debug!("Saved the global state (to '{path}')"),
         Err(err) => {


### PR DESCRIPTION
The daemon CLI was originally designed to make `--config` optional; if it were omitted, its value would be loaded from the state file. This design was reverted a long time ago, making `--config` and `--state` both mandatory. This meant that `--state` could be made optional instead; its path could be stored in the config file, as requested in #376. This PR makes that change, removing `--state` entirely.

This is a breaking change; the `--state` option and `CASCADE_STATE_PATH` environment variable are removed in favor of the new `state-file =` setting. It has the same default as before. The format of the state files is not affected.

---

Fixes #376

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?