### PR TITLE
Unit-test the full zone signer

### DIFF
--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -30,7 +30,7 @@ use crate::{
 
 mod server;
 pub mod zone;
-mod zonefile;
+pub mod zonefile;
 
 //----------- Loader -----------------------------------------------------------
 

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -134,7 +134,7 @@ async fn refresh(
             let metrics = metrics.clone();
             let result;
             (builder, result) = tokio::task::spawn_blocking(move || {
-                let result = zonefile::load(&zone, &path, &mut builder, &metrics);
+                let result = zonefile::load(&zone.name, &path, &mut builder, &metrics);
                 (builder, result)
             })
             .await

--- a/src/loader/zonefile.rs
+++ b/src/loader/zonefile.rs
@@ -1,15 +1,11 @@
 //! Loading zones from zonefiles.
 
-use std::{
-    fmt,
-    fs::File,
-    sync::{Arc, atomic::Ordering::Relaxed},
-};
+use std::{fmt, fs::File, sync::atomic::Ordering::Relaxed};
 
-use bytes::BufMut;
+use bytes::{BufMut, Bytes};
 use camino::Utf8Path;
 use domain::{
-    base::{ToName, iana::Class},
+    base::{Name, ToName, iana::Class},
     new::{
         base::{Record, name::RevNameBuf, wire::ParseBytes},
         rdata::{BoxedRecordData, RecordData},
@@ -20,7 +16,6 @@ use domain::{
 
 use crate::{
     loader::ActiveLoadMetrics,
-    zone::Zone,
     zonedata::{LoadedZoneBuilder, RegularRecord, ReplaceError, SoaRecord},
 };
 
@@ -30,19 +25,19 @@ use crate::{
 ///
 /// This will always read the entire zone, regardless of the serial in the SOA.
 pub fn load(
-    zone: &Arc<Zone>,
+    zone_name: &Name<Bytes>,
     path: &Utf8Path,
     builder: &mut LoadedZoneBuilder,
     metrics: &ActiveLoadMetrics,
 ) -> Result<(), Error> {
-    let mut reader = make_reader(zone, path, metrics)?;
+    let mut reader = make_reader(zone_name, path, metrics)?;
     let mut writer = builder.replace().unwrap();
 
     // A scratch buffer that we can use to parse
     let mut buf = Vec::new();
 
     // Parse all the records, extracting the SOA. We always read the whole zone.
-    while let Some(record) = parse_record(&mut buf, zone, &mut reader)? {
+    while let Some(record) = parse_record(&mut buf, zone_name, &mut reader)? {
         metrics.num_loaded_records.fetch_add(1, Relaxed);
         metrics
             .num_loaded_bytes
@@ -67,7 +62,7 @@ pub fn load(
 ///
 /// It will add the size of the file to the byte count of the metrics.
 fn make_reader(
-    zone: &Arc<Zone>,
+    zone_name: &Name<Bytes>,
     path: &Utf8Path,
     metrics: &ActiveLoadMetrics,
 ) -> Result<inplace::Zonefile, Error> {
@@ -83,7 +78,7 @@ fn make_reader(
     std::io::copy(&mut file, &mut zone_file).map_err(Error::Open)?;
 
     let mut reader = zone_file.into_inner();
-    reader.set_origin(zone.name.clone());
+    reader.set_origin(zone_name.clone());
     reader.set_default_class(Class::IN);
 
     Ok(reader)
@@ -92,7 +87,7 @@ fn make_reader(
 /// Parse a single record from a zonefile
 fn parse_record(
     buf: &mut Vec<u8>,
-    zone: &Arc<Zone>,
+    zone_name: &Name<Bytes>,
     reader: &mut inplace::Zonefile,
 ) -> Result<Option<Parsed>, Error> {
     buf.clear();
@@ -115,7 +110,7 @@ fn parse_record(
     if let RecordData::Soa(new_soa) = record.rdata.get() {
         // We have to compare with an old base name here so we use the record_name
         // instead of record.name.
-        if !record_name.name_eq(&zone.name) {
+        if !record_name.name_eq(zone_name) {
             // TODO: Check this in 'UnsignedZoneReplacer'.
             return Err(Error::MismatchedOrigin);
         }

--- a/src/signer/full.rs
+++ b/src/signer/full.rs
@@ -50,10 +50,7 @@ use crate::{
         keys::ZoneSigningKeys,
         status::{SigningStatusPerZone, ZoneSigningStatus},
     },
-    units::{
-        key_manager::mk_dnst_keyset_state_file_path,
-        zone_signer::{KeySetState, MinTimestamp, SignerError},
-    },
+    units::zone_signer::{KeySetState, MinTimestamp, SignerError},
     zonedata::{OldRecord, RegularRecord, SignedZoneBuilder},
 };
 
@@ -66,6 +63,7 @@ pub fn sign_zone(
     kmip_servers: &Mutex<HashMap<String, SyncConnPool>>,
     builder: &mut SignedZoneBuilder,
     local_state: &mut LocalState,
+    keyset_state: KeySetState,
     status: Arc<RwLock<SigningStatusPerZone>>,
 ) -> Result<(), SignerError> {
     info!("[ZS]: Starting signing operation for zone '{zone_name}'");
@@ -147,20 +145,12 @@ pub fn sign_zone(
         }
     }
 
-    debug!("Reading dnst keyset DNSKEY RRs and RRSIG RRs");
-    status.write().unwrap().current_action = "Fetching apex RRs from the key manager".to_string();
-    // Read the DNSKEY RRs and DNSKEY RRSIG RR from the keyset state.
-    let state_path = mk_dnst_keyset_state_file_path(&config.keys_dir, zone_name);
-    let state = std::fs::read_to_string(&state_path)
-        .map_err(|_| SignerError::CannotReadStateFile(state_path.into_string()))?;
-    let state: KeySetState = serde_json::from_str(&state).unwrap();
-
-    local_state.apex_remove = state.apex_remove.clone();
-    let mut apex_extra = state.apex_extra.clone();
+    local_state.apex_remove = keyset_state.apex_remove.clone();
+    let mut apex_extra = keyset_state.apex_extra.clone();
     apex_extra.sort();
     local_state.apex_extra = apex_extra;
 
-    for rr in &state.apex_extra {
+    for rr in &keyset_state.apex_extra {
         let mut zonefile = Zonefile::new();
         zonefile.extend_from_slice(rr.as_bytes());
         zonefile.extend_from_slice(b"\n");
@@ -173,12 +163,18 @@ pub fn sign_zone(
 
     debug!("Loading dnst keyset signing keys");
     // Load the signing keys indicated by the keyset state.
-    let signing_keys =
-        ZoneSigningKeys::load(config, zone_name, hsm_store, kmip_servers, &state, &status)?;
+    let signing_keys = ZoneSigningKeys::load(
+        config,
+        zone_name,
+        hsm_store,
+        kmip_servers,
+        &keyset_state,
+        &status,
+    )?;
 
     // Save the current zone signing keys and clear key_roll
     let mut key_tags = HashSet::new();
-    for v in state.keyset.keys().values() {
+    for v in keyset_state.keyset.keys().values() {
         let signer = match v.keytype() {
             KeyType::Ksk(_) => false,
             KeyType::Zsk(key_state) => key_state.signer(),

--- a/src/signer/incremental.rs
+++ b/src/signer/incremental.rs
@@ -51,7 +51,6 @@ use crate::hsm::HsmStore;
 use crate::policy::{PolicyVersion, SignerDenialPolicy};
 use crate::signer::keys::ZoneSigningKeys;
 use crate::signer::status::SigningStatusPerZone;
-use crate::units::key_manager::mk_dnst_keyset_state_file_path;
 use crate::units::zone_signer::{
     KeySetState, MinTimestamp, PassThroughMode, SignerError, faketime_or_now,
 };
@@ -69,6 +68,7 @@ pub fn sign_incrementally(
     kmip_servers: &Mutex<HashMap<String, SyncConnPool>>,
     patch: SignedZonePatcher,
     local_state: &mut LocalState,
+    keyset_state: KeySetState,
     status: Arc<RwLock<SigningStatusPerZone>>,
 ) -> Result<(), SignerError> {
     // Check what work needs to be done. If the keyset state
@@ -84,12 +84,6 @@ pub fn sign_incrementally(
     status.write().expect("should not fail").current_action =
         "Start incremental signing".to_string();
     let load_unsigned = patch.next_loaded().is_some();
-
-    let state_path = mk_dnst_keyset_state_file_path(&config.keys_dir, zone_name);
-    let state = std::fs::read_to_string(&state_path)
-        .map_err(|_| SignerError::CannotReadStateFile(state_path.into_string()))?;
-    let keyset_state: KeySetState = serde_json::from_str(&state)
-        .map_err(|e| SignerError::SigningError(format!("loading keyset state failed: {e}")))?;
 
     let use_nsec3 = matches!(policy.signer.denial, SignerDenialPolicy::NSec3 { .. });
 

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -31,7 +31,10 @@ use crate::{
     center::Center,
     policy::{PolicyVersion, SignerSerialPolicy},
     signer::{incremental::LocalState, queue::SigningPermit, status::SigningStatusPerZone},
-    units::zone_signer::SignerError,
+    units::{
+        key_manager::mk_dnst_keyset_state_file_path,
+        zone_signer::{KeySetState, SignerError},
+    },
     zone::{HistoricalEvent, Zone},
     zonedata::SignedZoneBuilder,
 };
@@ -75,29 +78,42 @@ fn sign(
     let hsm_store = center.state.lock().unwrap().hsms.clone();
     let kmip_servers = &center.signer.kmip_servers;
 
-    let result = if let Some(patcher) = builder.patch() {
-        self::incremental::sign_incrementally(
-            &center.config,
-            &zone.name,
-            &policy,
-            &hsm_store,
-            kmip_servers,
-            patcher,
-            &mut local_state,
-            status.clone(),
-        )
-    } else {
-        self::full::sign_zone(
-            &center.config,
-            &zone.name,
-            &policy,
-            &hsm_store,
-            kmip_servers,
-            &mut builder,
-            &mut local_state,
-            status.clone(),
-        )
-    };
+    // TODO: Store this in `ZoneState` and only fetch it when keyset is invoked.
+    let state_path = mk_dnst_keyset_state_file_path(&center.config.keys_dir, &zone.name);
+    let keyset_state = std::fs::read_to_string(&state_path)
+        .map_err(|_| SignerError::CannotReadStateFile(state_path.into_string()))
+        .and_then(|state| {
+            serde_json::from_str::<KeySetState>(&state)
+                .map_err(|e| SignerError::SigningError(format!("loading keyset state failed: {e}")))
+        });
+
+    let result = keyset_state.and_then(|keyset_state| {
+        if let Some(patcher) = builder.patch() {
+            self::incremental::sign_incrementally(
+                &center.config,
+                &zone.name,
+                &policy,
+                &hsm_store,
+                kmip_servers,
+                patcher,
+                &mut local_state,
+                keyset_state,
+                status.clone(),
+            )
+        } else {
+            self::full::sign_zone(
+                &center.config,
+                &zone.name,
+                &policy,
+                &hsm_store,
+                kmip_servers,
+                &mut builder,
+                &mut local_state,
+                keyset_state,
+                status.clone(),
+            )
+        }
+    });
 
     let end = Instant::now();
     let duration = (end - start).as_secs_f64();

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -46,6 +46,9 @@ pub mod queue;
 pub mod status;
 pub mod zone;
 
+#[cfg(test)]
+mod tests;
+
 //----------- sign() -----------------------------------------------------------
 
 /// Sign a zone.

--- a/src/signer/tests.rs
+++ b/src/signer/tests.rs
@@ -101,13 +101,11 @@ impl SimpleStorage {
 
 fn keyset_state(zone_name: &Name<Bytes>) -> KeySetState {
     let mut keyset = KeySet::new(zone_name.clone().octets_into());
-    let pubref = format!(
-        "file://{}/integration-tests/incremental-signing/keys/Kexample.+015+02835.key",
-        std::env::current_dir().unwrap().into_string().unwrap()
-    );
+    let cwd: Utf8PathBuf = std::env::current_dir().unwrap().try_into().unwrap();
+    let pubref =
+        format!("file://{cwd}/integration-tests/incremental-signing/keys/Kexample.+015+02835.key");
     let privref = format!(
-        "file://{}/integration-tests/incremental-signing/keys/Kexample.+015+02835.private",
-        std::env::current_dir().unwrap().into_string().unwrap()
+        "file://{cwd}/integration-tests/incremental-signing/keys/Kexample.+015+02835.private"
     );
     keyset
         .add_key_csk(

--- a/src/signer/tests.rs
+++ b/src/signer/tests.rs
@@ -1,0 +1,364 @@
+//! Testing zone signing.
+
+#![allow(clippy::disallowed_macros, reason = "tests")]
+
+use std::{
+    io::{BufReader, BufWriter, Write},
+    sync::{Arc, RwLock},
+};
+
+use bytes::{BufMut, Bytes};
+use camino::{Utf8Path, Utf8PathBuf};
+use cascade_policy_file::v1::SignerDenialSpec;
+use cascade_zonedata::{
+    LoadedZoneReviewer, RegularRecord, SignedZoneBuilder, SignedZoneReviewer, ZoneDataStorage,
+    ZoneViewer,
+};
+use domain::{
+    base::{
+        Name, Rtype,
+        iana::SecurityAlgorithm,
+        zonefile_fmt::{self, ZonefileFmt},
+    },
+    dep::octseq::OctetsInto,
+    dnssec::sign::keys::keyset::{self, KeySet},
+    rdata::dnssec::Timestamp,
+};
+
+use crate::{
+    loader::{self, ActiveLoadMetrics},
+    policy::{self, PolicyVersion},
+    signer::{
+        incremental::LocalState,
+        status::{RequestedStatus, SigningStatusPerZone, ZoneSigningStatus},
+    },
+    units::zone_signer::KeySetState,
+};
+
+fn policy(denial: SignerDenialSpec) -> PolicyVersion {
+    use cascade_policy_file::v1::*;
+
+    let spec = Spec {
+        signer: SignerSpec {
+            serial_policy: SignerSerialPolicySpec::Keep,
+            signature_inception_offset: TimeSpan::from_secs(0),
+            signature_lifetime: TimeSpan::from_secs(100000000),
+            denial,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    policy::file::Spec::V1(spec).parse("default")
+}
+
+struct SimpleStorage {
+    storage: ZoneDataStorage,
+    #[allow(dead_code)]
+    loaded_reviewer: LoadedZoneReviewer,
+    #[allow(dead_code)]
+    signed_reviewer: SignedZoneReviewer,
+    #[allow(dead_code)]
+    viewer: ZoneViewer,
+}
+
+impl SimpleStorage {
+    fn new() -> Self {
+        let (restorer, storage) = ZoneDataStorage::new();
+        let ZoneDataStorage::RestoringLoaded(storage) = storage else {
+            unreachable!();
+        };
+        let (loaded_reviewer, signed_reviewer, viewer, storage) = storage.abandon(restorer);
+        Self {
+            storage: ZoneDataStorage::Passive(storage),
+            loaded_reviewer,
+            signed_reviewer,
+            viewer,
+        }
+    }
+
+    fn load(&mut self, zone_name: &Name<Bytes>, path: impl AsRef<Utf8Path>) -> SignedZoneBuilder {
+        let path = path.as_ref();
+        let ZoneDataStorage::Passive(storage) = self.storage.take() else {
+            panic!()
+        };
+        let (storage, mut builder) = storage.load();
+        let metrics = ActiveLoadMetrics::begin(loader::Source::Zonefile { path: path.into() });
+        loader::zonefile::load(zone_name, path, &mut builder, &metrics).unwrap();
+        let built = builder
+            .finish()
+            .unwrap_or_else(|_| unreachable!("zonefile loaded successfully"));
+        let (storage, mut loaded_reviewer) = storage.finish(built);
+        std::mem::swap(&mut loaded_reviewer, &mut self.loaded_reviewer);
+        let storage = storage.start(loaded_reviewer);
+        let (storage, persister) = storage.mark_approved();
+        let persisted = persister.mark_complete();
+        let (storage, builder) = storage.mark_complete(persisted);
+        self.storage = ZoneDataStorage::Signing(storage);
+        builder
+    }
+}
+
+fn keyset_state(zone_name: &Name<Bytes>) -> KeySetState {
+    let mut keyset = KeySet::new(zone_name.clone().octets_into());
+    let pubref = format!(
+        "file://{}/integration-tests/incremental-signing/keys/Kexample.+015+02835.key",
+        std::env::current_dir().unwrap().into_string().unwrap()
+    );
+    let privref = format!(
+        "file://{}/integration-tests/incremental-signing/keys/Kexample.+015+02835.private",
+        std::env::current_dir().unwrap().into_string().unwrap()
+    );
+    keyset
+        .add_key_csk(
+            pubref.clone(),
+            Some(privref),
+            SecurityAlgorithm::ED25519,
+            2835,
+            Timestamp::from(0).into(),
+            keyset::Available::Available,
+        )
+        .unwrap();
+    keyset.set_signer(&pubref, true).unwrap();
+    KeySetState {
+        keyset,
+        apex_remove: [Rtype::DNSKEY, Rtype::CDS, Rtype::CDNSKEY].into(),
+        apex_extra: [
+            "example. IN DNSKEY 256 3 15 BnnbKMXdvQp2v+tzyvO/HxQGY8iYcJsWD4MN6fnr84Q=",
+            "example. 3600 IN RRSIG DNSKEY 15 1 3600 1700000000 1600000000 2835 example. RMn96put9kteW8DjunEY3o0J7+MZlrC/zXVBU0h0gpFwjz9mrqo/1EvQUSO6faKaNLD2uhiJ9mg91Z1AQSq4AQ==",
+        ]
+        .into_iter().map(String::from).collect(),
+    }
+}
+
+fn load_zonefile(path: impl AsRef<Utf8Path>, zone_name: &Name<Bytes>) -> Vec<RegularRecord> {
+    let path = path.as_ref();
+    let mut reader = BufReader::new(std::fs::File::open(path).unwrap());
+    let mut zonefile = domain::zonefile::inplace::Zonefile::new();
+    zonefile.set_origin(zone_name.clone());
+    let mut writer = zonefile.writer();
+    std::io::copy(&mut reader, &mut writer).unwrap();
+    let zonefile = writer.into_inner();
+    let mut buffer = Vec::new();
+    let mut records = zonefile
+        .map(|entry| match entry {
+            Ok(domain::zonefile::inplace::Entry::Record(record)) => {
+                buffer.clear();
+                record.compose(&mut buffer).unwrap();
+                let bytes = bytes::Bytes::from(buffer.clone());
+                buffer.clear();
+                let mut parser = domain::dep::octseq::Parser::from_ref(&bytes);
+                let record = cascade_zonedata::OldParsedRecord::parse(&mut parser)
+                    .unwrap()
+                    .unwrap();
+                cascade_zonedata::RegularRecord::from(record)
+            }
+            _ => panic!(),
+        })
+        .collect::<Vec<_>>();
+    records.sort_unstable();
+    records
+}
+
+fn compare_records(
+    zone_name: &Name<Bytes>,
+    actual: &[RegularRecord],
+    expected_path: impl AsRef<Utf8Path>,
+) {
+    let expected_path = expected_path.as_ref();
+    let expected = load_zonefile(expected_path, zone_name);
+    if expected != actual {
+        eprintln!("--- Expected output ({expected_path}):");
+        for record in &expected {
+            let record = cascade_zonedata::OldRecord::from(record.clone());
+            eprintln!(
+                "{}",
+                record.display_zonefile(zonefile_fmt::DisplayKind::Simple)
+            );
+        }
+        let actual_file = tempfile::NamedTempFile::new().unwrap();
+        let actual_path = Utf8PathBuf::from(actual_file.path().to_str().unwrap());
+        let mut writer = BufWriter::new(actual_file);
+        eprintln!("\n--- Actual output:");
+        for record in actual {
+            let record = cascade_zonedata::OldRecord::from(record.clone());
+            let record = record.display_zonefile(zonefile_fmt::DisplayKind::Simple);
+            eprintln!("{record}");
+            writeln!(writer, "{record}").unwrap();
+        }
+        eprintln!("\n--- Diff:");
+        std::process::Command::new("git")
+            .args([
+                "diff",
+                "--no-index",
+                "--word-diff",
+                "--",
+                expected_path.as_str(),
+                actual_path.as_str(),
+            ])
+            .status()
+            .unwrap();
+
+        // Make sure the temporary file is cleaned up.
+        std::mem::drop(writer);
+
+        panic!("Zone did not match expectation");
+    }
+}
+
+fn test_full(test_idx: usize, input_idx: usize, denial: SignerDenialSpec) {
+    let config = crate::config::Config::default();
+    let zone_name: Name<Bytes> = "example".parse().unwrap();
+    let policy = policy(denial.clone());
+    let hsm_store = Default::default();
+    let kmip_servers = Default::default();
+    let mut storage = SimpleStorage::new();
+    let mut builder = storage.load(
+        &zone_name,
+        format!("integration-tests/incremental-signing/zones/incremental-signing-test{test_idx}-input{input_idx}.zone"),
+    );
+    let keyset_state = keyset_state(&zone_name);
+
+    // TODO: Pass the fake-time info as a parameter to the signing code?
+    unsafe { std::env::set_var("CASCADE_FAKETIME", "1600000000") };
+
+    let status = Arc::new(RwLock::new(SigningStatusPerZone {
+        current_action: String::new(),
+        status: ZoneSigningStatus::Requested(RequestedStatus::new()),
+    }));
+
+    let mut local_state = LocalState {
+        apex_remove: Default::default(),
+        apex_extra: Default::default(),
+        last_signature_refresh: Timestamp::from(0).into(),
+        key_tags: Default::default(),
+        key_roll: None,
+        previous_serial: None,
+        next_min_expiration: None,
+    };
+
+    super::full::sign_zone(
+        &config,
+        &zone_name,
+        &policy,
+        &hsm_store,
+        &kmip_servers,
+        &mut builder,
+        &mut local_state,
+        keyset_state,
+        status,
+    )
+    .unwrap();
+
+    let mut records = builder
+        .next_signed()
+        .unwrap()
+        .all_records()
+        .cloned()
+        .collect::<Vec<_>>();
+    records.sort_unstable();
+
+    let denial = match denial {
+        SignerDenialSpec::NSec => "nsec",
+        SignerDenialSpec::NSec3 { opt_out: false } => "nsec3",
+        SignerDenialSpec::NSec3 { opt_out: true } => "nsec3-opt-out",
+    };
+
+    compare_records(
+        &zone_name,
+        &records,
+        format!(
+            "integration-tests/incremental-signing/reference-output/incremental-signing-test{test_idx}-input{input_idx}.zone.{denial}.signed.sorted"
+        ),
+    );
+}
+
+#[test]
+fn full_t1i2_nsec() {
+    test_full(1, 2, SignerDenialSpec::NSec);
+}
+
+#[test]
+fn full_t2i2_nsec() {
+    test_full(2, 2, SignerDenialSpec::NSec);
+}
+
+#[test]
+fn full_t3i2_nsec() {
+    test_full(3, 2, SignerDenialSpec::NSec);
+}
+
+#[test]
+fn full_t4i2_nsec() {
+    test_full(4, 2, SignerDenialSpec::NSec);
+}
+
+#[test]
+fn full_t4i3_nsec() {
+    test_full(4, 3, SignerDenialSpec::NSec);
+}
+
+#[test]
+fn full_t5i2_nsec() {
+    test_full(5, 2, SignerDenialSpec::NSec);
+}
+
+#[test]
+fn full_t1i2_nsec3() {
+    test_full(1, 2, SignerDenialSpec::NSec3 { opt_out: false });
+}
+
+#[test]
+fn full_t2i2_nsec3() {
+    test_full(2, 2, SignerDenialSpec::NSec3 { opt_out: false });
+}
+
+#[test]
+fn full_t3i2_nsec3() {
+    test_full(3, 2, SignerDenialSpec::NSec3 { opt_out: false });
+}
+
+#[test]
+fn full_t4i2_nsec3() {
+    test_full(4, 2, SignerDenialSpec::NSec3 { opt_out: false });
+}
+
+#[test]
+fn full_t4i3_nsec3() {
+    test_full(4, 3, SignerDenialSpec::NSec3 { opt_out: false });
+}
+
+#[test]
+fn full_t5i2_nsec3() {
+    test_full(5, 2, SignerDenialSpec::NSec3 { opt_out: false });
+}
+
+#[test]
+fn full_t1i2_nsec3_opt_out() {
+    test_full(1, 2, SignerDenialSpec::NSec3 { opt_out: true });
+}
+
+#[test]
+fn full_t2i2_nsec3_opt_out() {
+    test_full(2, 2, SignerDenialSpec::NSec3 { opt_out: true });
+}
+
+#[test]
+fn full_t3i2_nsec3_opt_out() {
+    test_full(3, 2, SignerDenialSpec::NSec3 { opt_out: true });
+}
+
+#[test]
+fn full_t4i2_nsec3_opt_out() {
+    test_full(4, 2, SignerDenialSpec::NSec3 { opt_out: true });
+}
+
+#[test]
+fn full_t4i3_nsec3_opt_out() {
+    test_full(4, 3, SignerDenialSpec::NSec3 { opt_out: true });
+}
+
+#[test]
+fn full_t5i2_nsec3_opt_out() {
+    test_full(5, 2, SignerDenialSpec::NSec3 { opt_out: true });
+}


### PR DESCRIPTION
The new `signer/tests.rs` ports the incremental signing test suite as unit tests focused on full zone signing. These tests are lightweight, easy to extend, enabled in CI, and easy to measure code coverage for.

Unblocks #537 and #630.

---

- If you are changing Rust code or integration tests (`Cargo.*`, `crates/`, `etc/`, `integration-tests/`, `src/`):
  - [x] Did you run the integration tests with `act` through the `act-wrapper` (as described in `TESTING.md`)?